### PR TITLE
Fix action: template expression in input description

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: "Claude Code OAuth token (from `claude setup-token`). The chair model — synthesizes, fixes, posts the review."
     required: true
   github_token:
-    description: "Token for gh (PR read + review write). Pass ${{ github.token }} from the caller."
+    description: "Token for gh (PR read + review write). Pass the workflow github.token from the caller."
     required: true
   openai_api_key:
     description: "OpenAI key — GPT/Codex council member (correctness lens). Omit to drop it."


### PR DESCRIPTION
GitHub parses `${{ }}` even inside input descriptions — the github.token reference broke every consumer at 'Set up job'. Plain prose now.