### PR TITLE
Flatten the two remaining over-complex functions

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -3,14 +3,14 @@
   "plugins": ["typescript", "import", "unicorn", "oxc"],
   "categories": { "correctness": "warn", "suspicious": "warn", "perf": "warn", "pedantic": "off", "style": "off", "restriction": "off", "nursery": "off" },
   "rules": {
-    "complexity": ["warn", { "max": 10 }],
-    "max-lines": ["warn", { "max": 300, "skipBlankLines": true, "skipComments": true }],
+    "complexity": ["error", { "max": 10 }],
+    "max-lines": ["error", { "max": 300, "skipBlankLines": true, "skipComments": true }],
     "max-lines-per-function": ["error", { "max": 50, "skipBlankLines": true, "skipComments": true }],
-    "max-params": ["warn", { "max": 4 }],
-    "max-depth": ["warn", { "max": 4 }],
-    "max-nested-callbacks": ["warn", { "max": 4 }],
-    "no-var": "warn", "prefer-const": "warn", "eqeqeq": "warn", "no-debugger": "warn",
-    "typescript/no-explicit-any": "warn", "typescript/no-non-null-assertion": "warn", "import/no-cycle": "warn"
+    "max-params": ["error", { "max": 4 }],
+    "max-depth": ["error", { "max": 4 }],
+    "max-nested-callbacks": ["error", { "max": 4 }],
+    "no-var": "error", "prefer-const": "error", "eqeqeq": "error", "no-debugger": "error",
+    "typescript/no-explicit-any": "error", "typescript/no-non-null-assertion": "error", "import/no-cycle": "error"
   },
   "overrides": [
     { "files": ["**/*.test.ts","**/*.test.tsx","**/*.spec.ts","**/*.spec.tsx","**/__tests__/**"], "rules": { "complexity":"off","max-lines":"off","max-lines-per-function":"off","max-depth":"off","max-nested-callbacks":"off","typescript/no-explicit-any":"off","typescript/no-non-null-assertion":"off" } },

--- a/bin/vibecodereview.mjs
+++ b/bin/vibecodereview.mjs
@@ -97,48 +97,59 @@ function review() {
   console.log("\n" + fs.readFileSync(out, "utf8"));
 }
 
-function reviewPrs() {
-  const post = process.argv.includes("--post");
+let prSeq = 0;
+
+function parseRepoArgs(argv) {
   const repos = [];
-  const argv = process.argv.slice(3);
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--repo" && argv[i + 1]) repos.push(argv[++i]);
     else if (!argv[i].startsWith("--")) repos.push(argv[i]);
   }
+  return repos;
+}
+
+function reviewOnePr(repo, number, post) {
+  const diff = sh("gh", ["pr", "diff", String(number), "--repo", repo]);
+  const seq = prSeq++;
+  const tmp = path.join(os.tmpdir(), `vibecodereview-${process.pid}-${seq}.diff`);
+  const out = path.join(os.tmpdir(), `vibecodereview-${process.pid}-${seq}.md`);
+  fs.writeFileSync(tmp, diff);
+  sh("node", [path.join(ROOT, "scripts", "council-review.mjs"), tmp, out], { stdio: ["ignore", "inherit", "inherit"] });
+  console.log(`\n=== ${repo}#${number} ===\n`);
+  console.log(fs.readFileSync(out, "utf8"));
+  if (post) sh("gh", ["pr", "comment", String(number), "--repo", repo, "--body-file", out]);
+}
+
+function reviewRepoPrs(repo, post, counts) {
+  let prs;
+  try {
+    prs = JSON.parse(sh("gh", ["pr", "list", "--repo", repo, "--state", "open", "--json", "number"]));
+  } catch (err) {
+    counts.errors++;
+    console.error(`${repo}: failed to list PRs: ${err?.message || err}`);
+    return;
+  }
+  for (const { number } of prs) {
+    try {
+      reviewOnePr(repo, number, post);
+      counts.reviewed++;
+    } catch (err) {
+      counts.errors++;
+      console.error(`${repo}#${number}: ${err?.message || err}`);
+    }
+  }
+}
+
+function reviewPrs() {
+  const post = process.argv.includes("--post");
+  const repos = parseRepoArgs(process.argv.slice(3));
   if (repos.length === 0) {
     console.log("Usage: vibecodereview review-prs [--post] [--repo <owner/repo>]... [<owner/repo>...]");
     return;
   }
-  let reviewed = 0,
-    errors = 0,
-    seq = 0;
-  for (const repo of repos) {
-    let prs;
-    try {
-      prs = JSON.parse(sh("gh", ["pr", "list", "--repo", repo, "--state", "open", "--json", "number"]));
-    } catch (err) {
-      errors++;
-      console.error(`${repo}: failed to list PRs: ${err?.message || err}`);
-      continue;
-    }
-    for (const { number } of prs) {
-      try {
-        const diff = sh("gh", ["pr", "diff", String(number), "--repo", repo]);
-        const tmp = path.join(os.tmpdir(), `vibecodereview-${process.pid}-${seq}.diff`);
-        const out = path.join(os.tmpdir(), `vibecodereview-${process.pid}-${seq}.md`);
-        seq++;
-        fs.writeFileSync(tmp, diff);
-        sh("node", [path.join(ROOT, "scripts", "council-review.mjs"), tmp, out], { stdio: ["ignore", "inherit", "inherit"] });
-        console.log(`\n=== ${repo}#${number} ===\n`);
-        console.log(fs.readFileSync(out, "utf8"));
-        if (post) sh("gh", ["pr", "comment", String(number), "--repo", repo, "--body-file", out]);
-        reviewed++;
-      } catch (err) {
-        errors++;
-        console.error(`${repo}#${number}: ${err?.message || err}`);
-      }
-    }
-  }
+  const counts = { reviewed: 0, errors: 0 };
+  for (const repo of repos) reviewRepoPrs(repo, post, counts);
+  const { reviewed, errors } = counts;
   console.log(`\nDone: ${repos.length} repo(s), ${reviewed} PR(s) reviewed, ${errors} error(s).`);
 }
 

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -45,26 +45,32 @@ function runCouncil(diff) {
   return fs.readFileSync(out, "utf8");
 }
 
-function handle(msg) {
-  const { id, method, params } = msg;
-  if (method === "initialize") {
-    return reply(id, {
+function callTool(id, params) {
+  if (params?.name !== "council_review") return fail(id, -32601, `Unknown tool: ${params?.name}`);
+  try {
+    const text = runCouncil(params?.arguments?.diff);
+    return reply(id, { content: [{ type: "text", text }] });
+  } catch (err) {
+    return reply(id, { content: [{ type: "text", text: `Council error: ${err?.message || err}` }], isError: true });
+  }
+}
+
+const METHODS = {
+  initialize: (id) =>
+    reply(id, {
       protocolVersion: "2024-11-05",
       capabilities: { tools: {} },
       serverInfo: { name: "vibecodereview", version: "0.1.0" },
-    });
-  }
+    }),
+  "tools/list": (id) => reply(id, { tools: [TOOL] }),
+  "tools/call": callTool,
+};
+
+function handle(msg) {
+  const { id, method, params } = msg;
   if (method === "notifications/initialized" || method?.startsWith("notifications/")) return;
-  if (method === "tools/list") return reply(id, { tools: [TOOL] });
-  if (method === "tools/call") {
-    if (params?.name !== "council_review") return fail(id, -32601, `Unknown tool: ${params?.name}`);
-    try {
-      const text = runCouncil(params?.arguments?.diff);
-      return reply(id, { content: [{ type: "text", text }] });
-    } catch (err) {
-      return reply(id, { content: [{ type: "text", text: `Council error: ${err?.message || err}` }], isError: true });
-    }
-  }
+  const fn = Object.hasOwn(METHODS, method) ? METHODS[method] : undefined;
+  if (fn) return fn(id, params);
   if (id !== undefined) fail(id, -32601, `Unknown method: ${method}`);
 }
 


### PR DESCRIPTION
Follow-up to #21 (merged). Replaces #22, which GitHub auto-closed when #21's branch was deleted.

## What

Takes `complexity` to zero and promotes **every** budget rule in `.oxlintrc.json` from
`warn` to `error`. With #21 this repo is fully enforced.

| Rule | Before (repo) | After |
|---|---|---|
| `complexity` | 4 | **0** |
| `max-lines-per-function` | 2 | **0** (done in #21) |
| `max-lines`, `max-params`, `max-depth`, `max-nested-callbacks` | 0 | 0 |

`bunx oxlint@^1 --config .oxlintrc.json .` exits **0** with all 13 rules at `error`.
`categories` stay at `warn`, matching the rest of the fleet.

## How each was fixed

Restructuring only. No cap raised, no rule disabled or downgraded, no ignore glob
widened, no `oxlint-disable` comment.

**`mcp/server.mjs` — `handle`, complexity 16.** It was a JSON-RPC `if (method === …)`
chain that also inlined the whole `tools/call` body. Now: a module-level `METHODS`
dispatch table, plus a `callTool` helper holding the `tools/call` work.

Two things deliberately kept rather than tidied:

- The table lookup is guarded — `const fn = Object.hasOwn(METHODS, method) ? METHODS[method] : undefined`.
  A bare `METHODS[method]` would return `Object.prototype.constructor` for
  `{"method":"constructor"}`, which is truthy and would then be *called*. The old
  `if`-chain fell through to the unknown-method error, and so does this.
- The `notifications/` early return is byte-identical, including the redundant
  `method === "notifications/initialized"` comparison. A non-string `method` currently
  makes `method?.startsWith` throw, and the caller turns that into
  `parse error: method?.startsWith is not a function` on stderr. Adding a
  `typeof method === "string"` guard would have silently changed that.

**`bin/vibecodereview.mjs` — `reviewPrs`, complexity 15.** Split into `parseRepoArgs`,
`reviewOnePr`, and `reviewRepoPrs`; the `reviewed`/`errors` tallies move into a shared
`counts` object.

The temp-file sequence number needed care: it is one counter shared across all repos, and
it is only consumed *after* `gh pr diff` succeeds, so a failed diff does not burn a
number. It is now a module-level `prSeq`, still incremented only after the diff call, so
`vibecodereview-<pid>-<seq>.diff` / `.md` names are unchanged.

## How I verified behaviour is unchanged

`handle` and `reviewPrs` keep their names and signatures. I captured stdout + stderr +
exit code on `main` and on this branch and diffed. **Every probe is byte-identical.**

- **MCP server, 13 JSON-RPC lines over stdio** — `initialize`; two `notifications/*`;
  `tools/list`; `tools/call` with a wrong name, with no name, with a diff, with no
  arguments; unknown method with an id and without one; `"method": 5`; malformed JSON.
  Both `parse error:` lines reproduce exactly, including the TypeError one.
- **Prototype-key methods** — `constructor`, `toString`, `__proto__`, `hasOwnProperty`
  all still return `Unknown method: …` and are never dispatched.
- **`review-prs`, 8 invocations** against a stubbed `gh` — no args; `--repo`; positional;
  a repo whose `gh pr list` fails; a repo with no open PRs; `--post`; mixed
  `--repo`/positional; a dangling `--repo`. The `Done: N repo(s), N PR(s) reviewed,
  N error(s).` tallies and both error strings match.
- **`rollout.mjs`, 5 invocations** (from #21) — still identical.

Also: `node --check` on every `.mjs` in `bin/`, `mcp/`, `scripts/`, and
`npm run selfcheck` → `selfcheck ok`. The repo has no test suite beyond `selfcheck`.

## Note for the reviewer

The `review` check fails for a reason unrelated to these PRs, and it has failed on
every branch in this repo since 05:36 UTC today (three other branches hit it first). Two
separate causes, both environmental:

1. `No provider keys — council skipped.` — this repo has no `OPENAI_API_KEY`,
   `GEMINI_API_KEY`, `MOONSHOT_API_KEY` or `OPENROUTER_API_KEY` secret set, so the
   council fan-out produces nothing.
2. The chair fails on **both** Claude tokens in ~330 ms with `total_cost_usd: 0` and
   `modelUsage: {}` — an instant rejection, i.e. the subscriptions, not the prompt.

The good news is the check fails **loudly**: `chair review failed (primary=failure,
backup=failure, third=skipped)`. It does not report a degraded review as a pass.
