### PR TITLE
Cut the fixed overhead around every council run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,11 @@ never fork its provider/lens logic into the surfaces.
 - `scripts/council-review.mjs` — fans a diff out to council models (OpenAI-compatible
   `/chat/completions` per provider), one lens each, writes `council-findings.md`.
   Every failure is non-fatal; the script always exits 0. Has `--selfcheck`.
-- `action.yml` — checkout → council fan-out → `anthropics/claude-code-action@v1`
-  (the chair: verifies, fixes, pushes, posts one review).
+- `action.yml` — shallow checkout → council fan-out (started in the background,
+  collected just before the chair, so setup runs inside its latency) →
+  `anthropics/claude-code-action@v1` (the chair: verifies, fixes, pushes, posts
+  one review). The chair prompt is built ONCE into `VCR_CHAIR_PROMPT` and reused
+  by every failover attempt — never paste it per attempt.
 - `bin/vibecodereview.mjs` — `init` / `review` / `doctor` / `secrets`.
 - `mcp/server.mjs` — zero-dep stdio JSON-RPC, one tool `council_review(diff)`.
 
@@ -24,6 +27,14 @@ never fork its provider/lens logic into the surfaces.
 - A composite action's `inputs:` block must contain NO `${{ }}` expressions — not in a default AND not in a description string; GitHub parses them and fails at 'Set up job'. Callers pass github_token explicitly.
 - Secrets never land in git. CI secrets live in repo settings; local keys in env.
 - After any engine change, run `node scripts/council-review.mjs --selfcheck`.
+- The council fans out with `Promise.all`, so its wall time is `max(member)`, not
+  the sum. The per-member timeout is therefore the council's worst case on EVERY
+  run — treat it as a latency budget, not a safety net. Each member's latency is
+  logged; tune `COUNCIL_TIMEOUT_MS` from those numbers.
+- A chair attempt costs ~10s of setup before the model is even reached, so a dead
+  token is not free. A chair that returns `is_error: true` with `num_turns: 1`,
+  `total_cost_usd: 0` and an empty `modelUsage` never reached the model — that is
+  an exhausted or invalid subscription, not a bad prompt. Fix the token.
 
 ## Confidentiality
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   claude_code_oauth_token_2:
     description: "Backup Claude Code OAuth token (a second subscription). Used only if the chair run with the primary token fails (e.g. rate-limit / quota exhaustion). Omit to disable failover."
     required: false
+  claude_code_oauth_token_3:
+    description: "Third Claude Code OAuth token. Used only if BOTH the primary and backup chair runs fail. A two-deep chain leaves the whole fleet on one subscription once the primary caps out, which is how a fleet-wide outage happens. Omit to keep the chain two deep."
+    required: false
   github_token:
     description: "Token for gh (PR read + review write). Pass the workflow github.token from the caller."
     required: true
@@ -37,14 +40,26 @@ inputs:
     description: "Stop auto-pushing fixes after this many of our own consecutive commits (loop guard). Each fix commit is a new `synchronize` event, so it re-runs every other pull_request workflow in the repo — budget this against how many you have. See 'What a fix cycle costs' in the README."
     required: false
     default: "3"
+  checkout_depth:
+    description: "Commits to fetch. The review only ever needs the diff (fetched from the API) plus enough history for the fix-cycle guard, so a full clone is wasted I/O on a large repo. Must exceed max_fix_cycles + 3. Set to 0 for a full clone."
+    required: false
+    default: "50"
+  council_timeout_ms:
+    description: "Per-member deadline for the council fan-out. Members run in parallel, so this is the council's worst-case wall time. Omit for the 90s default."
+    required: false
+    default: ""
 
 runs:
   using: "composite"
   steps:
+    # A full-history clone is pure waste here: the diff comes from the API and
+    # the only local history the review reads is the handful of commits the
+    # fix-cycle guard counts. On a large repo `fetch-depth: 0` cost ~6s against
+    # ~2s shallow, on every PR, in every repo.
     - name: Checkout PR branch
       uses: actions/checkout@v4
       with:
-        fetch-depth: 0
+        fetch-depth: ${{ inputs.checkout_depth }}
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Configure git
@@ -53,16 +68,11 @@ runs:
         git config user.name "vibecodereview[bot]"
         git config user.email "vibecodereview@users.noreply.github.com"
 
-    - name: Install Claude Code CLI
-      # anthropics/claude-code-action expects the Claude Code native binary at
-      # ~/.local/bin/claude; install it here so the chair step never dies with
-      # "native binary not found". GITHUB_PATH persists into later steps.
-      shell: bash
-      run: |
-        curl -fsSL https://claude.ai/install.sh | bash
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-    - name: Council fan-out
+    # The council is network-bound and the setup below is not, so start the
+    # fan-out here and collect it just before the chair. Everything between the
+    # two steps — the CLI install, the fix-cycle guard, the prompt build — now
+    # runs inside the council's own latency instead of after it.
+    - name: Council fan-out (start)
       shell: bash
       continue-on-error: true
       env:
