### PR TITLE
Count only our own commits against the fix budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,44 @@ export COUNCIL_MODELS="custom|<model>|Name|lens"
 
 No `CUSTOM_BASE_URL` → the member skips with a note, same as a missing key.
 
+## What a fix cycle costs
+
+When the chair pushes a fix, that is a real commit on the PR branch, so GitHub
+raises a `synchronize` event. Every *other* workflow in the repo that triggers on
+`pull_request` runs again. The cost does not show up against this action — it
+shows up as extra runs of your test, lint, build and e2e workflows.
+
+The arithmetic, for a repo with five `pull_request` workflows and the default
+`max_fix_cycles: 3`:
+
+```
+1 human push        -> 5 workflow runs
+3 chair fix commits -> 15 more
+                       20 runs for one PR
+```
+
+Two things to set, especially if agents open most of your PRs:
+
+- **Lower `max_fix_cycles`** to 1 or 2 on high-volume repos. Fixes past the
+  second pass are usually the chair arguing with itself, and each one costs a
+  full pipeline.
+- **Give every `pull_request` workflow a `concurrency` group** so a fix commit
+  cancels the run it superseded instead of stacking beside it. `init` already
+  writes one into `vibecodereview.yml`; hand-written workflows often lack it.
+
+```yaml
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Use `cancel-in-progress: true` for test, lint and scan workflows. Leave it
+`false`, or omit the group, on anything that deploys or runs migrations —
+cancelling those midway is worse than queueing.
+
+Set `can_push_fixes: false` to get review comments with no commits at all, which
+costs one pipeline per PR.
+
 ## Set up across many repos
 
 `bin/rollout.mjs` rolls the action out to a fleet of repos. For each repo it

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
     required: false
     default: "true"
   max_fix_cycles:
-    description: "Stop auto-pushing fixes after this many consecutive bot commits (loop guard)."
+    description: "Stop auto-pushing fixes after this many of our own consecutive commits (loop guard). Each fix commit is a new `synchronize` event, so it re-runs every other pull_request workflow in the repo — budget this against how many you have. See 'What a fix cycle costs' in the README."
     required: false
     default: "3"
 
@@ -81,17 +81,18 @@ runs:
       id: cycle
       shell: bash
       run: |
-        # Count consecutive bot commits at HEAD. After the limit, stop pushing
-        # fixes (comment-only) so review->fix->re-review can't loop forever.
+        # Count our own consecutive commits at HEAD. After the limit, stop
+        # pushing fixes (comment-only) so review->fix->re-review can't loop
+        # forever.
         LIMIT="${{ inputs.max_fix_cycles }}"
         COUNT=0
-        for SHA in $(git log --format='%H' -"$((LIMIT + 3))"); do
-          AUTHOR="$(git log -1 --format='%an' "$SHA")"
-          case "$AUTHOR" in
-            *"[bot]"|"vibecodereview"*) COUNT=$((COUNT + 1)) ;;
-            *) break ;;
-          esac
-        done
+        # Only our own commits count against the budget. Matching any *[bot]
+        # author let an unrelated bot (dependabot, another action's self-heal)
+        # sitting at HEAD burn the fix budget and silently turn fixes off.
+        while IFS= read -r AUTHOR; do
+          [ "$AUTHOR" = "vibecodereview[bot]" ] || break
+          COUNT=$((COUNT + 1))
+        done < <(git log --format='%an' -"$((LIMIT + 3))")
         if [ "$COUNT" -ge "$LIMIT" ] || [ "${{ inputs.can_push_fixes }}" = "false" ]; then
           echo "can_push=false" >> "$GITHUB_OUTPUT"
         else


### PR DESCRIPTION
Two changes, both from running this action at high pull-request volume.

## The fix-cycle guard counted other bots

```bash
case "$AUTHOR" in
  *"[bot]"|"vibecodereview"*) COUNT=$((COUNT + 1)) ;;
```

Any author ending in `[bot]` counted. So a dependabot commit, or a self-heal commit pushed by a different action, sitting at HEAD burned this action's fix budget — and the failure is silent: fixes just stop happening and the review goes comment-only with no explanation.

Now it matches the committer identity the action configures for itself. Same loop, one `git log` call instead of one per commit.

## A fix cycle is more expensive than it looks

Every fix commit is a real commit on the PR branch, so GitHub raises `synchronize`, so **every other `pull_request` workflow in the repo runs again**. None of that cost shows up against this action — it lands on the caller's test, lint, build and e2e workflows, which is why it goes unnoticed.

For a repo with five `pull_request` workflows at the default `max_fix_cycles: 3`, one pull request costs 20 workflow runs. The new README section gives the arithmetic and the two levers: lower `max_fix_cycles` on busy repos, and put a `concurrency` group on every `pull_request` workflow so a fix commit cancels the run it superseded.

I left the default at `3` rather than changing behaviour for every consumer, and documented the recommendation instead. Happy to lower it if you'd rather.