### PR TITLE
Rename to vibecodereview + fix-cycle loop guard

### DIFF
--- a/.github/workflows/vibecodereview.yml
+++ b/.github/workflows/vibecodereview.yml
@@ -1,10 +1,10 @@
-name: vibereview
+name: vibecodereview
 on:
   pull_request:
     types: [opened, synchronize, review_requested]
     paths-ignore: ["**.md"]
 concurrency:
-  group: vibereview-${{ github.event.pull_request.number }}
+  group: vibecodereview-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 jobs:
   review:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
-# AGENTS.md — vibereview
+# AGENTS.md — vibecodereview
 
 Council PR-review tool. One engine (`scripts/council-review.mjs`) drives three
-surfaces: a GitHub composite Action (`action.yml`), a CLI (`bin/vibereview.mjs`),
+surfaces: a GitHub composite Action (`action.yml`), a CLI (`bin/vibecodereview.mjs`),
 and an MCP server (`mcp/server.mjs`). Keep the engine the single source of truth —
 never fork its provider/lens logic into the surfaces.
 
@@ -12,7 +12,7 @@ never fork its provider/lens logic into the surfaces.
   Every failure is non-fatal; the script always exits 0. Has `--selfcheck`.
 - `action.yml` — checkout → council fan-out → `anthropics/claude-code-action@v1`
   (the chair: verifies, fixes, pushes, posts one review).
-- `bin/vibereview.mjs` — `init` / `review` / `doctor` / `secrets`.
+- `bin/vibecodereview.mjs` — `init` / `review` / `doctor` / `secrets`.
 - `mcp/server.mjs` — zero-dep stdio JSON-RPC, one tool `council_review(diff)`.
 
 ## Rules
@@ -26,5 +26,5 @@ never fork its provider/lens logic into the surfaces.
 
 ## Confidentiality
 
-vibereview sends diffs to third-party model providers. Use it on **personal /
+vibecodereview sends diffs to third-party model providers. Use it on **personal /
 private repos**. Do not point it at proprietary or employer code.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vibereview
+# vibecodereview
 
 **A council of AI models reviews your PR — many models, one check.**
 
@@ -25,8 +25,8 @@ Claude still reviews alone. Nothing here blocks the PR on a provider outage.
 ## Use it in a repo
 
 ```bash
-npx vibereview init          # writes .github/workflows/vibereview.yml
-npx vibereview secrets --repo owner/name   # prints the gh commands to set keys
+npx vibecodereview init          # writes .github/workflows/vibecodereview.yml
+npx vibecodereview secrets --repo owner/name   # prints the gh commands to set keys
 ```
 
 Set at least `CLAUDE_CODE_OAUTH_TOKEN` (from `claude setup-token`). Add provider
@@ -35,7 +35,7 @@ keys to grow the council. Set them on **private** repos.
 Or wire the action directly:
 
 ```yaml
-- uses: pooriaarab/vibereview@v1
+- uses: pooriaarab/vibecodereview@v1
   with:
     claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     github_token: ${{ github.token }}
@@ -52,13 +52,13 @@ overrides (`OPENROUTER_MODEL=deepseek/deepseek-v4-flash`, etc.).
 
 ```bash
 export OPENAI_API_KEY=... MOONSHOT_API_KEY=...   # whichever members you want
-vibereview review --base origin/main
+vibecodereview review --base origin/main
 ```
 
 ## As an MCP tool
 
 ```bash