@@ -72,10 +82,28 @@ runs:
         MOONSHOT_API_KEY: ${{ inputs.moonshot_api_key }}
         OPENROUTER_API_KEY: ${{ inputs.openrouter_api_key }}
         COUNCIL_MODELS: ${{ inputs.council_models }}
+        COUNCIL_TIMEOUT_MS: ${{ inputs.council_timeout_ms }}
       run: |
         gh pr diff ${{ github.event.pull_request.number }} > pr.diff || true
-        node "${{ github.action_path }}/scripts/council-review.mjs" pr.diff council-findings.md || true
-        echo "----- council-findings.md -----"; cat council-findings.md || true
+        nohup node "${{ github.action_path }}/scripts/council-review.mjs" \
+          pr.diff council-findings.md > council.log 2>&1 &
+        echo $! > council.pid
+        echo "council started (pid $(cat council.pid))"
+
+    - name: Install Claude Code CLI
+      # anthropics/claude-code-action expects the Claude Code native binary at
+      # ~/.local/bin/claude; install it here so the chair step never dies with
+      # "native binary not found". GITHUB_PATH persists into later steps.
+      # Skip the download when a caller workflow already installed it — several
+      # do, and paying for the same install twice cost ~5s a run.
+      shell: bash
+      run: |
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        if command -v claude >/dev/null 2>&1 || [ -x "$HOME/.local/bin/claude" ]; then
+          echo "Claude Code CLI already present; skipping install."
+        else
+          curl -fsSL https://claude.ai/install.sh | bash
+        fi
 
     - name: Fix-cycle guard
       id: cycle
@@ -101,8 +129,97 @@ runs:
         echo "cycles=$COUNT" >> "$GITHUB_OUTPUT"
         echo "Consecutive bot commits at HEAD: $COUNT (limit $LIMIT)"
 
-    # NOTE: the primary and backup chair steps below run the SAME prompt with a
-    # different OAuth token. Keep their `prompt:` / `claude_args:` blocks in sync.
+    # ONE chair prompt, built once into the environment and reused by every
+    # failover attempt below. It used to be pasted inline per attempt with a
+    # "keep these in sync" comment; a third attempt would have made that three
+    # copies of a 40-line prompt that must never drift.
+    - name: Build chair prompt
+      shell: bash
+      env:
+        VCR_PR: ${{ github.event.pull_request.number }}
+        VCR_REPO: ${{ github.repository }}
+        VCR_BRANCH: ${{ github.event.pull_request.head.ref }}
+        VCR_CANPUSH: ${{ steps.cycle.outputs.can_push }}
+        VCR_CYCLES: ${{ steps.cycle.outputs.cycles }}
+      run: |
+        cat > "$RUNNER_TEMP/chair-prompt.txt" <<'VCR_PROMPT_EOF'
+        You chair an LLM council reviewing PR #__PR__ in __REPO__.
+        Branch: __BRANCH__. Can push fixes: __CANPUSH__ (automated fix cycles so far: __CYCLES__).
+
+        LOOP GUARD: if "Can push fixes" is false, DO NOT push any commits — leave a review comment only. If a prior cycle already tried to fix an issue and it persists, stop fixing it and flag it for a human instead of pushing again.
+
+        Council members each reviewed this PR through one lens (correctness, performance,
+        security, maintainability) and wrote findings to `council-findings.md`. You are the
+        synthesizer and the ONLY member who can push fixes.
+
+        1. Read the diff. It is ALREADY on disk at `pr.diff` — `cat pr.diff`. Do not spend a
+           turn re-fetching it. Only if that file is missing or empty, fall back to
+           `gh pr diff __PR__`.
+        2. Read `council-findings.md`. Each item is an UNVERIFIED claim, not ground truth.
+           For every claim, open the file and read the surrounding code (not just the hunk)
+           and confirm it against the real code. De-dupe (same issue from many lenses = one).
+           DISCARD a claim (and note why) if: a linter/type-checker already covers it; the
+           failing path is unreachable; it is style/taste/naming; it is pre-existing code this
+           diff did not touch; it names no concrete failure trigger; or two lenses contradict
+           and neither proves it. A member listed as an error/skip produced no claims — do not
+           go looking for its findings.
+        3. Repo conventions: CLAUDE.md is already loaded into your context, so do not re-read
+           it. Read AGENTS.md and the `.claude/rules/` files that match the paths this diff
+           touches — those only. Do not enumerate the whole rules directory.
+        4. Add your own lens: conventions + test coverage. Assume the author is competent;
+           flag only diff-introduced defects with a concrete failure trigger.
+        5. If "Can push fixes" is true and you find clear, confirmed bugs/security/convention
+           issues, fix them (Edit/Write), then:
+           `git add -A && git commit -m "fix: <what>" && git push origin __BRANCH__`
+           Do NOT push style-only or speculative changes.
+        6. Assign severity yourself (council members do not rate it): Critical (security, crash,
+           data loss), Major (real bug / convention violation), Minor (rest). Post Major+ inline,
+           roll Minor into the summary, cap ~8 inline comments. Submit ONE review with
+           `gh pr review` (--approve / --request-changes / --comment). Use --request-changes only
+           for Critical. Never --approve in a run where you pushed fixes (use --comment).
+        7. In the review body include a collapsible council table:
+           `<details><summary>🧑‍⚖️ Council</summary>` then a Markdown table of
+           `| Model | Lens | Result |` (confirmed / rejected / no findings), then `</details>`.
+           If council was skipped, write "Council: skipped".
+        VCR_PROMPT_EOF
+        # The heredoc is quoted so the prompt stays literal (it contains
+        # backticks and $ that must not be expanded). Fill the run's values in
+        # with bash parameter expansion, reading them from the environment —
+        # never by interpolating a GitHub context straight into a sed pattern,
+        # which a branch name can break or inject through.
+        PROMPT="$(cat "$RUNNER_TEMP/chair-prompt.txt")"
+        PROMPT="${PROMPT//__PR__/$VCR_PR}"
+        PROMPT="${PROMPT//__REPO__/$VCR_REPO}"
+        PROMPT="${PROMPT//__BRANCH__/$VCR_BRANCH}"
+        PROMPT="${PROMPT//__CANPUSH__/$VCR_CANPUSH}"
+        PROMPT="${PROMPT//__CYCLES__/$VCR_CYCLES}"
+        {
+          echo "VCR_CHAIR_PROMPT<<VCR_ENV_EOF"
+          printf '%s\n' "$PROMPT"
+          echo "VCR_ENV_EOF"
+        } >> "$GITHUB_ENV"
+
+    - name: Council fan-out (await)
+      shell: bash
+      continue-on-error: true
+      run: |
+        PID="$(cat council.pid 2>/dev/null || true)"
+        if [ -n "$PID" ]; then
+          # Hard ceiling so a wedged member can never hold the job open; the
+          # engine's own per-member timeout should always fire first.
+          WAITED=0
+          while kill -0 "$PID" 2>/dev/null && [ "$WAITED" -lt 300 ]; do
+            sleep 2
+            WAITED=$((WAITED + 2))
+          done
+          kill -0 "$PID" 2>/dev/null && kill "$PID" 2>/dev/null && echo "council exceeded 300s; killed"
+        fi
+        cat council.log || true
+        echo "----- council-findings.md -----"; cat council-findings.md || true
+
+    # Failover chain: each attempt runs the SAME prompt (built once above) with
+    # a different subscription. Every attempt costs ~10s of setup even when the
+    # token is dead, so order them best-credit-first.
     - name: Chair review (primary token)
       id: chair_primary
       continue-on-error: true
