### PR TITLE
Brand rollout job as vibecodereview + merge-rollout recognizes it

### DIFF
--- a/bin/merge-rollout.mjs
+++ b/bin/merge-rollout.mjs
@@ -14,7 +14,11 @@ const repos = (process.argv.slice(2).filter((a) => a !== "--lenient").length
   ? process.argv.slice(2).filter((a) => a !== "--lenient")
   : (process.env.REPOS || "").split(",")).map((s) => s.trim()).filter(Boolean);
 
-const isVibe = (c) => /vibecodereview/i.test(c.name || c.workflowName || c.context || "");
+// The rolled-out workflow job is named `review` (older) or `vibecodereview`.
+const isVibe = (c) => {
+  const n = (c.name || c.workflowName || c.context || "").toLowerCase();
+  return /vibecodereview/.test(n) || n === "review";
+};
 const state = (c) => (c.conclusion || c.status || "").toUpperCase();
 const FAIL = ["FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"];
 const WAIT = ["PENDING", "QUEUED", "IN_PROGRESS", ""];

--- a/bin/vibecodereview.mjs
+++ b/bin/vibecodereview.mjs
@@ -31,7 +31,7 @@ concurrency:
   group: vibecodereview-\${{ github.event.pull_request.number }}
   cancel-in-progress: true
 jobs:
-  review:
+  vibecodereview:
     # Only review PRs opened by the repo owner. On public repos this stops
     # arbitrary external PRs from spending your model budget (and blunts diff
     # prompt-injection from untrusted authors). Widen the allowlist if needed.


### PR DESCRIPTION
Future rollouts name the job `vibecodereview` (was `review`) for a branded check. merge-rollout matches both the new name and the legacy `review` job.