### PR TITLE
Let the Claude subscriptions hold council seats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,12 @@ never fork its provider/lens logic into the surfaces.
 
 ## Rules
 
-- Zero runtime deps. Node ≥20, global `fetch` only. Do not add npm dependencies.
-- Providers: `openai`, `gemini`, `moonshot`, `openrouter`. Add one by extending
-  `PROVIDERS` + `DEFAULT_MODELS` in the engine only.
+- Zero runtime deps. Node ≥20, global `fetch` only, except the `claude`/`claude2`
+  providers, which shell the Claude Code CLI (no npm dependency added). Do not
+  add npm dependencies.
+- Providers: `openai`, `gemini`, `moonshot`, `openrouter`, `custom`, `claude`,
+  `claude2`. Add one by extending `PROVIDERS` (+ `DEFAULT_MODELS` if it should
+  be on by default) in the engine only.
 - A member with no API key must skip with a note, never throw.
 - A composite action's `inputs:` block must contain NO `${{ }}` expressions — not in a default AND not in a description string; GitHub parses them and fails at 'Set up job'. Callers pass github_token explicitly.
 - Secrets never land in git. CI secrets live in repo settings; local keys in env.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,33 @@ export COUNCIL_MODELS="custom|<model>|Name|lens"
 
 No `CUSTOM_BASE_URL` → the member skips with a note, same as a missing key.
 
+### Claude subscription seats
+
+Every other seat needs a metered API key, and those are what run dry — a repo
+can sit at three-of-four members returning HTTP 429 while the posted summary
+still lists four reviewers, so a PR looks multi-model reviewed when only the
+chair ran.
+
+A Claude Code OAuth token is not an API bearer, so it cannot hold a normal
+seat. The `claude` and `claude2` providers shell the Claude Code CLI (already
+installed for the chair) instead of POSTing, putting the cost on the
+subscription. `claude2` lets a second subscription hold a real seat rather
+than idling as the chair's failover token.
+
+```yaml
+council_models: >-
+  claude|claude-opus-4-5|Claude Opus 4.5|correctness,
+  claude2|claude-sonnet-4-5|Claude Sonnet 4.5|security,
+  openrouter|google/gemini-3.1-pro-preview|Gemini 3.1 Pro|performance,
+  openrouter|x-ai/grok-4.6|Grok 4.6|maintainability
+```
+
+The seats run with no tools, `--max-turns 1`, and a working directory outside
+the PR checkout — `claude -p` skips the workspace-trust prompt and would
+otherwise execute a repo-local `.claude/settings.json` hook with every secret
+in the step's environment. Set `CLI_TIMEOUT_MS` to change their budget
+(default 240000).
+
 ## Set up across many repos
 
 `bin/rollout.mjs` rolls the action out to a fleet of repos. For each repo it

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: "OpenRouter key — Grok/DeepSeek member (maintainability lens). Omit to drop it."
     required: false
   council_models:
-    description: "Optional CSV override: provider|model|Name|lens,... (providers: openai, gemini, moonshot, openrouter, custom, claude, claude2)."
+    description: "Optional CSV override: provider|model|Name|lens,... (providers: openai, gemini, moonshot, openrouter, custom, claude, claude2). `claude`/`claude2` are subscription-backed seats that shell the Claude Code CLI using claude_code_oauth_token / _2 instead of a metered API key."
     required: false
   can_push_fixes:
     description: "If true, the chair may commit and push fixes to the PR branch."

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
     description: "OpenRouter key — Grok/DeepSeek member (maintainability lens). Omit to drop it."
     required: false
   council_models:
-    description: "Optional CSV override: provider|model|Name|lens,... (providers: openai, gemini, moonshot, openrouter)."
+    description: "Optional CSV override: provider|model|Name|lens,... (providers: openai, gemini, moonshot, openrouter, custom, claude, claude2)."
     required: false
   can_push_fixes:
     description: "If true, the chair may commit and push fixes to the PR branch."