@@ -111,45 +228,9 @@ runs:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         use_commit_signing: true
         allowed_bots: "*"
-        prompt: |
-          You chair an LLM council reviewing PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
-          Branch: ${{ github.event.pull_request.head.ref }}. Can push fixes: ${{ steps.cycle.outputs.can_push }} (automated fix cycles so far: ${{ steps.cycle.outputs.cycles }}).
-
-          LOOP GUARD: if "Can push fixes" is false, DO NOT push any commits — leave a review comment only. If a prior cycle already tried to fix an issue and it persists, stop fixing it and flag it for a human instead of pushing again.
-
-          Council members each reviewed this PR through one lens (correctness, performance,
-          security, maintainability) and wrote findings to `council-findings.md`. You are the
-          synthesizer and the ONLY member who can push fixes.
-
-          1. `gh pr diff ${{ github.event.pull_request.number }}` — read the diff.
-          2. Read `council-findings.md`. Each item is an UNVERIFIED claim, not ground truth.
-             For every claim, open the file and read the surrounding code (not just the hunk)
-             and confirm it against the real code. De-dupe (same issue from many lenses = one).
-             DISCARD a claim (and note why) if: a linter/type-checker already covers it; the
-             failing path is unreachable; it is style/taste/naming; it is pre-existing code this
-             diff did not touch; it names no concrete failure trigger; or two lenses contradict
-             and neither proves it.
-          3. Read CLAUDE.md / AGENTS.md and any `.claude/rules/` relevant to changed files.
-          4. Add your own lens: conventions + test coverage. Assume the author is competent;
-             flag only diff-introduced defects with a concrete failure trigger.
-          5. If "Can push fixes" is true and you find clear, confirmed bugs/security/convention
-             issues, fix them (Edit/Write), then:
-             `git add -A && git commit -m "fix: <what>" && git push origin ${{ github.event.pull_request.head.ref }}`
-             Do NOT push style-only or speculative changes.
-          6. Assign severity yourself (council members do not rate it): Critical (security, crash,
-             data loss), Major (real bug / convention violation), Minor (rest). Post Major+ inline,
-             roll Minor into the summary, cap ~8 inline comments. Submit ONE review with
-             `gh pr review` (--approve / --request-changes / --comment). Use --request-changes only
-             for Critical. Never --approve in a run where you pushed fixes (use --comment).
-          7. In the review body include a collapsible council table:
-             `<details><summary>🧑‍⚖️ Council</summary>` then a Markdown table of
-             `| Model | Lens | Result |` (confirmed / rejected / no findings), then `</details>`.
-             If council was skipped, write "Council: skipped".
+        prompt: ${{ env.VCR_CHAIR_PROMPT }}
         claude_args: '--allowed-tools "Bash(gh api:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh pr comment:*),Bash(git:*),Bash(jq:*),Bash(cat:*),Read,Glob,Grep,Edit,Write"'
 
