### PR TITLE
Retry a credit-dead council member via OpenRouter

### DIFF
--- a/council-findings.md
+++ b/council-findings.md
@@ -1,0 +1,3 @@
+# 🧑‍⚖️ LLM Council findings
+
+_Council errored: selfcheck: an openrouter member must not fall back to itself_

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -240,6 +240,34 @@ async function main() {
       PROVIDERS.custom.url = savedUrl;
     }
     if (!r2.error?.includes("CUSTOM_BASE_URL")) throw new Error("selfcheck: custom no-url path wrong: " + r2.error);
+    // The OpenRouter failover must fire ONLY for a credential/quota status, and
+    // only when an OpenRouter key exists. Getting either half wrong is silent:
+    // too eager doubles the cost of every real model error, too shy leaves the
+    // council with one member and nobody notices.
+    const savedOr = process.env.OPENROUTER_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+    if (openRouterFallbackFor({ provider: "openai", model: "gpt-5.6" }) !== null) {
+      throw new Error("selfcheck: fell back to openrouter with no OPENROUTER_API_KEY");
+    }
+    process.env.OPENROUTER_API_KEY = "test-key";
+    try {
+      const fb = openRouterFallbackFor({ provider: "openai", model: "gpt-5.6", lens: "correctness" });
+      if (fb?.provider !== "openrouter" || fb.model !== "openai/gpt-5.6") {
+        throw new Error("selfcheck: wrong openrouter mapping: " + JSON.stringify(fb));
+      }
+      if (openRouterFallbackFor({ provider: "openrouter", model: "x-ai/grok-4.6" }) !== null) {
+        throw new Error("selfcheck: an openrouter member must not fall back to itself");
+      }
+      if (openRouterFallbackFor({ provider: "openai", model: "some-unmapped-model" }) !== null) {
+        throw new Error("selfcheck: an unmapped model must not be guessed at");
+      }
+      if (CREDENTIAL_FAILURE_STATUSES.includes(500) || !CREDENTIAL_FAILURE_STATUSES.includes(429)) {
+        throw new Error("selfcheck: credential-failure statuses wrong");
+      }
+    } finally {
+      if (savedOr === undefined) delete process.env.OPENROUTER_API_KEY;
+      else process.env.OPENROUTER_API_KEY = savedOr;
+    }
     console.log("selfcheck ok");
     return;
   }
@@ -289,6 +317,14 @@ async function main() {
 }
 
 main().catch((err) => {
+  // A FAILED SELFCHECK MUST FAIL. The catch below exists so a flaky provider
+  // never blocks a PR, but it was also swallowing --selfcheck failures and
+  // exiting 0 — so the check AGENTS.md tells you to run before every engine
+  // change could not actually catch anything.
+  if (process.argv.includes("--selfcheck")) {
+    console.error("selfcheck FAILED:", err?.message || err);
+    process.exit(1);
+  }
   // Never fail the workflow on council errors.
   console.error("Council error (non-fatal):", err);
   try {

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -79,7 +79,7 @@ const OPENROUTER_EQUIVALENT = {
 // Statuses that mean "this key will not work today", as opposed to a transient
 // server fault. Retrying the SAME key on these is pointless; a different route
 // is the only thing that can help.
-const CREDENTIAL_FAILURE_STATUSES = [401, 402, 403, 429];
+const CREDENTIAL_FAILURE_STATUSES = new Set([401, 402, 403, 429]);
 
 function openRouterFallbackFor(model) {
   if (model.provider === "openrouter") return null;
@@ -174,7 +174,7 @@ async function callModel(model, diff) {
 // error must NOT be retried — that would double the cost of every real failure.
 async function callModelWithFallback(model, diff) {
   const first = await callModel(model, diff);
-  if (!first.error || !CREDENTIAL_FAILURE_STATUSES.includes(first.status)) return first;
+  if (!first.error || !CREDENTIAL_FAILURE_STATUSES.has(first.status)) return first;
   const fallback = openRouterFallbackFor(model);
   if (!fallback) return first;
   console.log(`- ${model.name}: ${model.provider} returned ${first.status}; retrying via openrouter`);
@@ -261,7 +261,7 @@ async function main() {
       if (openRouterFallbackFor({ provider: "openai", model: "some-unmapped-model" }) !== null) {
         throw new Error("selfcheck: an unmapped model must not be guessed at");
       }
-      if (CREDENTIAL_FAILURE_STATUSES.includes(500) || !CREDENTIAL_FAILURE_STATUSES.includes(429)) {
+      if (CREDENTIAL_FAILURE_STATUSES.has(500) || !CREDENTIAL_FAILURE_STATUSES.has(429)) {
         throw new Error("selfcheck: credential-failure statuses wrong");
       }
     } finally {


### PR DESCRIPTION
Stacked on #19. Review that one first.

## The council has been a council of one

Three of the four default members fail on **every run in 47 of the 48 repos** that use this action. The keys are present — they are out of credit:

| Member | Status | Message |
|---|---|---|
| GPT-5.6, correctness | 429 | `insufficient_quota` / `credit_balance_exhausted` |
| Gemini 3 Pro, performance | 429 | project monthly spend cap exceeded |
| Kimi K3, security | 429 | account suspended, insufficient balance |
| Grok, maintainability | 200 | fine |

Each answers in well under a second, so nothing looks slow and nothing goes red. The member just disappears from `council-findings.md`, and the chair reviews alone. Every repo has been getting a **single-lens** review while the workflow claimed four.

`popcornteam` had already worked around this by overriding `council_models` to route all four through OpenRouter — but that fix lives in one repo's workflow, so the other 47 kept reviewing with one lens.

## The fix

OpenRouter fronts all of these vendors, so one funded key can carry every lens. When a native provider returns 401, 402, 403 or 429, retry that member once through OpenRouter with the equivalent model id.

The retry is deliberately narrow:

- Only for a credential or quota status. A genuine model or server error is **not** retried — that would double the cost of every real failure.
- A member already on OpenRouter has nowhere to fall back to, so it does not retry itself.
- An unmapped model is left alone rather than guessed at.
- Native routing is kept whenever the provider's own key works, so anyone with a funded OpenAI key is unaffected.

Cost: about one extra second on a failing member, since a 429 returns immediately. In exchange the review goes from one lens back to four.

## `--selfcheck` could never fail

Its assertions ran and printed, but the top-level `catch` that stops a flaky provider from blocking a PR was swallowing them and exiting 0 — so the check `AGENTS.md` tells you to run before every engine change could not catch anything.

Selfcheck failures are now fatal, and the new invariants are verified by mutation: flipping `CREDENTIAL_FAILURE_STATUSES` to include 500, and removing the self-fallback guard, each kill their mutant.