### PR TITLE
Fall back to an OpenRouter chair when every Claude token fails

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
   openrouter_api_key:
     description: "OpenRouter key — Grok/DeepSeek member (maintainability lens). Omit to drop it."
     required: false
+  chair_fallback_model:
+    description: "Model for the OpenRouter fallback chair, used only when every Claude OAuth token fails. Defaults to anthropic/claude-sonnet-5 — the same model the primary chair runs — so the fallback review reads like the real one. Set empty-string behaviour by omitting; omit openrouter_api_key to disable the fallback entirely."
+    required: false
+    default: "anthropic/claude-sonnet-5"
   council_models:
     description: "Optional CSV override: provider|model|Name|lens,... (providers: openai, gemini, moonshot, openrouter)."
     required: false
@@ -278,13 +282,36 @@ runs:
     # failed. Without this, continue-on-error would mask a genuine failure as
     # success. A chair that dies in ~0.5s at $0 cost with one turn is a dead
     # token, not a bad review — check the subscription before the prompt.
+    # Last resort. Every Claude token has failed, so the choice is between a
+    # weaker review and none at all. On 2026-08-27 both subscriptions capped out
+    # at once and the whole fleet lost its review for days — a Claude-only chair
+    # makes one vendor's quota a single point of failure for every repo.
+    - name: Chair fallback (OpenRouter)
+      id: chair_fallback
+      if: >-
+        steps.chair_primary.outcome == 'failure' &&
+        steps.chair_backup.outcome != 'success' &&
+        steps.chair_third.outcome != 'success' &&
+        inputs.openrouter_api_key != ''
+      continue-on-error: true
+      shell: bash
+      env:
+        OPENROUTER_API_KEY: ${{ inputs.openrouter_api_key }}
+        GH_TOKEN: ${{ inputs.github_token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        CHAIR_FALLBACK_MODEL: ${{ inputs.chair_fallback_model }}
+      run: node "${{ github.action_path }}/scripts/chair-fallback.mjs" pr.diff council-findings.md
+
     - name: Chair result gate
       shell: bash
       run: |
         P="${{ steps.chair_primary.outcome }}"
         B="${{ steps.chair_backup.outcome }}"
         T="${{ steps.chair_third.outcome }}"
+        F="${{ steps.chair_fallback.outcome }}"
         if [ "$P" = "success" ]; then echo "chair: primary token succeeded"; exit 0; fi
         if [ "$B" = "success" ]; then echo "chair: primary failed ($P); backup token succeeded"; exit 0; fi
         if [ "$T" = "success" ]; then echo "chair: primary and backup failed; third token succeeded"; exit 0; fi
-        echo "chair review failed (primary=$P, backup=${B:-skipped}, third=${T:-skipped})"; exit 1
+        if [ "$F" = "success" ]; then echo "chair: all Claude tokens failed; OpenRouter fallback posted the review"; exit 0; fi
+        echo "chair review failed (primary=$P, backup=${B:-skipped}, third=${T:-skipped}, fallback=${F:-skipped})"; exit 1

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -108,7 +108,8 @@ function normalizeFindings(parsed) {
   if (bad.length) throw new Error(`chair reply had ${bad.length} finding(s) that were not objects`);
   // Severity is matched with === below, so "major" would slip past the gate
   // and let a substantive finding fall through to the model's own verdict.
-  return raw.map((f) => ({ ...f, severity: SEVERITIES[String(f.severity).toLowerCase()] ?? "Minor" }));
+  for (const f of raw) f.severity = SEVERITIES[String(f.severity).toLowerCase()] ?? "Minor";
+  return raw;
 }
 
 // The model's `verdict` field is advisory; the findings are the evidence. It

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+// Fallback chair. Runs ONLY when every Claude OAuth token has failed.
+//
+// The primary chair is anthropics/claude-code-action, which can read the repo,
+// push fixes, and post inline comments. This one cannot: it is a single
+// completion call through OpenRouter with no tools. It sees the diff and the
+// council's findings, and it posts ONE summary review. That is deliberately
+// less than the real chair — the point is that a subscription outage degrades
+// the review instead of deleting it.
+//
+// Usage: node chair-fallback.mjs <diff-file> <council-findings-file>
+// Env: OPENROUTER_API_KEY, GH_TOKEN, GITHUB_REPOSITORY, PR_NUMBER,
+//      CHAIR_FALLBACK_MODEL (default anthropic/claude-sonnet-5)
+
+import fs from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const MAX_DIFF_CHARS = 180_000;
+const TIMEOUT_MS = Number(process.env.CHAIR_FALLBACK_TIMEOUT_MS) || 180_000;
+const MODEL = process.env.CHAIR_FALLBACK_MODEL || "anthropic/claude-sonnet-5";
+
+const SYSTEM = `You chair a multi-model code review council. You receive a pull request diff and
+the council's per-lens findings. Produce ONE review.
+
+You have NO tools: you cannot open files beyond the diff, run anything, or push
+fixes. Judge only what the diff shows. When a council claim depends on code the
+diff does not include, say so and drop it rather than guessing.
+
+Rules:
+- Each council item is an UNVERIFIED claim. De-dupe them (the same issue from
+  several lenses is one issue). Discard a claim if a linter or type-checker
+  already covers it, the path is unreachable, it is style or naming, it is
+  pre-existing code this diff did not touch, or it names no concrete failure
+  trigger.
+- Assume the author is competent. Report only diff-introduced defects that have
+  a concrete failure trigger.
+- Severity: Critical (security, crash, data loss), Major (real bug or
+  convention violation), Minor (everything else).
+
+Reply with STRICT JSON and nothing else:
+{"verdict":"approve"|"request_changes"|"comment","summary":"<markdown>","findings":[{"severity":"Critical"|"Major"|"Minor","file":"<path>","line":<number|null>,"body":"<markdown>"}]}
+
+Use "request_changes" only when at least one finding is Critical. Use "approve"
+when nothing Critical or Major survives. Otherwise "comment".`;
+
+function truncate(s, n) {
+  return s.length > n ? s.slice(0, n) : s;
+}
+
+async function askChair(diff, council) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+      method: "POST",
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}`,
+        "Content-Type": "application/json",
+        "X-Title": "vibecodereview chair fallback",
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        response_format: { type: "json_object" },
+        messages: [
+          { role: "system", content: SYSTEM },
+          { role: "user", content: `PR diff:\n\n${diff}\n\n---\n\nCouncil findings:\n\n${council}` },
+        ],
+      }),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}: ${truncate(await res.text().catch(() => ""), 300)}`);
+    const json = await res.json();
+    const text = json?.choices?.[0]?.message?.content?.trim();
+    if (!text) throw new Error("empty response");
+    return text;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// A model told to emit JSON still sometimes wraps it in a fence or prose. Take
+// the outermost braces rather than failing the whole review on formatting.
+function parseVerdict(text) {
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end <= start) throw new Error(`no JSON object in chair reply: ${truncate(text, 200)}`);
+  return JSON.parse(text.slice(start, end + 1));
+}
+
+function renderBody(parsed) {
+  const findings = Array.isArray(parsed.findings) ? parsed.findings : [];
+  const order = { Critical: 0, Major: 1, Minor: 2 };
+  const sorted = findings.toSorted((a, b) => (order[a.severity] ?? 3) - (order[b.severity] ?? 3));
+  const icon = { Critical: "🔴", Major: "🟠", Minor: "🟡" };
+  const lines = [
+    "## 🧑‍⚖️ Council review",
+    "",
+    "> ⚠️ Posted by the **fallback chair**: every Claude subscription token failed, so this",
+    "> review came from a single OpenRouter completion with no repo access. It saw the diff",
+    "> and the council's findings only — it could not open other files, run anything, or push",
+    "> fixes. Treat it as weaker than a normal review.",
+    "",
+    parsed.summary || "_No summary._",
+    "",
+  ];
+  if (sorted.length) {
+    lines.push("### Findings", "");
+    for (const f of sorted) {
+      const where = f.file ? `\`${f.file}${f.line ? `:${f.line}` : ""}\`` : "";
+      lines.push(`- ${icon[f.severity] || "⚪"} **${f.severity}** ${where} — ${f.body}`);
+    }
+    lines.push("");
+  }
+  lines.push(`<sub>Fallback chair: \`${MODEL}\` via OpenRouter.</sub>`);
+  return lines.join("\n");
+}
+
+async function main() {
+  const [diffFile, councilFile] = process.argv.slice(2);
+  const repo = process.env.GITHUB_REPOSITORY;
+  const pr = process.env.PR_NUMBER;
+  if (!process.env.OPENROUTER_API_KEY?.trim()) throw new Error("OPENROUTER_API_KEY not set");
+  if (!repo || !pr) throw new Error("GITHUB_REPOSITORY and PR_NUMBER are required");
+
+  const diff = diffFile && fs.existsSync(diffFile) ? fs.readFileSync(diffFile, "utf8") : "";
+  if (!diff.trim()) throw new Error("empty diff");
+  const council =
+    councilFile && fs.existsSync(councilFile) ? fs.readFileSync(councilFile, "utf8") : "_No council findings._";
+
+  const parsed = parseVerdict(await askChair(truncate(diff, MAX_DIFF_CHARS), council));
+  const body = renderBody(parsed);
+
+  // Never request changes without a Critical finding, and never approve while a
+  // Critical is on the table — the model's own verdict field is advisory, the
+  // findings are the evidence.
+  const hasCritical = (parsed.findings || []).some((f) => f.severity === "Critical");
+  let flag = "--comment";
+  if (hasCritical) flag = "--request-changes";
+  else if (parsed.verdict === "approve") flag = "--approve";
+
+  fs.writeFileSync("chair-fallback-review.md", body);
+  execFileSync("gh", ["pr", "review", String(pr), "--repo", repo, flag, "--body-file", "chair-fallback-review.md"], {
+    stdio: "inherit",
+  });
+  console.log(`fallback chair posted ${flag} (${(parsed.findings || []).length} findings, model ${MODEL})`);
+}
+
+main().catch((err) => {
+  console.error("Fallback chair failed:", err?.message || err);
+  process.exit(1);
+});

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -108,7 +108,15 @@ function normalizeFindings(parsed) {
   if (bad.length) throw new Error(`chair reply had ${bad.length} finding(s) that were not objects`);
   // Severity is matched with === below, so "major" would slip past the gate
   // and let a substantive finding fall through to the model's own verdict.
-  for (const f of raw) f.severity = SEVERITIES[String(f.severity).toLowerCase()] ?? "Minor";
+  // Silently mapping an unrecognized severity to "Minor" would let "Critical "
+  // (stray whitespace) or "blocker" score as nothing and clear the way for an
+  // approve. Every downgrade path in this file is a way to lose a real finding,
+  // so trim, then refuse what we do not recognize.
+  for (const f of raw) {
+    const severity = SEVERITIES[String(f.severity).trim().toLowerCase()];
+    if (!severity) throw new Error(`chair reply used an unrecognized severity: ${JSON.stringify(f.severity)}`);
+    f.severity = severity;
+  }
   return raw;
 }
 

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -95,8 +95,15 @@ function parseVerdict(text) {
 // One normalization, used by both the rendered body and the verdict. Two
 // call sites normalizing differently is how a parseable reply still throws.
 function normalizeFindings(parsed) {
-  if (!Array.isArray(parsed?.findings)) return [];
-  return parsed.findings.filter((f) => f && typeof f === "object");
+  const raw = parsed?.findings;
+  if (raw === undefined || raw === null) return [];
+  // Coercing a malformed shape to [] would silently discard a Critical or
+  // Major and let verdictFlag fall through to the model's claimed verdict —
+  // exactly the "never approve over a Major" guarantee this file exists to
+  // keep. json_object mode guarantees valid JSON, not the instructed schema,
+  // so treat a wrong shape as a hard failure rather than an empty review.
+  if (!Array.isArray(raw)) throw new Error("chair reply had a malformed `findings` field (expected an array)");
+  return raw.filter((f) => f && typeof f === "object");
 }
 
 // The model's `verdict` field is advisory; the findings are the evidence. It

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -184,13 +184,19 @@ async function main() {
     post(flag);
     console.log(`fallback chair posted ${flag} (${findings.length} findings, model ${MODEL})`);
   } catch (err) {
-    // A repo with "Allow GitHub Actions to create and approve pull requests"
-    // off cannot --approve. Losing the whole review over the CLEANEST outcome
-    // is the worst possible failure for a path that exists to rescue a broken
-    // chair, so degrade to a comment and still deliver the review.
     if (flag === "--comment") throw err;
+    // A repo with "Allow GitHub Actions to create and approve pull requests"
+    // off cannot --approve or --request-changes. Post the findings as a plain
+    // comment either way, so the review is never lost to a permission setting.
     console.log(`${flag} failed (${err?.message || err}); posting as a comment instead`);
     post("--comment");
+    // But a downgraded --request-changes must NOT read as a pass: the verdict
+    // said Critical, and a green check would silently drop the block.
+    if (flag === "--request-changes") {
+      throw new Error("posted the review as a comment, but could not request changes on a Critical finding", {
+        cause: err,
+      });
+    }
     console.log(`fallback chair posted --comment (${findings.length} findings, model ${MODEL})`);
   }
 }

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -152,6 +152,13 @@ async function main() {
   const truncated = diff.length > MAX_DIFF_CHARS;
   const parsed = parseVerdict(await askChair(truncate(diff, MAX_DIFF_CHARS), council, truncated));
   const findings = normalizeFindings(parsed);
+  // A syntactically-valid but empty reply ({}) would otherwise post "_No
+  // summary._" with no findings and still report the step as a success —
+  // a hollow review that looks like a real one. Fail loudly instead, so the
+  // gate reports the fallback as failed and the red check means something.
+  if (!parsed.summary?.trim() && findings.length === 0) {
+    throw new Error("chair reply had neither a summary nor any findings");
+  }
   const body = renderBody(parsed, findings, { truncated });
   const flag = verdictFlag(findings, parsed.verdict);
 

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -47,7 +47,7 @@ function truncate(s, n) {
   return s.length > n ? s.slice(0, n) : s;
 }
 
-async function askChair(diff, council) {
+async function askChair(diff, council, truncated) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
@@ -64,7 +64,12 @@ async function askChair(diff, council) {
         response_format: { type: "json_object" },
         messages: [
           { role: "system", content: SYSTEM },
-          { role: "user", content: `PR diff:\n\n${diff}\n\n---\n\nCouncil findings:\n\n${council}` },
+          {
+            role: "user",
+            content:
+              (truncated ? "NOTE: this diff was truncated for length. Judge only what you can see.\n\n" : "") +
+              `PR diff:\n\n${diff}\n\n---\n\nCouncil findings:\n\n${council}`,
+          },
         ],
       }),
     });
