### PR TITLE
Cancel superseded oxlint runs on a PR push

### DIFF
--- a/.github/workflows/oxlint.yml
+++ b/.github/workflows/oxlint.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   push:
     branches: [main]
+concurrency:
+  group: oxlint-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   oxlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `oxlint.yml` had no `concurrency` block, so every push to an open PR
  queued a full new run instead of cancelling the stale one that was
  already superseded.
- Evidence: across the last 19 pull_request-triggered oxlint runs
  (7 branches), `feat/openrouter-chair-fallback` alone got 8 separate
  runs from rapid pushes, none cancelled — two of them (33151194999,
  33151209311) started only 14s apart and overlapped in wall clock.
- Fix: add a `concurrency` group keyed on PR number, with
  `cancel-in-progress` gated to `pull_request` events only — same
  pattern `vibecodereview.yml` already uses. A push to `main` gets its
  own `run_id`-scoped group so it always runs to completion.

## What I checked (no other defects found)
- `action.yml`'s `continue-on-error` steps are a deliberate,
  already-gated chair-failover chain (primary → backup → third token →
  OpenRouter fallback), with an explicit "Chair result gate" step that
  surfaces the true pass/fail — not a masked non-gating job.
- No `actions/cache` usage anywhere, so cache-key/restore-keys defects
  don't apply.
- No `turbo.json` / build-output globs to sweep a cache dir into.
- `oxlint` has no `--cache` flag (checked `--help`); its own step ran
  in ~1s in recent runs, so there's nothing to cache.
- No memory/worker-count mitigations anywhere (grepped for
  `max-old-space-size`, `NODE_OPTIONS`, swap, worker caps).
- All three workflows run on `ubuntu-latest`; the repo's default
  branch is `main`, matching every `branches:` filter.
- No parallelizable-but-serial steps: `npm-publish.yml`'s
  selfcheck→publish is a real dependency, and `action.yml`'s steps are
  already reordered so the council fan-out overlaps with CLI install
  (per its own comments).

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Watch `oxlint` + `vibecodereview` checks on this PR