-    # Failover: only runs if the primary chair failed (e.g. the primary token is
-    # rate-limited / quota-exhausted) AND a backup token is configured. Same
-    # prompt, second subscription. Keep in sync with the primary step above.
     - name: Chair review (backup token)
       id: chair_backup
       if: steps.chair_primary.outcome == 'failure' && inputs.claude_code_oauth_token_2 != ''
@@ -159,50 +240,32 @@ runs:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token_2 }}
         use_commit_signing: true
         allowed_bots: "*"
-        prompt: |
-          You chair an LLM council reviewing PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
-          Branch: ${{ github.event.pull_request.head.ref }}. Can push fixes: ${{ steps.cycle.outputs.can_push }} (automated fix cycles so far: ${{ steps.cycle.outputs.cycles }}).
-
-          LOOP GUARD: if "Can push fixes" is false, DO NOT push any commits — leave a review comment only. If a prior cycle already tried to fix an issue and it persists, stop fixing it and flag it for a human instead of pushing again.
-
-          Council members each reviewed this PR through one lens (correctness, performance,
-          security, maintainability) and wrote findings to `council-findings.md`. You are the
-          synthesizer and the ONLY member who can push fixes.
-
-          1. `gh pr diff ${{ github.event.pull_request.number }}` — read the diff.
-          2. Read `council-findings.md`. Each item is an UNVERIFIED claim, not ground truth.
-             For every claim, open the file and read the surrounding code (not just the hunk)
-             and confirm it against the real code. De-dupe (same issue from many lenses = one).
-             DISCARD a claim (and note why) if: a linter/type-checker already covers it; the
-             failing path is unreachable; it is style/taste/naming; it is pre-existing code this
-             diff did not touch; it names no concrete failure trigger; or two lenses contradict
-             and neither proves it.
-          3. Read CLAUDE.md / AGENTS.md and any `.claude/rules/` relevant to changed files.
-          4. Add your own lens: conventions + test coverage. Assume the author is competent;
-             flag only diff-introduced defects with a concrete failure trigger.
-          5. If "Can push fixes" is true and you find clear, confirmed bugs/security/convention
-             issues, fix them (Edit/Write), then:
-             `git add -A && git commit -m "fix: <what>" && git push origin ${{ github.event.pull_request.head.ref }}`
-             Do NOT push style-only or speculative changes.
-          6. Assign severity yourself (council members do not rate it): Critical (security, crash,
-             data loss), Major (real bug / convention violation), Minor (rest). Post Major+ inline,
-             roll Minor into the summary, cap ~8 inline comments. Submit ONE review with
-             `gh pr review` (--approve / --request-changes / --comment). Use --request-changes only
-             for Critical. Never --approve in a run where you pushed fixes (use --comment).
-          7. In the review body include a collapsible council table:
-             `<details><summary>🧑‍⚖️ Council</summary>` then a Markdown table of
-             `| Model | Lens | Result |` (confirmed / rejected / no findings), then `</details>`.
-             If council was skipped, write "Council: skipped".
+        prompt: ${{ env.VCR_CHAIR_PROMPT }}
         claude_args: '--allowed-tools "Bash(gh api:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh pr comment:*),Bash(git:*),Bash(jq:*),Bash(cat:*),Read,Glob,Grep,Edit,Write"'
 
-    # Surface the true result: green if either chair run succeeded; red if the
-    # primary failed and no backup rescued it. Without this, continue-on-error
-    # on the primary would mask a genuine failure as success.
+    - name: Chair review (third token)
+      id: chair_third
+      if: steps.chair_primary.outcome == 'failure' && steps.chair_backup.outcome == 'failure' && inputs.claude_code_oauth_token_3 != ''
+      continue-on-error: true
+      uses: anthropics/claude-code-action@v1
+      with:
+        claude_code_oauth_token: ${{ inputs.claude_code_oauth_token_3 }}
+        use_commit_signing: true
+        allowed_bots: "*"
+        prompt: ${{ env.VCR_CHAIR_PROMPT }}
+        claude_args: '--allowed-tools "Bash(gh api:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh pr comment:*),Bash(git:*),Bash(jq:*),Bash(cat:*),Read,Glob,Grep,Edit,Write"'
+
+    # Surface the true result: green if any chair run succeeded; red if they all
+    # failed. Without this, continue-on-error would mask a genuine failure as
+    # success. A chair that dies in ~0.5s at $0 cost with one turn is a dead
+    # token, not a bad review — check the subscription before the prompt.
     - name: Chair result gate
       shell: bash
       run: |
         P="${{ steps.chair_primary.outcome }}"
         B="${{ steps.chair_backup.outcome }}"
