### PR TITLE
Add backup-token failover + install Claude Code

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   claude_code_oauth_token:
     description: "Claude Code OAuth token (from `claude setup-token`). The chair model — synthesizes, fixes, posts the review."
     required: true
+  claude_code_oauth_token_2:
+    description: "Backup Claude Code OAuth token (a second subscription). Used only if the chair run with the primary token fails (e.g. rate-limit / quota exhaustion). Omit to disable failover."
+    required: false
   github_token:
     description: "Token for gh (PR read + review write). Pass the workflow github.token from the caller."
     required: true
@@ -50,6 +53,15 @@ runs:
         git config user.name "vibecodereview[bot]"
         git config user.email "vibecodereview@users.noreply.github.com"
 
+    - name: Install Claude Code CLI
+      # anthropics/claude-code-action expects the Claude Code native binary at
+      # ~/.local/bin/claude; install it here so the chair step never dies with
+      # "native binary not found". GITHUB_PATH persists into later steps.
+      shell: bash
+      run: |
+        curl -fsSL https://claude.ai/install.sh | bash
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
     - name: Council fan-out
       shell: bash
       continue-on-error: true
@@ -88,7 +100,11 @@ runs:
         echo "cycles=$COUNT" >> "$GITHUB_OUTPUT"
         echo "Consecutive bot commits at HEAD: $COUNT (limit $LIMIT)"
 
-    - name: Chair review (Claude synthesizes, fixes, posts)
+    # NOTE: the primary and backup chair steps below run the SAME prompt with a
+    # different OAuth token. Keep their `prompt:` / `claude_args:` blocks in sync.
+    - name: Chair review (primary token)
+      id: chair_primary
+      continue-on-error: true
       uses: anthropics/claude-code-action@v1
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
@@ -129,3 +145,63 @@ runs:
              `| Model | Lens | Result |` (confirmed / rejected / no findings), then `</details>`.
              If council was skipped, write "Council: skipped".
         claude_args: '--allowed-tools "Bash(gh api:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh pr comment:*),Bash(git:*),Bash(jq:*),Bash(cat:*),Read,Glob,Grep,Edit,Write"'
+
+    # Failover: only runs if the primary chair failed (e.g. the primary token is
+    # rate-limited / quota-exhausted) AND a backup token is configured. Same
+    # prompt, second subscription. Keep in sync with the primary step above.
+    - name: Chair review (backup token)
+      id: chair_backup
+      if: steps.chair_primary.outcome == 'failure' && inputs.claude_code_oauth_token_2 != ''
+      continue-on-error: true
+      uses: anthropics/claude-code-action@v1
+      with:
+        claude_code_oauth_token: ${{ inputs.claude_code_oauth_token_2 }}
+        use_commit_signing: true
+        allowed_bots: "*"
+        prompt: |
+          You chair an LLM council reviewing PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+          Branch: ${{ github.event.pull_request.head.ref }}. Can push fixes: ${{ steps.cycle.outputs.can_push }} (automated fix cycles so far: ${{ steps.cycle.outputs.cycles }}).
+
+          LOOP GUARD: if "Can push fixes" is false, DO NOT push any commits — leave a review comment only. If a prior cycle already tried to fix an issue and it persists, stop fixing it and flag it for a human instead of pushing again.
+
+          Council members each reviewed this PR through one lens (correctness, performance,
+          security, maintainability) and wrote findings to `council-findings.md`. You are the
+          synthesizer and the ONLY member who can push fixes.
+
+          1. `gh pr diff ${{ github.event.pull_request.number }}` — read the diff.
+          2. Read `council-findings.md`. Each item is an UNVERIFIED claim, not ground truth.
+             For every claim, open the file and read the surrounding code (not just the hunk)
+             and confirm it against the real code. De-dupe (same issue from many lenses = one).
+             DISCARD a claim (and note why) if: a linter/type-checker already covers it; the
+             failing path is unreachable; it is style/taste/naming; it is pre-existing code this
+             diff did not touch; it names no concrete failure trigger; or two lenses contradict
+             and neither proves it.
+          3. Read CLAUDE.md / AGENTS.md and any `.claude/rules/` relevant to changed files.
+          4. Add your own lens: conventions + test coverage. Assume the author is competent;
+             flag only diff-introduced defects with a concrete failure trigger.
+          5. If "Can push fixes" is true and you find clear, confirmed bugs/security/convention
+             issues, fix them (Edit/Write), then:
+             `git add -A && git commit -m "fix: <what>" && git push origin ${{ github.event.pull_request.head.ref }}`
+             Do NOT push style-only or speculative changes.
+          6. Assign severity yourself (council members do not rate it): Critical (security, crash,
+             data loss), Major (real bug / convention violation), Minor (rest). Post Major+ inline,
+             roll Minor into the summary, cap ~8 inline comments. Submit ONE review with
+             `gh pr review` (--approve / --request-changes / --comment). Use --request-changes only
+             for Critical. Never --approve in a run where you pushed fixes (use --comment).
+          7. In the review body include a collapsible council table:
+             `<details><summary>🧑‍⚖️ Council</summary>` then a Markdown table of
+             `| Model | Lens | Result |` (confirmed / rejected / no findings), then `</details>`.
+             If council was skipped, write "Council: skipped".
+        claude_args: '--allowed-tools "Bash(gh api:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh pr comment:*),Bash(git:*),Bash(jq:*),Bash(cat:*),Read,Glob,Grep,Edit,Write"'
+
+    # Surface the true result: green if either chair run succeeded; red if the
+    # primary failed and no backup rescued it. Without this, continue-on-error
+    # on the primary would mask a genuine failure as success.
+    - name: Chair result gate
+      shell: bash
+      run: |
+        P="${{ steps.chair_primary.outcome }}"
+        B="${{ steps.chair_backup.outcome }}"
+        if [ "$P" = "success" ]; then echo "chair: primary token succeeded"; exit 0; fi
+        if [ "$B" = "success" ]; then echo "chair: primary failed ($P); backup token succeeded"; exit 0; fi
+        echo "chair review failed (primary=$P, backup=${B:-skipped})"; exit 1


### PR DESCRIPTION
Two reliability fixes to the vibecodereview composite action.

## Install Claude Code binary
The chair step (`anthropics/claude-code-action@v1`) expects the native binary at `~/.local/bin/claude`; it wasn't always present, so reviews failed with `native binary not found`. Added an install step (mirrors the fix already landed in nova's workflow).

## Backup-token failover
New optional input `claude_code_oauth_token_2`. The chair runs with the primary token; if that run **fails** (rate-limit / quota exhaustion — the `is_error:true` we hit repeatedly) **and** a backup token is set, it retries the same review with a second subscription. A **result-gate** step reports the true outcome: green if either token succeeded, red if the primary failed with no backup to rescue it (so `continue-on-error` can't mask a genuine failure).

Consumers opt in by passing `claude_code_oauth_token_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}`; omitting it keeps today's single-token behavior.

Prompt is duplicated across the two chair steps (GitHub Actions strips YAML anchors, and a bash/heredoc rewrite would mangle the backticks in the prompt) with a keep-in-sync marker.