### PR TITLE
Add npm publish CI (release / tag)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,24 @@
+name: npm publish
+on:
+  release:
+    types: [published]
+  push:
+    tags: ["v*.*.*"]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - name: Selfcheck
+        run: node scripts/council-review.mjs --selfcheck
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Future v*.*.* tag or GitHub release auto-publishes to npm via the NPM_TOKEN secret (set). Release flow: bump version, tag vX.Y.Z, push tag.