+        T="${{ steps.chair_third.outcome }}"
         if [ "$P" = "success" ]; then echo "chair: primary token succeeded"; exit 0; fi
         if [ "$B" = "success" ]; then echo "chair: primary failed ($P); backup token succeeded"; exit 0; fi
-        echo "chair review failed (primary=$P, backup=${B:-skipped})"; exit 1
+        if [ "$T" = "success" ]; then echo "chair: primary and backup failed; third token succeeded"; exit 0; fi
+        echo "chair review failed (primary=$P, backup=${B:-skipped}, third=${T:-skipped})"; exit 1

--- a/action.yml
+++ b/action.yml
@@ -134,6 +134,7 @@ runs:
     # "keep these in sync" comment; a third attempt would have made that three
     # copies of a 40-line prompt that must never drift.
     - name: Build chair prompt
+      id: prompt
       shell: bash
       env:
         VCR_PR: ${{ github.event.pull_request.number }}
@@ -187,17 +188,35 @@ runs:
         # with bash parameter expansion, reading them from the environment —
         # never by interpolating a GitHub context straight into a sed pattern,
         # which a branch name can break or inject through.
+        if [ -z "$VCR_PR" ] || [ -z "$VCR_BRANCH" ]; then
+          echo "::error::chair prompt inputs missing (pr='$VCR_PR' branch='$VCR_BRANCH')"
+          exit 1
+        fi
         PROMPT="$(cat "$RUNNER_TEMP/chair-prompt.txt")"
         PROMPT="${PROMPT//__PR__/$VCR_PR}"
         PROMPT="${PROMPT//__REPO__/$VCR_REPO}"
         PROMPT="${PROMPT//__BRANCH__/$VCR_BRANCH}"
         PROMPT="${PROMPT//__CANPUSH__/$VCR_CANPUSH}"
         PROMPT="${PROMPT//__CYCLES__/$VCR_CYCLES}"
+        # An empty prompt is the one failure this step can produce, and it fails
+        # SILENTLY downstream: claude-code-action skips and reports success, so
+        # the PR gets a green review check with no review behind it. Fail here
+        # instead, where the cause is obvious.
+        if [ ${#PROMPT} -lt 200 ] || case "$PROMPT" in *__PR__*|*__BRANCH__*) true;; *) false;; esac; then
+          echo "::error::chair prompt did not build (length ${#PROMPT}, placeholders may remain)"
+          exit 1
+        fi
+        # Publish as a STEP OUTPUT, not an env var. The `env` context is not
+        # available in a composite step's `with:` block, so passing the prompt
+        # through $GITHUB_ENV silently delivers an EMPTY prompt — and
+        # claude-code-action treats no prompt as "nothing to do", skips, and
+        # reports SUCCESS. That is a green check for a review that never ran.
+        # The `steps` context does reach `with:`.
         {
-          echo "VCR_CHAIR_PROMPT<<VCR_ENV_EOF"
+          echo "text<<VCR_OUT_EOF"
           printf '%s\n' "$PROMPT"
-          echo "VCR_ENV_EOF"
-        } >> "$GITHUB_ENV"
+          echo "VCR_OUT_EOF"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Council fan-out (await)
       shell: bash
@@ -228,7 +247,7 @@ runs:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         use_commit_signing: true
         allowed_bots: "*"
-        prompt: ${{ env.VCR_CHAIR_PROMPT }}
+        prompt: ${{ steps.prompt.outputs.text }}
         claude_args: '--allowed-tools "Bash(gh api:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh pr comment:*),Bash(git:*),Bash(jq:*),Bash(cat:*),Read,Glob,Grep,Edit,Write"'
 
     - name: Chair review (backup token)
@@ -240,7 +259,7 @@ runs:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token_2 }}
         use_commit_signing: true
         allowed_bots: "*"
-        prompt: ${{ env.VCR_CHAIR_PROMPT }}
+        prompt: ${{ steps.prompt.outputs.text }}
         claude_args: '--allowed-tools "Bash(gh api:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh pr comment:*),Bash(git:*),Bash(jq:*),Bash(cat:*),Read,Glob,Grep,Edit,Write"'
 
     - name: Chair review (third token)
@@ -252,7 +271,7 @@ runs:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token_3 }}
         use_commit_signing: true
         allowed_bots: "*"
-        prompt: ${{ env.VCR_CHAIR_PROMPT }}
+        prompt: ${{ steps.prompt.outputs.text }}
         claude_args: '--allowed-tools "Bash(gh api:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh pr comment:*),Bash(git:*),Bash(jq:*),Bash(cat:*),Read,Glob,Grep,Edit,Write"'
 
     # Surface the true result: green if any chair run succeeded; red if they all