@@ -87,8 +92,22 @@ function parseVerdict(text) {
   return JSON.parse(text.slice(start, end + 1));
 }
 
-function renderBody(parsed) {
-  const findings = Array.isArray(parsed.findings) ? parsed.findings : [];
+// One normalization, used by both the rendered body and the verdict. Two
+// call sites normalizing differently is how a parseable reply still throws.
+function normalizeFindings(parsed) {
+  if (!Array.isArray(parsed?.findings)) return [];
+  return parsed.findings.filter((f) => f && typeof f === "object");
+}
+
+// The model's `verdict` field is advisory; the findings are the evidence. It
+// must never approve over a Major, which its own instructions forbid.
+function verdictFlag(findings, claimed) {
+  if (findings.some((f) => f.severity === "Critical")) return "--request-changes";
+  if (findings.some((f) => f.severity === "Major")) return "--comment";
+  return claimed === "approve" ? "--approve" : "--comment";
+}
+
+function renderBody(parsed, findings, { truncated } = {}) {
   const order = { Critical: 0, Major: 1, Minor: 2 };
   const sorted = findings.toSorted((a, b) => (order[a.severity] ?? 3) - (order[b.severity] ?? 3));
   const icon = { Critical: "🔴", Major: "🟠", Minor: "🟡" };
@@ -103,6 +122,9 @@ function renderBody(parsed) {
     parsed.summary || "_No summary._",
     "",
   ];
+  if (truncated) {
+    lines.push("> ⚠️ The diff was truncated for length; this review covers the first portion only.", "");
+  }
   if (sorted.length) {
     lines.push("### Findings", "");
     for (const f of sorted) {
@@ -127,22 +149,17 @@ async function main() {
   const council =
     councilFile && fs.existsSync(councilFile) ? fs.readFileSync(councilFile, "utf8") : "_No council findings._";
 
-  const parsed = parseVerdict(await askChair(truncate(diff, MAX_DIFF_CHARS), council));
-  const body = renderBody(parsed);
-
-  // Never request changes without a Critical finding, and never approve while a
-  // Critical is on the table — the model's own verdict field is advisory, the
-  // findings are the evidence.
-  const hasCritical = (parsed.findings || []).some((f) => f.severity === "Critical");
-  let flag = "--comment";
-  if (hasCritical) flag = "--request-changes";
-  else if (parsed.verdict === "approve") flag = "--approve";
+  const truncated = diff.length > MAX_DIFF_CHARS;
+  const parsed = parseVerdict(await askChair(truncate(diff, MAX_DIFF_CHARS), council, truncated));
+  const findings = normalizeFindings(parsed);
+  const body = renderBody(parsed, findings, { truncated });
+  const flag = verdictFlag(findings, parsed.verdict);
 
   fs.writeFileSync("chair-fallback-review.md", body);
   execFileSync("gh", ["pr", "review", String(pr), "--repo", repo, flag, "--body-file", "chair-fallback-review.md"], {
     stdio: "inherit",
   });
-  console.log(`fallback chair posted ${flag} (${(parsed.findings || []).length} findings, model ${MODEL})`);
+  console.log(`fallback chair posted ${flag} (${findings.length} findings, model ${MODEL})`);
 }
 
 main().catch((err) => {

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -18,6 +18,7 @@ import { execFileSync } from "node:child_process";
 const MAX_DIFF_CHARS = 180_000;
 const TIMEOUT_MS = Number(process.env.CHAIR_FALLBACK_TIMEOUT_MS) || 180_000;
 const MODEL = process.env.CHAIR_FALLBACK_MODEL || "anthropic/claude-sonnet-5";
+const SEVERITIES = { critical: "Critical", major: "Major", minor: "Minor" };
 
 const SYSTEM = `You chair a multi-model code review council. You receive a pull request diff and
 the council's per-lens findings. Produce ONE review.
@@ -103,7 +104,11 @@ function normalizeFindings(parsed) {
   // keep. json_object mode guarantees valid JSON, not the instructed schema,
   // so treat a wrong shape as a hard failure rather than an empty review.
   if (!Array.isArray(raw)) throw new Error("chair reply had a malformed `findings` field (expected an array)");
-  return raw.filter((f) => f && typeof f === "object");
+  const bad = raw.filter((f) => !f || typeof f !== "object");
+  if (bad.length) throw new Error(`chair reply had ${bad.length} finding(s) that were not objects`);
+  // Severity is matched with === below, so "major" would slip past the gate
+  // and let a substantive finding fall through to the model's own verdict.
+  return raw.map((f) => ({ ...f, severity: SEVERITIES[String(f.severity).toLowerCase()] ?? "Minor" }));
 }
 
 // The model's `verdict` field is advisory; the findings are the evidence. It
@@ -170,10 +175,23 @@ async function main() {
   const flag = verdictFlag(findings, parsed.verdict);
 
   fs.writeFileSync("chair-fallback-review.md", body);
-  execFileSync("gh", ["pr", "review", String(pr), "--repo", repo, flag, "--body-file", "chair-fallback-review.md"], {
-    stdio: "inherit",
-  });
-  console.log(`fallback chair posted ${flag} (${findings.length} findings, model ${MODEL})`);
+  const post = (f) =>
+    execFileSync("gh", ["pr", "review", String(pr), "--repo", repo, f, "--body-file", "chair-fallback-review.md"], {
+      stdio: "inherit",
+    });
+  try {
+    post(flag);
+    console.log(`fallback chair posted ${flag} (${findings.length} findings, model ${MODEL})`);
+  } catch (err) {
+    // A repo with "Allow GitHub Actions to create and approve pull requests"
+    // off cannot --approve. Losing the whole review over the CLEANEST outcome
+    // is the worst possible failure for a path that exists to rescue a broken
+    // chair, so degrade to a comment and still deliver the review.
+    if (flag === "--comment") throw err;
+    console.log(`${flag} failed (${err?.message || err}); posting as a comment instead`);
+    post("--comment");
+    console.log(`fallback chair posted --comment (${findings.length} findings, model ${MODEL})`);
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
The chair is Claude-only, so one vendor's quota is a single point of failure for every repo running this action. On 2026-08-27 both subscriptions capped out together and the whole fleet lost its review for days — the council still ran and wrote findings, but nothing posted them.

This adds a last-resort chair that runs **only** after every OAuth token has failed. It is one OpenRouter completion with no tools, so it is genuinely weaker than the real chair: it reads the diff and `council-findings.md`, and posts one summary review. The posted body states that plainly.

- Defaults to `anthropic/claude-sonnet-5` — the same model the primary chair runs.
- Omit `openrouter_api_key` to disable it entirely.
- `--request-changes` still needs a Critical finding; a Critical blocks `--approve` regardless of the model's own verdict field.

Verified against a planted off-by-one: caught it with a concrete failure trigger, and correctly discarded a council member's style nitpick.