### PR TITLE
Route a keyless council member through OpenRouter too

### DIFF
--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -172,7 +172,28 @@ async function callModel(model, diff) {
 // One retry, on a different route, only for a credential/quota failure. A
 // member already on OpenRouter has nowhere to fall back to, and a genuine model
 // error must NOT be retried — that would double the cost of every real failure.
+function hasNativeKey(model) {
+  const keyEnv = PROVIDERS[model.provider]?.keyEnv;
+  return Boolean(keyEnv && process.env[keyEnv]?.trim());
+}
+
 async function callModelWithFallback(model, diff) {
+  // An ABSENT native key leaves the member in exactly the position a REJECTED
+  // one does: it cannot serve its lens. Only the rejected case used to reroute,
+  // so a repo that simply never set MOONSHOT_API_KEY silently lost the security
+  // lens while a repo with a suspended Moonshot account kept it. Route both the
+  // same way — and skip the pointless round trip, since a call with no key
+  // cannot succeed.
+  if (!hasNativeKey(model)) {
+    const route = openRouterFallbackFor(model);
+    if (!route) return callModel(model, diff); // no OpenRouter route: keep the skip note
+    console.log(`- ${model.name}: no ${PROVIDERS[model.provider]?.keyEnv}; routing via openrouter`);
+    const only = await callModel(route, diff);
+    if (only.error) {
+      return { ...only, error: `${PROVIDERS[model.provider]?.keyEnv} not set, openrouter: ${only.error}` };
+    }
+    return { ...only, model: { ...route, name: `${model.name} (via OpenRouter)` } };
+  }
   const first = await callModel(model, diff);
   if (!first.error || !CREDENTIAL_FAILURE_STATUSES.includes(first.status)) return first;
   const fallback = openRouterFallbackFor(model);
@@ -256,8 +277,12 @@ async function main() {
     console.log("No valid council members — skipped.");
     return;
   }
-  const withKey = models.filter((m) => process.env[PROVIDERS[m.provider]?.keyEnv]?.trim());
-  if (withKey.length === 0) {
+  // A member is servable if its own key is set OR it can be routed through
+  // OpenRouter. Counting only native keys skipped the whole council on a repo
+  // that had nothing but OPENROUTER_API_KEY, even though every lens was
+  // reachable through it.
+  const servable = models.filter((m) => hasNativeKey(m) || openRouterFallbackFor(m));
+  if (servable.length === 0) {
     const missing = models.map((m) => PROVIDERS[m.provider]?.keyEnv).join(", ");
     write(`# 🧑‍⚖️ LLM Council findings\n\n_Council skipped: no provider keys set (${missing})._\n`);
     console.log("No provider keys — council skipped.");


### PR DESCRIPTION
A member whose native key is **rejected** (401/402/403/429) already retries through OpenRouter. A member whose native key is **absent** did not — it was skipped and its lens disappeared from the review.

That asymmetry is invisible in an audit: a missing secret reads as an absence, and the check still goes green with fewer reviewers. Five pooriaarab repos were reviewing with no security lens purely because they had never been given `MOONSHOT_API_KEY`.

Also fixes the pre-flight guard, which counted only native keys and skipped the whole council on a repo holding nothing but `OPENROUTER_API_KEY`.

Net effect: a repo now needs **only** `OPENROUTER_API_KEY` to run all four lenses. Native keys still take precedence when present.

Verified locally with every native key unset:
```
- GPT-5.6 (Codex): no OPENAI_API_KEY; routing via openrouter
- Kimi K3: no MOONSHOT_API_KEY; routing via openrouter
- GPT-5.6 (Codex) (via OpenRouter) (3.4s): ok
- Kimi K3 (via OpenRouter) (13.7s): ok
- Grok 4.5 (8.7s): ok
```
Both the correctness and maintainability lenses caught a planted off-by-one.