--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,9 @@ runs:
         GEMINI_API_KEY: ${{ inputs.gemini_api_key }}
         MOONSHOT_API_KEY: ${{ inputs.moonshot_api_key }}
         OPENROUTER_API_KEY: ${{ inputs.openrouter_api_key }}
+        # Subscription-backed council seats (provider `claude` / `claude2`).
+        CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
+        CLAUDE_CODE_OAUTH_TOKEN_2: ${{ inputs.claude_code_oauth_token_2 }}
         COUNCIL_MODELS: ${{ inputs.council_models }}
       run: |
         gh pr diff ${{ github.event.pull_request.number }} > pr.diff || true

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -108,11 +108,17 @@ function systemPrompt(lens) {
 
 async function callClaudeCli(model, diff, oauthToken) {
   const { execFile } = await import("node:child_process");
-  const prompt = `${systemPrompt(model.lens)}\n\nPR diff:\n\n${diff}`;
+  // `claude -p` requires the prompt as a CLI argument — it does not accept a
+  // stdin-only prompt with no positional arg (stdin is documented as
+  // supplementary piped content, e.g. `cat file | claude -p "query"`). Keep
+  // the fixed, short lens instructions on argv and put the diff — which can
+  // be up to MAX_DIFF_CHARS and would blow past the per-arg ARGV_MAX limit —
+  // on stdin instead.
+  const instructions = `${systemPrompt(model.lens)}\n\nReview the PR diff piped on stdin.`;
   return new Promise((resolve) => {
     const child = execFile(
       "claude",
-      ["-p", "--model", model.model],
+      ["-p", instructions, "--model", model.model],
       {
         timeout: REQUEST_TIMEOUT_MS,
         maxBuffer: 32 * 1024 * 1024,
@@ -130,8 +136,7 @@ async function callClaudeCli(model, diff, oauthToken) {
         resolve(text ? { model, text } : { model, error: "empty response" });
       },
     );
-    // The prompt goes on stdin: a large diff blows past ARGV_MAX as an argv.
-    child.stdin?.end(prompt);
+    child.stdin?.end(diff);
   });
 }
 

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -16,6 +16,11 @@
 //   GEMINI_API_KEY      Gemini             (generativelanguage.googleapis.com)
 //   MOONSHOT_API_KEY    Kimi               (api.moonshot.ai)
 //   OPENROUTER_API_KEY  Grok / DeepSeek    (openrouter.ai)
+//   CLAUDE_CODE_OAUTH_TOKEN[_2]  Claude subscription seats (providers
+//                       `claude` / `claude2`). These shell the Claude Code
+//                       CLI instead of POSTing — no chat endpoint accepts a
+//                       subscription OAuth token — so the cost lands on the
+//                       subscription rather than a metered API key.
 //   CUSTOM_API_KEY      Any OpenAI-compatible gateway — set CUSTOM_BASE_URL
 //                       to its /chat/completions URL (OpenRouter, a self-hosted
 //                       proxy, or a local OffRouter endpoint).
@@ -30,6 +35,7 @@
 import fs from "node:fs";
 
 const MAX_DIFF_CHARS = 180_000; // bound tokens/cost on large PRs
+const CLI_TIMEOUT_MS = Number(process.env.CLI_TIMEOUT_MS || 240_000);
 const REQUEST_TIMEOUT_MS = 150_000;
 
 // All providers expose an OpenAI-compatible /chat/completions endpoint
@@ -108,34 +114,68 @@ function systemPrompt(lens) {
 
 async function callClaudeCli(model, diff, oauthToken) {
   const { execFile } = await import("node:child_process");
-  // `claude -p` requires the prompt as a CLI argument — it does not accept a
-  // stdin-only prompt with no positional arg (stdin is documented as
-  // supplementary piped content, e.g. `cat file | claude -p "query"`). Keep
-  // the fixed, short lens instructions on argv and put the diff — which can
-  // be up to MAX_DIFF_CHARS and would blow past the per-arg ARGV_MAX limit —
-  // on stdin instead.
+  const os = await import("node:os");
+  // Short lens instructions on argv, the diff on stdin. Both forms work —
+  // `claude -p` does read a stdin-only prompt — but keeping the diff off argv
+  // is what avoids ARGV_MAX at MAX_DIFF_CHARS.
   const instructions = `${systemPrompt(model.lens)}\n\nReview the PR diff piped on stdin.`;
+  // Strip every other Anthropic auth source. The CLI PREFERS ANTHROPIC_API_KEY
+  // (and the Bedrock/Vertex switches) over a claude.ai login, so a caller that
+  // sets one at job level would silently take both seats off their own
+  // subscriptions — the precedence hole is invisible from the output.
+  const env = { ...process.env, CLAUDE_CODE_OAUTH_TOKEN: oauthToken };
+  for (const k of [
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "CLAUDE_CODE_OAUTH_TOKEN_2", // a seat must only ever hold its own token
+  ]) {
+    delete env[k];
+  }
   return new Promise((resolve) => {
     const child = execFile(
       "claude",
-      ["-p", instructions, "--model", model.model],
+      [
+        "-p",
+        instructions,
+        "--model",
+        model.model,
+        // No tools: the seat needs nothing but the diff on stdin. This also
+        // keeps an agentic loop from eating the timeout.
+        "--allowed-tools",
+        "",
+        "--max-turns",
+        "1",
+      ],
       {
-        timeout: REQUEST_TIMEOUT_MS,
+        timeout: CLI_TIMEOUT_MS,
         maxBuffer: 32 * 1024 * 1024,
-        // Scope the token to this child. A seat must not inherit an ambient
-        // token from the runner, or two seats would silently share one
-        // subscription and the second would look like it ran when it did not.
-        env: { ...process.env, CLAUDE_CODE_OAUTH_TOKEN: oauthToken },
+        env,
+        // NOT the PR checkout. `claude -p` skips the workspace-trust prompt and
+        // WILL execute a repo-local .claude/settings.json hook, and this step's
+        // env holds every API key plus GH_TOKEN. Running in the untrusted head
+        // branch would hand a PR author arbitrary execution with those secrets.
+        cwd: os.tmpdir(),
       },
       (err, stdout, stderr) => {
         if (err) {
-          const why = err.killed ? "timed out" : String(stderr || err.message).slice(0, 300);
+          // The CLI reports auth failures on STDOUT and exits 1, so stderr is
+          // empty exactly when the reason matters most (dead/expired token).
+          const why = err.killed
+            ? "timed out"
+            : String(stderr || stdout || err.message).slice(0, 300);
           return resolve({ model, error: why });
         }
         const text = String(stdout || "").trim();
         resolve(text ? { model, text } : { model, error: "empty response" });
       },
     );
+    // A pending write to a child killed mid-stream emits EPIPE. Unhandled, that
+    // is an uncaughtException that exits non-zero BEFORE the findings file is
+    // written — one hung seat would destroy every other seat's review.
+    child.stdin?.on("error", () => {});
     child.stdin?.end(diff);
   });
 }
@@ -240,19 +280,23 @@ async function main() {
       PROVIDERS.custom.url = savedUrl;
     }
     if (!r2.error?.includes("CUSTOM_BASE_URL")) throw new Error("selfcheck: custom no-url path wrong: " + r2.error);
-    // a claude (CLI-backed) member with no oauth token must also skip, not
-    // shell out — even when the ambient env sets one, so the check stays
-    // offline and never spawns the CLI.
-    const savedToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
-    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
-    let r3;
-    try {
-      r3 = await callModel({ provider: "claude", model: "x", name: "X", lens: "correctness" }, "diff");
-    } finally {
-      if (savedToken !== undefined) process.env.CLAUDE_CODE_OAUTH_TOKEN = savedToken;
-    }
-    if (!r3.error?.includes("CLAUDE_CODE_OAUTH_TOKEN")) {
-      throw new Error("selfcheck: claude missing-token path wrong: " + r3.error);
+    // Both CLI seats with no token must skip WITHOUT spawning anything, so the
+    // check stays offline and does not depend on `claude` being installed.
+    for (const [prov, keyEnv] of [
+      ["claude", "CLAUDE_CODE_OAUTH_TOKEN"],
+      ["claude2", "CLAUDE_CODE_OAUTH_TOKEN_2"],
+    ]) {
+      const saved = process.env[keyEnv];
+      delete process.env[keyEnv];
+      let r3;
+      try {
+        r3 = await callModel({ provider: prov, model: "x", name: "X", lens: "security" }, "diff");
+      } finally {
+        if (saved !== undefined) process.env[keyEnv] = saved;
+      }
+      if (!r3.error?.includes(keyEnv)) {
+        throw new Error(`selfcheck: ${prov} missing-token path wrong: ${r3.error}`);
+      }
     }
     console.log("selfcheck ok");
     return;

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -123,6 +123,13 @@ async function callClaudeCli(model, diff, oauthToken) {
   // (and the Bedrock/Vertex switches) over a claude.ai login, so a caller that
   // sets one at job level would silently take both seats off their own
   // subscriptions — the precedence hole is invisible from the output.
+  //
+  // Also strip the unrelated secrets this step's env carries (GH_TOKEN, the
+  // other provider API keys). --allowed-tools "" and the os.tmpdir() cwd below
+  // already close the known ways a prompt-injected diff could get the CLI to
+  // read its env, but the seat never needs these values to do its job — don't
+  // leave them reachable as a second line of defense against a bypass in either
+  // of those controls.
   const env = { ...process.env, CLAUDE_CODE_OAUTH_TOKEN: oauthToken };
   for (const k of [
     "ANTHROPIC_API_KEY",
@@ -131,6 +138,12 @@ async function callClaudeCli(model, diff, oauthToken) {
     "CLAUDE_CODE_USE_BEDROCK",
     "CLAUDE_CODE_USE_VERTEX",
     "CLAUDE_CODE_OAUTH_TOKEN_2", // a seat must only ever hold its own token
+    "GH_TOKEN",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "MOONSHOT_API_KEY",
+    "OPENROUTER_API_KEY",
+    "CUSTOM_API_KEY",
   ]) {
     delete env[k];
   }

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -41,6 +41,15 @@ const PROVIDERS = {
   // Generic OpenAI-compatible endpoint (OpenRouter, self-hosted proxy, local
   // OffRouter). URL comes from env at call time; unset means the member skips.
   custom: { url: process.env.CUSTOM_BASE_URL, keyEnv: "CUSTOM_API_KEY" },
+  // Subscription-backed seats. These do NOT post to a chat endpoint — there is
+  // no OpenAI-compatible URL that accepts a Claude Code OAuth token — so they
+  // shell the Claude Code CLI the action already installs for the chair. Cost
+  // comes out of the Claude subscription instead of a metered API key, which
+  // is the whole point: the metered keys are what keep running dry.
+  // `claude2` exists so a second subscription can hold its own seat rather
+  // than idling as the chair's failover token.
+  claude: { cli: true, keyEnv: "CLAUDE_CODE_OAUTH_TOKEN" },
+  claude2: { cli: true, keyEnv: "CLAUDE_CODE_OAUTH_TOKEN_2" },
 };
 
 // Diverse lenses so each model catches what the others miss.
@@ -93,8 +102,42 @@ function systemPrompt(lens) {
   ].join("\n");
 }
 
+async function callClaudeCli(model, diff, oauthToken) {
+  const { execFile } = await import("node:child_process");
+  const prompt = `${systemPrompt(model.lens)}\n\nPR diff:\n\n${diff}`;
+  return new Promise((resolve) => {
+    const child = execFile(
+      "claude",
+      ["-p", "--model", model.model],
+      {
+        timeout: REQUEST_TIMEOUT_MS,
+        maxBuffer: 32 * 1024 * 1024,
+        // Scope the token to this child. A seat must not inherit an ambient
+        // token from the runner, or two seats would silently share one
+        // subscription and the second would look like it ran when it did not.
+        env: { ...process.env, CLAUDE_CODE_OAUTH_TOKEN: oauthToken },
+      },
+      (err, stdout, stderr) => {
+        if (err) {
+          const why = err.killed ? "timed out" : String(stderr || err.message).slice(0, 300);
+          return resolve({ model, error: why });
+        }
+        const text = String(stdout || "").trim();
+        resolve(text ? { model, text } : { model, error: "empty response" });
+      },
+    );
+    // The prompt goes on stdin: a large diff blows past ARGV_MAX as an argv.
+    child.stdin?.end(prompt);
+  });
+}
+
 async function callModel(model, diff) {
   const provider = PROVIDERS[model.provider];
+  const cliToken = provider?.cli && process.env[provider.keyEnv]?.trim();
+  if (provider?.cli) {
+    if (!cliToken) return { model, error: `skipped: ${provider.keyEnv} not set` };
+    return callClaudeCli(model, diff, cliToken);
+  }
   if (provider && !provider.url) return { model, error: "skipped: CUSTOM_BASE_URL not set" };
   const apiKey = provider && process.env[provider.keyEnv]?.trim();
   if (!apiKey) return { model, error: `skipped: ${provider?.keyEnv || model.provider} not set` };

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -19,6 +19,10 @@
 //   CUSTOM_API_KEY      Any OpenAI-compatible gateway — set CUSTOM_BASE_URL
 //                       to its /chat/completions URL (OpenRouter, a self-hosted
 //                       proxy, or a local OffRouter endpoint).
+//   CLAUDE_CODE_OAUTH_TOKEN    Claude subscription seat (provider `claude`) —
+//   CLAUDE_CODE_OAUTH_TOKEN_2  a second seat (provider `claude2`). Shells the
+//                       Claude Code CLI instead of calling a chat endpoint;
+//                       opt in per member via COUNCIL_MODELS.
 // Optional per-member model override: OPENAI_MODEL, GEMINI_MODEL,
 //   MOONSHOT_MODEL, OPENROUTER_MODEL.
 // Optional full override: COUNCIL_MODELS = CSV of "provider|model|Name|lens".
@@ -231,6 +235,20 @@ async function main() {
       PROVIDERS.custom.url = savedUrl;
     }
     if (!r2.error?.includes("CUSTOM_BASE_URL")) throw new Error("selfcheck: custom no-url path wrong: " + r2.error);
+    // a claude (CLI-backed) member with no oauth token must also skip, not
+    // shell out — even when the ambient env sets one, so the check stays
+    // offline and never spawns the CLI.
+    const savedToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    let r3;
+    try {
+      r3 = await callModel({ provider: "claude", model: "x", name: "X", lens: "correctness" }, "diff");
+    } finally {
+      if (savedToken !== undefined) process.env.CLAUDE_CODE_OAUTH_TOKEN = savedToken;
+    }
+    if (!r3.error?.includes("CLAUDE_CODE_OAUTH_TOKEN")) {
+      throw new Error("selfcheck: claude missing-token path wrong: " + r3.error);
+    }
     console.log("selfcheck ok");
     return;
   }
@@ -242,7 +260,7 @@ async function main() {
   const models = parseModels();
   if (models.length === 0) {
     write(
-      "# 🧑‍⚖️ LLM Council findings\n\n_Council skipped: COUNCIL_MODELS parsed to no valid members (expected `provider|model|Name|lens`; providers: openai, gemini, moonshot, openrouter, custom)._\n",
+      "# 🧑‍⚖️ LLM Council findings\n\n_Council skipped: COUNCIL_MODELS parsed to no valid members (expected `provider|model|Name|lens`; providers: openai, gemini, moonshot, openrouter, custom, claude, claude2)._\n",
     );
     console.log("No valid council members — skipped.");
     return;


### PR DESCRIPTION
## Problem

Every council seat does one thing: `POST <url>/chat/completions` with `Authorization: Bearer <key>`. So the only credential that can hold a seat is a **metered API key** — and those are exactly the ones that run dry.

Observed on `pooriaarab/popcornteam`, three of four members failing every run:

| Member | Provider | Result |
|---|---|---|
| GPT-5.6 (Codex) | openai | `429 insufficient_quota` |
| Gemini 3 Pro | gemini | `429` monthly spend cap exceeded |
| Kimi K3 | moonshot | `429` account suspended |
| Grok 4.5 | openrouter | ran |

The posted summary still listed four reviewers, so the PR **looked** multi-model reviewed when only the chair had actually run. That false-completion signal is the real bug — worse than the outage itself.

The subscriptions that *do* have headroom can't be spent here: a Claude Code OAuth token is not an API bearer, and no `/chat/completions` accepts one.

## Fix

The action already installs the Claude Code CLI (so the chair can run) and puts it on `PATH` **before** the council step. So add two CLI-backed seats — `claude` and `claude2` — that shell `claude -p` instead of POSTing. Cost lands on the subscription instead of a metered key.

`claude2` matters on its own: today `claude_code_oauth_token_2` is used **only** as the chair's failover (`if: steps.chair_primary.outcome == 'failure'`), so a second subscription sits idle on every successful run. Now it can hold a real seat.

```yaml
council_models: >-
  claude|claude-opus-4-5|Claude Opus 4.5|correctness,
  claude2|claude-sonnet-4-5|Claude Sonnet 4.5|security,
  openrouter|google/gemini-3.1-pro-preview|Gemini 3.1 Pro|performance,
  openrouter|x-ai/grok-4.6|Grok 4.6|maintainability
```

## Details worth reviewing

- **Prompt goes in on stdin**, not argv — a large diff as an argument blows past `ARGV_MAX`.
- **Each child gets its token via an explicit `env`**, not the ambient one. Otherwise two seats silently share one subscription and the second one looks like it ran when it didn't — the same false-completion failure this PR exists to remove.
- `timeout` reuses `REQUEST_TIMEOUT_MS`; a killed child reports `timed out` like the fetch path.

## Compatibility

Purely additive. `DEFAULT_MODELS` is unchanged, so any repo that doesn't set `COUNCIL_MODELS` behaves exactly as before. An unset token skips that seat with a note and still exits 0 — verified:

```
$ env -u CLAUDE_CODE_OAUTH_TOKEN -u CLAUDE_CODE_OAUTH_TOKEN_2 ... node scripts/council-review.mjs t.diff t.out
No provider keys — council skipped.       exit=0
_Council skipped: no provider keys set (CLAUDE_CODE_OAUTH_TOKEN, CLAUDE_CODE_OAUTH_TOKEN_2)._
```

`--selfcheck` passes.

## Deploy step — merging is not enough

Consumers pin `pooriaarab/vibecodereview@v1`, and `v1` is a moving major tag currently at `c76b7104`. **The tag has to be re-pointed at the merge commit** or no repo picks this up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for subscription-backed Claude and Claude 2 council members.
  - Added separate primary and backup Claude authentication options.
  - Claude reviews now run through the installed Claude Code CLI with controlled execution limits, isolated workspaces, and clearer failure reporting.
- **Documentation**
  - Updated provider documentation to cover custom and Claude-based options, setup requirements, execution restrictions, configurable timeouts, and provider registration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->