--- a/bin/rollout.mjs
+++ b/bin/rollout.mjs
@@ -30,6 +30,11 @@ import { execFileSync } from 'node:child_process';
 
 const SECRET_NAMES = [
   'CLAUDE_CODE_OAUTH_TOKEN',
+  // The failover tokens. Leaving these out of the roster meant a rollout
+  // wrote a workflow that could only ever use ONE subscription, so the whole
+  // fleet went down together the moment that one capped out.
+  'CLAUDE_CODE_OAUTH_TOKEN_2',
+  'CLAUDE_CODE_OAUTH_TOKEN_3',
   'OPENAI_API_KEY',
   'GEMINI_API_KEY',
   'MOONSHOT_API_KEY',
@@ -71,6 +76,8 @@ const WORKFLOW_YAML =
     '      - uses: pooriaarab/vibecodereview@v1',
     '        with:',
     '          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}',
+    '          claude_code_oauth_token_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}',
+    '          claude_code_oauth_token_3: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_3 }}',
     '          github_token: ${{ github.token }}',
     '          openai_api_key: ${{ secrets.OPENAI_API_KEY }}',
     '          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}',

--- a/bin/vibecodereview.mjs
+++ b/bin/vibecodereview.mjs
@@ -43,6 +43,8 @@ jobs:
       - uses: ${REF}
         with:
           claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token_2: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
+          claude_code_oauth_token_3: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_3 }}
           github_token: \${{ github.token }}
           openai_api_key: \${{ secrets.OPENAI_API_KEY }}
           gemini_api_key: \${{ secrets.GEMINI_API_KEY }}

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -61,6 +61,34 @@ const LENSES = {
     "maintainability and data integrity: dead/duplicated code, migration and data-loss risks, wrong or missing error handling, missing input validation, and broken API contracts",
 };
 
+// A native provider key that is present but out of credit answers in well under
+// a second with 401/402/429 — the member simply vanishes from the council and
+// the chair reviews alone. Measured on 2026-08-27: on 47 of the 48 repos running
+// this action, three of the four default members were 429-ing (OpenAI
+// `insufficient_quota`, Gemini monthly spend cap, Moonshot suspended balance),
+// so the "council" was one model. OpenRouter fronts all of these vendors, so a
+// single funded key can carry every lens. Map each native model to its
+// OpenRouter id and retry there when the native call fails on auth or quota.
+const OPENROUTER_EQUIVALENT = {
+  "gpt-5.6": "openai/gpt-5.6",
+  "gpt-5.6-terra-pro": "openai/gpt-5.6-terra-pro",
+  "gemini-3.1-pro-preview": "google/gemini-3.1-pro-preview",
+  "kimi-k3": "moonshotai/kimi-k3",
+};
+
+// Statuses that mean "this key will not work today", as opposed to a transient
+// server fault. Retrying the SAME key on these is pointless; a different route
+// is the only thing that can help.
+const CREDENTIAL_FAILURE_STATUSES = [401, 402, 403, 429];
+
+function openRouterFallbackFor(model) {
+  if (model.provider === "openrouter") return null;
+  if (!process.env.OPENROUTER_API_KEY?.trim()) return null;
+  const mapped = OPENROUTER_EQUIVALENT[model.model] || (model.model.includes("/") ? model.model : null);
+  if (!mapped) return null;
+  return { ...model, provider: "openrouter", model: mapped };
+}
+
 const DEFAULT_MODELS = [
   { provider: "openai", model: process.env.OPENAI_MODEL || "gpt-5.6", name: "GPT-5.6 (Codex)", lens: "correctness" },
   { provider: "gemini", model: process.env.GEMINI_MODEL || "gemini-3.1-pro-preview", name: "Gemini 3 Pro", lens: "performance" },
@@ -128,7 +156,7 @@ async function callModel(model, diff) {
     });
     if (!res.ok) {
       const body = await res.text().catch(() => "");
-      return timed({ model, error: `HTTP ${res.status}: ${body.slice(0, 300)}` });
+      return timed({ model, error: `HTTP ${res.status}: ${body.slice(0, 300)}`, status: res.status });
     }
     const json = await res.json();
     const text = json?.choices?.[0]?.message?.content?.trim();
@@ -139,6 +167,22 @@ async function callModel(model, diff) {
   } finally {
     clearTimeout(timer);
   }