-claude mcp add vibereview -- node /path/to/vibereview/mcp/server.mjs
+claude mcp add vibecodereview -- node /path/to/vibecodereview/mcp/server.mjs
 ```
 
 Exposes one tool, `council_review(diff)`. Provider keys come from the server env.

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "vibereview"
+name: "vibecodereview"
 description: "LLM-council PR review: many models, diverse lenses, one self-healing GitHub check."
 branding:
   icon: "eye"
@@ -31,6 +31,10 @@ inputs:
     description: "If true, the chair may commit and push fixes to the PR branch."
     required: false
     default: "true"
+  max_fix_cycles:
+    description: "Stop auto-pushing fixes after this many consecutive bot commits (loop guard)."
+    required: false
+    default: "3"
 
 runs:
   using: "composite"
@@ -44,8 +48,8 @@ runs:
     - name: Configure git
       shell: bash
       run: |
-        git config user.name "vibereview[bot]"
-        git config user.email "vibereview@users.noreply.github.com"
+        git config user.name "vibecodereview[bot]"
+        git config user.email "vibecodereview@users.noreply.github.com"
 
     - name: Council fan-out
       shell: bash
@@ -62,6 +66,29 @@ runs:
         node "${{ github.action_path }}/scripts/council-review.mjs" pr.diff council-findings.md || true
         echo "----- council-findings.md -----"; cat council-findings.md || true
 
+    - name: Fix-cycle guard
+      id: cycle
+      shell: bash
+      run: |
+        # Count consecutive bot commits at HEAD. After the limit, stop pushing
+        # fixes (comment-only) so review->fix->re-review can't loop forever.
+        LIMIT="${{ inputs.max_fix_cycles }}"
+        COUNT=0
+        for SHA in $(git log --format='%H' -"$((LIMIT + 3))"); do
+          AUTHOR="$(git log -1 --format='%an' "$SHA")"
+          case "$AUTHOR" in
+            *"[bot]"|"vibecodereview"*) COUNT=$((COUNT + 1)) ;;
+            *) break ;;
+          esac
+        done
+        if [ "$COUNT" -ge "$LIMIT" ] || [ "${{ inputs.can_push_fixes }}" = "false" ]; then
+          echo "can_push=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "can_push=true" >> "$GITHUB_OUTPUT"
+        fi
+        echo "cycles=$COUNT" >> "$GITHUB_OUTPUT"
+        echo "Consecutive bot commits at HEAD: $COUNT (limit $LIMIT)"
+
     - name: Chair review (Claude synthesizes, fixes, posts)
       uses: anthropics/claude-code-action@v1
       with:
@@ -70,7 +97,9 @@ runs:
         allowed_bots: "*"
         prompt: |
           You chair an LLM council reviewing PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
-          Branch: ${{ github.event.pull_request.head.ref }}. Can push fixes: ${{ inputs.can_push_fixes }}.
+          Branch: ${{ github.event.pull_request.head.ref }}. Can push fixes: ${{ steps.cycle.outputs.can_push }} (automated fix cycles so far: ${{ steps.cycle.outputs.cycles }}).
+
+          LOOP GUARD: if "Can push fixes" is false, DO NOT push any commits — leave a review comment only. If a prior cycle already tried to fix an issue and it persists, stop fixing it and flag it for a human instead of pushing again.
 
           Council members each reviewed this PR through one lens (correctness, performance,
           security, maintainability) and wrote findings to `council-findings.md`. You are the

--- a/bin/rollout.mjs
+++ b/bin/rollout.mjs
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 /**
- * rollout.mjs — roll out the vibereview council PR review to many repos.
+ * rollout.mjs — roll out the vibecodereview council PR review to many repos.
  *
  * For each repo (owned by pooriaarab), in order:
- *   1. Set the GitHub Actions secrets vibereview needs, from this process env.
- *   2. Skip the PR if `.github/workflows/vibereview.yml` already exists on the
+ *   1. Set the GitHub Actions secrets vibecodereview needs, from this process env.
+ *   2. Skip the PR if `.github/workflows/vibecodereview.yml` already exists on the
  *      default branch.
- *   3. Otherwise open a PR that adds the workflow (branch `add-vibereview`).
+ *   3. Otherwise open a PR that adds the workflow (branch `add-vibecodereview`).
  *      PRs are never merged here — a human reviews them.
  *
  * Usage:
@@ -36,12 +36,12 @@ const SECRET_NAMES = [
   'OPENROUTER_API_KEY',
 ];
 
-const WORKFLOW_PATH = '.github/workflows/vibereview.yml';
-const BRANCH = 'add-vibereview';
-const COMMIT_MESSAGE = 'Add vibereview council PR review';
-const PR_TITLE = 'Add vibereview council PR review';
+const WORKFLOW_PATH = '.github/workflows/vibecodereview.yml';
+const BRANCH = 'add-vibecodereview';
+const COMMIT_MESSAGE = 'Add vibecodereview council PR review';
+const PR_TITLE = 'Add vibecodereview council PR review';
 const PR_BODY =
-  'Adds owner-gated LLM-council PR review (pooriaarab/vibereview@v1). ' +
+  'Adds owner-gated LLM-council PR review (pooriaarab/vibecodereview@v1). ' +
   'Set secrets are handled separately. Review before merge.';
 
 // The `${{ ... }}` sequences are literal GitHub Actions syntax. They sit in
@@ -49,13 +49,13 @@ const PR_BODY =
 // literal.
 const WORKFLOW_YAML =
   [
-    'name: vibereview',
+    'name: vibecodereview',
     'on:',
     '  pull_request:',
     '    types: [opened, synchronize, review_requested]',
     '    paths-ignore: ["**.md", "docs/**"]',
     'concurrency:',
-    '  group: vibereview-${{ github.event.pull_request.number }}',
+    '  group: vibecodereview-${{ github.event.pull_request.number }}',
     '  cancel-in-progress: true',
     'jobs:',
     '  review:',
@@ -68,7 +68,7 @@ const WORKFLOW_YAML =
     '      pull-requests: write',
     '      id-token: write',
     '    steps:',
-    '      - uses: pooriaarab/vibereview@v1',
+    '      - uses: pooriaarab/vibecodereview@v1',
     '        with:',
     '          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}',
     '          github_token: ${{ github.token }}',

--- a/bin/vibecodereview.mjs
+++ b/bin/vibecodereview.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
-// vibereview CLI — set up council PR review in a repo, or review your local diff.
+// vibecodereview CLI — set up council PR review in a repo, or review your local diff.
 //
-//   vibereview init [--dir .]       Write .github/workflows/vibereview.yml into a repo.
-//   vibereview review [--base <ref>] Review your local diff with the council (prints findings).
-//   vibereview doctor               Show which provider keys are set in the environment.
-//   vibereview secrets [--repo o/r] Print the gh commands to set the required repo secrets.
+//   vibecodereview init [--dir .]       Write .github/workflows/vibecodereview.yml into a repo.
+//   vibecodereview review [--base <ref>] Review your local diff with the council (prints findings).
+//   vibecodereview doctor               Show which provider keys are set in the environment.
+//   vibecodereview secrets [--repo o/r] Print the gh commands to set the required repo secrets.
 //
 // Provider keys (env or repo secrets): CLAUDE_CODE_OAUTH_TOKEN (chair, required for CI),
 //   OPENAI_API_KEY, GEMINI_API_KEY, MOONSHOT_API_KEY, OPENROUTER_API_KEY (council members).
@@ -18,15 +18,15 @@ import os from "node:os";
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(HERE, "..");
 const PROVIDER_KEYS = ["OPENAI_API_KEY", "GEMINI_API_KEY", "MOONSHOT_API_KEY", "OPENROUTER_API_KEY"];
-const REF = "pooriaarab/vibereview@v1"; // action ref repos pin to
+const REF = "pooriaarab/vibecodereview@v1"; // action ref repos pin to
 
-const WORKFLOW = `name: vibereview
+const WORKFLOW = `name: vibecodereview
 on:
   pull_request:
     types: [opened, synchronize, review_requested]
     paths-ignore: ["**.md", "docs/**"]
 concurrency:
-  group: vibereview-\${{ github.event.pull_request.number }}
+  group: vibecodereview-\${{ github.event.pull_request.number }}
   cancel-in-progress: true
 jobs:
   review:
@@ -58,11 +58,11 @@ function sh(cmd, args, opts = {}) {
 
 function init() {
   const dir = path.resolve(arg("dir", "."));
-  const dest = path.join(dir, ".github", "workflows", "vibereview.yml");
+  const dest = path.join(dir, ".github", "workflows", "vibecodereview.yml");
   fs.mkdirSync(path.dirname(dest), { recursive: true });
   fs.writeFileSync(dest, WORKFLOW);
   console.log(`Wrote ${dest}`);
-  console.log("\nNext: set repo secrets (see `vibereview secrets`), commit, open a PR.");
+  console.log("\nNext: set repo secrets (see `vibecodereview secrets`), commit, open a PR.");
 }
 
 function secrets() {
@@ -86,8 +86,8 @@ function review() {
     console.log("No diff to review (try --base origin/main).");
     return;
   }
-  const tmp = path.join(os.tmpdir(), `vibereview-${process.pid}.diff`);
-  const out = path.join(os.tmpdir(), `vibereview-${process.pid}.md`);
+  const tmp = path.join(os.tmpdir(), `vibecodereview-${process.pid}.diff`);
+  const out = path.join(os.tmpdir(), `vibecodereview-${process.pid}.md`);
   fs.writeFileSync(tmp, diff);
   sh("node", [path.join(ROOT, "scripts", "council-review.mjs"), tmp, out], { stdio: ["ignore", "inherit", "inherit"] });
   console.log("\n" + fs.readFileSync(out, "utf8"));
@@ -100,10 +100,10 @@ try {
   else if (cmd === "doctor") doctor();
   else if (cmd === "review") review();
   else {
-    console.log("vibereview <init|review|doctor|secrets>  (see `vibereview` header comment)");
+    console.log("vibecodereview <init|review|doctor|secrets>  (see `vibecodereview` header comment)");
     process.exit(cmd ? 1 : 0);
   }
 } catch (err) {
-  console.error("vibereview error:", err?.message || err);
+  console.error("vibecodereview error:", err?.message || err);
   process.exit(1);
 }

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
-// vibereview MCP server (v0.1) — exposes one tool, `council_review`, that runs
+// vibecodereview MCP server (v0.1) — exposes one tool, `council_review`, that runs
 // the LLM council over a diff and returns the findings. Zero-dep: newline-
 // delimited JSON-RPC over stdio (the MCP stdio transport framing).
 //
 // Provider keys come from the environment (OPENAI_API_KEY, GEMINI_API_KEY,
 // MOONSHOT_API_KEY, OPENROUTER_API_KEY). Wire into a client, e.g. Claude Code:
-//   claude mcp add vibereview -- node /path/to/vibereview/mcp/server.mjs
+//   claude mcp add vibecodereview -- node /path/to/vibecodereview/mcp/server.mjs
 
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
@@ -38,8 +38,8 @@ const TOOL = {
 };
 
 function runCouncil(diff) {
-  const tmp = path.join(os.tmpdir(), `vibereview-mcp-${process.pid}-${Date.now()}.diff`);
-  const out = path.join(os.tmpdir(), `vibereview-mcp-${process.pid}-${Date.now()}.md`);
+  const tmp = path.join(os.tmpdir(), `vibecodereview-mcp-${process.pid}-${Date.now()}.diff`);
+  const out = path.join(os.tmpdir(), `vibecodereview-mcp-${process.pid}-${Date.now()}.md`);
   fs.writeFileSync(tmp, diff || "");
   execFileSync("node", [SCRIPT, tmp, out], { stdio: "ignore" });
   return fs.readFileSync(out, "utf8");
@@ -51,7 +51,7 @@ function handle(msg) {
     return reply(id, {
       protocolVersion: "2024-11-05",
       capabilities: { tools: {} },
-      serverInfo: { name: "vibereview", version: "0.1.0" },
+      serverInfo: { name: "vibecodereview", version: "0.1.0" },
     });
   }
   if (method === "notifications/initialized" || method?.startsWith("notifications/")) return;

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "vibereview",
+  "name": "vibecodereview",
   "version": "0.1.0",
+  "publishConfig": { "access": "public" },
   "description": "LLM-council PR review: many models, diverse lenses, one self-healing GitHub check. Also reviews your local diff before you push.",
   "type": "module",
   "bin": {
-    "vibereview": "bin/vibereview.mjs"
+    "vibecodereview": "bin/vibecodereview.mjs"
   },
   "scripts": {
     "selfcheck": "node scripts/council-review.mjs --selfcheck",
@@ -23,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pooriaarab/vibereview.git"
+    "url": "git+https://github.com/pooriaarab/vibecodereview.git"
   },
   "license": "MIT"
 }

--- a/skills/vibecodereview/SKILL.md
+++ b/skills/vibecodereview/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: vibereview
+name: vibecodereview
 description: Review a code diff with a council of AI models before pushing or merging. Use when the user wants a multi-model review of local changes, a PR, or a diff — "council review", "review my diff", "what would the models flag", "second opinion on this PR". Runs correctness, performance, security, and maintainability lenses in parallel and returns findings.
 ---
 
-# vibereview — council diff review
+# vibecodereview — council diff review
 
 Send a diff to several models at once, each reviewing through a different lens,
 then read back the combined findings. Catches what one reviewer misses.
@@ -11,7 +11,7 @@ then read back the combined findings. Catches what one reviewer misses.
 ## Review the working diff
 
 ```bash
-vibereview review --base origin/main
+vibecodereview review --base origin/main
 ```
 
 Or a specific diff file via the engine directly:
@@ -33,8 +33,8 @@ member is skipped, not an error:
 ## Set it up in a repo (CI)
 
 ```bash
-vibereview init                      # writes .github/workflows/vibereview.yml
-vibereview secrets --repo owner/name # prints the gh secret commands
+vibecodereview init                      # writes .github/workflows/vibecodereview.yml
+vibecodereview secrets --repo owner/name # prints the gh secret commands
 ```
 
 The CI chair (Claude via `CLAUDE_CODE_OAUTH_TOKEN`) verifies each finding, fixes


### PR DESCRIPTION
npm blocks bare 'vibereview' (too similar to 'vibe-review') so unify on **vibecodereview** everywhere (repo already renamed). Adds `max_fix_cycles` (default 3): the chair stops auto-pushing after N consecutive bot commits and comments only — breaks the review->fix->re-review loop.