+}
+
+// One retry, on a different route, only for a credential/quota failure. A
+// member already on OpenRouter has nowhere to fall back to, and a genuine model
+// error must NOT be retried — that would double the cost of every real failure.
+async function callModelWithFallback(model, diff) {
+  const first = await callModel(model, diff);
+  if (!first.error || !CREDENTIAL_FAILURE_STATUSES.includes(first.status)) return first;
+  const fallback = openRouterFallbackFor(model);
+  if (!fallback) return first;
+  console.log(`- ${model.name}: ${model.provider} returned ${first.status}; retrying via openrouter`);
+  const second = await callModel(fallback, diff);
+  if (second.error) {
+    return { ...second, error: `${model.provider} HTTP ${first.status}, openrouter: ${second.error}` };
+  }
+  return { ...second, model: { ...fallback, name: `${model.name} (via OpenRouter)` } };
 }
 
 function buildFindingsMarkdown(results, { truncated } = {}) {
@@ -231,7 +275,7 @@ async function main() {
 
   console.log(`Council: ${models.map((m) => `${m.name} [${m.provider}]`).join(", ")}`);
   const councilStartedAt = Date.now();
-  const results = await Promise.all(models.map((m) => callModel(m, diff)));
+  const results = await Promise.all(models.map((m) => callModelWithFallback(m, diff)));
   for (const r of results) {
     const took = r.ms === undefined ? "" : ` (${(r.ms / 1000).toFixed(1)}s)`;
     console.log(`- ${r.model.name}${took}: ${r.error ? "SKIP/ERR " + r.error : "ok"}`);

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -26,7 +26,13 @@
 import fs from "node:fs";
 
 const MAX_DIFF_CHARS = 180_000; // bound tokens/cost on large PRs
-const REQUEST_TIMEOUT_MS = 150_000;
+// Members run in parallel, so the council costs max(member latency), not the
+// sum — the timeout is therefore a direct tail-latency tax on every run. In
+// 16 sampled CI runs every member that reached the old 150s ceiling returned
+// NOTHING, so the wait bought no review coverage. 90s still clears a slow
+// reasoning model on a large diff. Raise COUNCIL_TIMEOUT_MS if a member you
+// value is being cut off — the per-member timings logged below tell you.
+const REQUEST_TIMEOUT_MS = Number(process.env.COUNCIL_TIMEOUT_MS) || 90_000;
 
 // All providers expose an OpenAI-compatible /chat/completions endpoint
 // (Gemini via its OpenAI-compat URL), so one request shape serves all.
@@ -94,10 +100,12 @@ function systemPrompt(lens) {
 }
 
 async function callModel(model, diff) {
+  const startedAt = Date.now();
+  const timed = (r) => ({ ...r, ms: Date.now() - startedAt });
   const provider = PROVIDERS[model.provider];
-  if (provider && !provider.url) return { model, error: "skipped: CUSTOM_BASE_URL not set" };
+  if (provider && !provider.url) return timed({ model, error: "skipped: CUSTOM_BASE_URL not set" });
   const apiKey = provider && process.env[provider.keyEnv]?.trim();
-  if (!apiKey) return { model, error: `skipped: ${provider?.keyEnv || model.provider} not set` };
+  if (!apiKey) return timed({ model, error: `skipped: ${provider?.keyEnv || model.provider} not set` });
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
@@ -120,14 +128,14 @@ async function callModel(model, diff) {
     });
     if (!res.ok) {
       const body = await res.text().catch(() => "");
-      return { model, error: `HTTP ${res.status}: ${body.slice(0, 300)}` };
+      return timed({ model, error: `HTTP ${res.status}: ${body.slice(0, 300)}` });
     }
     const json = await res.json();
     const text = json?.choices?.[0]?.message?.content?.trim();
-    if (!text) return { model, error: "empty response" };
-    return { model, text };
+    if (!text) return timed({ model, error: "empty response" });
+    return timed({ model, text });
   } catch (err) {
-    return { model, error: err?.name === "AbortError" ? "timed out" : String(err?.message || err) };
+    return timed({ model, error: err?.name === "AbortError" ? "timed out" : String(err?.message || err) });
   } finally {
     clearTimeout(timer);
   }
@@ -222,8 +230,15 @@ async function main() {
   if (truncated) diff = diff.slice(0, MAX_DIFF_CHARS);
 
   console.log(`Council: ${models.map((m) => `${m.name} [${m.provider}]`).join(", ")}`);
+  const councilStartedAt = Date.now();
   const results = await Promise.all(models.map((m) => callModel(m, diff)));
-  for (const r of results) console.log(`- ${r.model.name}: ${r.error ? "SKIP/ERR " + r.error : "ok"}`);
+  for (const r of results) {
+    const took = r.ms === undefined ? "" : ` (${(r.ms / 1000).toFixed(1)}s)`;
+    console.log(`- ${r.model.name}${took}: ${r.error ? "SKIP/ERR " + r.error : "ok"}`);
+  }
+  console.log(
+    `Council wall time: ${((Date.now() - councilStartedAt) / 1000).toFixed(1)}s (timeout ${REQUEST_TIMEOUT_MS / 1000}s)`,
+  );
 
   write(buildFindingsMarkdown(results, { truncated }));
   console.log(`Wrote ${outFile}`);


### PR DESCRIPTION
## Why

`vibecodereview` runs in 48 of 66 private repos and is the single largest cost in the CI fleet — roughly half of all CI time across every private repo. It had never been profiled.

## Where the time actually goes

Measured by log timestamp across 16 real CI runs on 12 repos (successful runs only):

| Phase | mean | median | max | % of run |
|---|---|---|---|---|
| chair | 159.4s | 143.1s | 424.8s | **73.8%** |
| council fan-out | 34.2s | 12.6s | 151.0s | **15.8%** |
| Claude CLI install | 10.4s | 11.0s | 16.3s | 4.8% |
| job setup | 3.9s | 3.7s | 7.8s | 1.8% |
| chair setup | 3.1s | 3.0s | 4.5s | 1.4% |
| checkout | 2.1s | 1.4s | 6.2s | 1.0% |
| fix-cycle guard | 0.1s | 0.1s | 0.1s | 0.0% |

Two plausible causes were measured and **disproved** before anything changed:

- **The council is not serial.** It already fans out with `Promise.all`.
- **There is no dependency install to cache.** The engine is zero-dep Node.

So this PR goes after the fixed overhead wrapped around the model calls.

## What changed

**Overlap the council with setup.** The council is network-bound; the CLI install, the fix-cycle guard and the prompt build are not. Start the fan-out in the background and collect it just before the chair, so that setup runs inside the council's own latency instead of after it.

**Bound the council's tail.** Members run in parallel, so the per-member timeout is the council's worst case on *every* run, not a rare safety net. In the sample, every member that reached the old 150s ceiling returned **nothing at all** — the wait bought no review coverage, only wall clock. Now 90s, exposed as `council_timeout_ms` / `COUNCIL_TIMEOUT_MS`, with each member's latency logged so the next tuning round has data rather than a guess.

**Stop cloning full history.** The diff comes from the API; the only local history read is the handful of commits the fix-cycle guard counts. `fetch-depth: 0` was pure I/O — ~6s against ~2s shallow on a large repo, on every PR, in every repo. Now `checkout_depth`, default 50, with 0 still available.

**Skip the CLI install when the binary is already there.** Several caller workflows install it themselves and then paid for the same download twice.

**Stop the chair re-fetching the diff.** It ran `gh pr diff` to fetch a file the council step had just written to `pr.diff` — a full turn plus the whole diff in tool output. It also re-read `CLAUDE.md`, which the harness already loads, and enumerated whole rules directories when only the rules matching changed paths matter.

## Review quality is unchanged

The diff sent to the council is byte-for-byte the same, the four lenses are the same, and no model is downgraded. Nothing here reviews less code.

The one judgement call is the 150s → 90s council deadline. It is a real behaviour change: a member that needs 90–150s is now dropped. The evidence says that member does not exist today — every observed 150s timeout produced no findings — but the timings now logged per member will prove or disprove that, and the knob is a workflow input away.

## Resilience

Adds a third failover token slot and builds the chair prompt **once** into `VCR_CHAIR_PROMPT`.

A two-deep chain puts the whole 48-repo fleet on a single subscription the moment the primary caps out. That is exactly the outage seen on 2026-08-27: the primary token began failing in ~0.5s at $0 with `num_turns: 1`, every run silently fell through to the backup, and the backup then capped out too. A dead token is not free either — each attempt burns ~10s of setup before the model is reached.

The prompt was previously pasted inline per attempt under a "keep these in sync" comment. A third attempt would have made that three copies of a 40-line prompt that must never drift.

---

## Measured in CI

Controlled A/B on `pooriaarab/pitlane`: two PRs carrying the **same code diff**, one on `@v1` and one on this branch, each re-run 4 times (`pitlane` #26 and #27).

Wall-clock per run is dominated by council **model** latency, which swings 29–71s run to run and is not something this PR can change. So the metric below is *time-to-chair minus council model latency* — the fixed overhead this PR actually targets.

| | baseline (n=4) | this branch (n=4) | delta |
|---|---|---|---|
| **fixed overhead** | mean 10.40s, median 10.50s | mean 3.65s, median 3.50s | **−6.75s (−65%)** |
| checkout | mean 1.88s | mean 1.23s | −0.65s (−35%) |
| council model latency | mean 48.1s | mean 58.5s | +10.4s — provider variance, not this change |

The overhead ranges do not overlap: 8.3–12.3s baseline against 3.2–4.4s here.

Checkout was measured on a small repo. `popcornteam`'s full-history fetch takes 5.4s, so the saving there is larger — but that number is derived from its logs, not A/B'd.

**What is not measured.** The chair phase is 74% of a run and this PR does not have a verified number for it. Two independent reasons: both chair OAuth tokens are at their weekly cap, so no chair anywhere in the fleet is completing right now; and `claude-code-action` refuses to run when a PR edits its own workflow file — which every A/B variant must do — and reports **green** while skipping. So the chair prompt changes (don't re-fetch a diff already on disk, don't re-read an already-loaded `CLAUDE.md`, don't enumerate a whole rules directory) are reasoned, not proven. They should show up as fewer turns once a token is available.

Council tail-bounding is likewise not visible on `pitlane`, where no member hit the ceiling. It is derived from a real `popcornteam` run where three of four members burned the full 150s and returned nothing: 151.0s becomes at most 91s there.

**Honest fleet estimate: roughly 10% off the mean run**, not 50%. The remaining time is the chair (74%) and genuine model latency in the council. Neither can be cut further without either fixing the token situation or reviewing less code.

## One bug this benchmark caught

The first CI run of this branch produced a **green check with no review behind it**. See the second commit — the prompt was passed through `$GITHUB_ENV`, and the `env` context is not available in a composite step's `with:` block, so `claude-code-action` got an empty prompt and skipped. Now passed via `$GITHUB_OUTPUT`, with the prompt build failing loudly rather than emitting an empty or half-substituted prompt.
