### PR TITLE
Skip chair attempts whose token is already dead

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -222,6 +222,71 @@ runs:
           echo "VCR_OUT_EOF"
         } >> "$GITHUB_OUTPUT"
 
+
+    # Probe the chair tokens before paying for an attempt.
+    #
+    # A chair attempt costs ~12s of claude-code-action setup (Bun, dependencies,
+    # app-token mint and revoke) before the model is reached, and a dead token
+    # then fails in ~0.3s. Measured on 7 successful runs across 5 repos
+    # (2026-08-28): primary 12.6s median, backup 9.4s median, both dead, on a
+    # 52s median job. That is 22s -- 42% of the job -- spent on two attempts
+    # that could not succeed.
+    #
+    # The probe runs the SAME CLI the action runs, with the same token, so it is
+    # faithful by construction: a dead token returns the documented signature
+    # (is_error true, num_turns 1, total_cost_usd 0, empty modelUsage). The three
+    # probes run concurrently, so the cost is one probe (~1-4s), not three.
+    #
+    # It FAILS OPEN. Only that exact signature prunes an attempt. A timeout, a
+    # crash, a parse failure or any unexpected output leaves the attempt in
+    # place, because wrongly skipping a healthy chair would silently downgrade
+    # every review on the fleet -- a far worse outcome than a wasted 12s. A
+    # chair that genuinely ran and failed does not match either: it carries
+    # num_turns > 1 and a nonzero cost, so a real bad run is never pruned.
+    #
+    # Placement is deliberate. This sits between the council's start and its
+    # await, so the probe overlaps the council's background window (5.5s
+    # measured) instead of adding to the critical path.
+    - name: Probe chair tokens
+      id: chair_probe
+      shell: bash
+      env:
+        VCR_T1: ${{ inputs.claude_code_oauth_token }}
+        VCR_T2: ${{ inputs.claude_code_oauth_token_2 }}
+        VCR_T3: ${{ inputs.claude_code_oauth_token_3 }}
+      run: |
+        probe() {
+          slot="$1"; token="$2"
+          # An absent token is already handled by the `if:` on each attempt.
+          # Report it live so this step never becomes a second, divergent gate.
+          if [ -z "$token" ]; then echo "live" > "probe.$slot"; return; fi
+          # A dead token makes the CLI exit non-zero AND print the dead
+          # signature, so the exit code cannot gate the parse. Ignore it and
+          # judge the JSON alone; anything unparseable falls through to live.
+          out="$(CLAUDE_CODE_OAUTH_TOKEN="$token" ANTHROPIC_API_KEY= \
+                 timeout 60 claude -p ok \
+                   --max-turns 1 \
+                   --allowed-tools "" \
+                   --output-format json 2>/dev/null || true)"
+          if printf '%s' "$out" | jq -e \
+               '.is_error == true and .num_turns == 1 and .total_cost_usd == 0
+                and (.modelUsage | length) == 0' >/dev/null 2>&1; then
+            echo "dead" > "probe.$slot"
+          else
+            echo "live" > "probe.$slot"
+          fi
+        }
+        probe 1 "$VCR_T1" &
+        probe 2 "$VCR_T2" &
+        probe 3 "$VCR_T3" &
+        wait
+        for s in 1 2 3; do
+          v="$(cat "probe.$s" 2>/dev/null || echo live)"
+          [ "$v" = "dead" ] || v="live"
+          echo "token_${s}=$v" >> "$GITHUB_OUTPUT"
+          echo "chair token $s: $v"
+        done
+
     - name: Council fan-out (await)
       shell: bash
       continue-on-error: true
@@ -239,12 +304,12 @@ runs:
         fi
         cat council.log || true
         echo "----- council-findings.md -----"; cat council-findings.md || true
-
     # Failover chain: each attempt runs the SAME prompt (built once above) with
     # a different subscription. Every attempt costs ~10s of setup even when the
     # token is dead, so order them best-credit-first.
     - name: Chair review (primary token)
       id: chair_primary
+      if: steps.chair_probe.outputs.token_1 != 'dead'
       continue-on-error: true
       uses: anthropics/claude-code-action@v1
       with:
@@ -256,7 +321,7 @@ runs:
 
     - name: Chair review (backup token)
       id: chair_backup
-      if: steps.chair_primary.outcome == 'failure' && inputs.claude_code_oauth_token_2 != ''
+      if: steps.chair_primary.outcome != 'success' && steps.chair_probe.outputs.token_2 != 'dead' && inputs.claude_code_oauth_token_2 != ''
       continue-on-error: true
       uses: anthropics/claude-code-action@v1
       with:
@@ -268,7 +333,7 @@ runs:
 
     - name: Chair review (third token)
       id: chair_third
-      if: steps.chair_primary.outcome == 'failure' && steps.chair_backup.outcome == 'failure' && inputs.claude_code_oauth_token_3 != ''
+      if: steps.chair_primary.outcome != 'success' && steps.chair_backup.outcome != 'success' && steps.chair_probe.outputs.token_3 != 'dead' && inputs.claude_code_oauth_token_3 != ''
       continue-on-error: true
       uses: anthropics/claude-code-action@v1
       with:
@@ -289,7 +354,7 @@ runs:
     - name: Chair fallback (OpenRouter)
       id: chair_fallback
       if: >-
-        steps.chair_primary.outcome == 'failure' &&
+        steps.chair_primary.outcome != 'success' &&
         steps.chair_backup.outcome != 'success' &&
         steps.chair_third.outcome != 'success' &&
         inputs.openrouter_api_key != ''
@@ -311,7 +376,9 @@ runs:
         T="${{ steps.chair_third.outcome }}"
         F="${{ steps.chair_fallback.outcome }}"
         if [ "$P" = "success" ]; then echo "chair: primary token succeeded"; exit 0; fi
-        if [ "$B" = "success" ]; then echo "chair: primary failed ($P); backup token succeeded"; exit 0; fi
+        if [ "$B" = "success" ]; then echo "chair: primary did not review ($P); backup token succeeded"; exit 0; fi
         if [ "$T" = "success" ]; then echo "chair: primary and backup failed; third token succeeded"; exit 0; fi
         if [ "$F" = "success" ]; then echo "chair: all Claude tokens failed; OpenRouter fallback posted the review"; exit 0; fi
-        echo "chair review failed (primary=$P, backup=${B:-skipped}, third=${T:-skipped}, fallback=${F:-skipped})"; exit 1
+        echo "chair review failed (primary=$P, backup=${B:-skipped}, third=${T:-skipped}, fallback=${F:-skipped})"
+        echo "probe: token_1=${{ steps.chair_probe.outputs.token_1 }} token_2=${{ steps.chair_probe.outputs.token_2 }} token_3=${{ steps.chair_probe.outputs.token_3 }}"
+        exit 1

--- a/action.yml
+++ b/action.yml
@@ -270,7 +270,8 @@ runs:
                    --output-format json 2>/dev/null || true)"
           if printf '%s' "$out" | jq -e \
                '.is_error == true and .num_turns == 1 and .total_cost_usd == 0
-                and (.modelUsage | length) == 0' >/dev/null 2>&1; then
+                and (.modelUsage | type == "object" and length == 0)' \
+             >/dev/null 2>&1; then
             echo "dead" > "probe.$slot"
             # Say WHY. 401 means the token is revoked or stale and needs
             # re-minting with `claude setup-token`; 429 means the subscription

--- a/action.yml
+++ b/action.yml
@@ -272,6 +272,13 @@ runs:
                '.is_error == true and .num_turns == 1 and .total_cost_usd == 0
                 and (.modelUsage | length) == 0' >/dev/null 2>&1; then
             echo "dead" > "probe.$slot"
+            # Say WHY. 401 means the token is revoked or stale and needs
+            # re-minting with `claude setup-token`; 429 means the subscription
+            # is capped and only time fixes it. Both look identical in the
+            # result JSON otherwise, and the difference decides what to do.
+            printf '%s' "$out" \
+              | jq -r '"  reason: HTTP \(.api_error_status // "?") \(.result // "no detail")"' \
+                    2>/dev/null > "reason.$slot" || true
           else
             echo "live" > "probe.$slot"
           fi
@@ -285,6 +292,8 @@ runs:
           [ "$v" = "dead" ] || v="live"
           echo "token_${s}=$v" >> "$GITHUB_OUTPUT"
           echo "chair token $s: $v"
+          [ "$v" = "dead" ] && cat "reason.$s" 2>/dev/null
+          true
         done
 
     - name: Council fan-out (await)


### PR DESCRIPTION
## The finding this came from

**Every vibecodereview check on the fleet is currently green on a review the Claude chair never wrote.**

All three Claude chair attempts fail, every run, on every consumer repo. The OpenRouter fallback posts the review instead. I checked 7 successful runs across 5 repos (offrouter, adscapi, blogbat, supportsheep, vibedating) on 2026-08-28; all 7 ended at `chair: all Claude tokens failed; OpenRouter fallback posted the review`.

That is a quality problem, and it is the more important half of this PR's context. This PR does not fix it — the tokens need capacity. It fixes what that outage *costs*.

## What it costs

A chair attempt pays ~12s of `claude-code-action` setup — Bun, dependencies, app-token mint, app-token revoke — before the model is reached. The dead token then fails in **326ms**. So a dead subscription is not free. It is billed at full setup price, twice, on every run of every consumer repo.

Measured, n=7 runs across 5 repos:

| phase | median | note |
|---|---|---|
| chair primary | 12.6s | dead in 7/7 |
| chair backup | 9.4s | dead in 7/7 |
| chair fallback (OpenRouter) | 4.9s | the review that actually ships |
| **job total** | **52s** | |

**22.0s — 42% of the job — goes to two attempts that cannot succeed.**

## The change

Probe the tokens first, concurrently, with the same CLI the action runs. Skip an attempt whose token is already dead.

Faithful by construction: same binary, same token, same documented dead signature (`is_error`, `num_turns: 1`, `total_cost_usd: 0`, empty `modelUsage`) that `AGENTS.md` already describes. The three probes run in parallel, so the cost is one probe, not three. The step sits between the council's start and its await, so it overlaps a background window that already exists rather than extending the run.

**It fails open.** Only that exact signature prunes an attempt. Verified against each case:

| probe sees | verdict | why |
|---|---|---|
| dead-token JSON | `dead` — prune | the documented signature |
| empty token | `live` | deferred to the existing `!= ''` gate, so this never becomes a second, divergent gate |
| empty / unparseable output | `live` | `jq` exits non-zero |
| timeout or crash | `live` | no output to match |
| a chair that ran and genuinely failed | `live` | carries `num_turns > 1` and a nonzero cost |

Wrongly skipping a healthy chair would silently downgrade every review on the fleet. That is far worse than wasting 12s, so every ambiguous case keeps the attempt.

The OpenRouter fallback and the result gate now key off "did not succeed" rather than "failed". Without that, a pruned attempt would leave `outcome == 'skipped'`, the fallback would not fire, and the PR would get **no review at all**.

## Measured on a real consumer run

Pointed `vibeqa` at this branch and opened a PR. The run executed — verified from its log, not from the check's colour:

```
chair token 1: dead
chair token 2: dead
chair token 3: live      <- empty on this repo; the existing `!= ''` gate skips it
chair: all Claude tokens failed; OpenRouter fallback posted the review
```

| phase | before (n=7) | after | delta |
|---|---|---|---|
| chair_probe | — | 2.4s | +2.4s |
| chair_primary | 12.6s | skipped, 0s | −12.6s |
| chair_backup | 9.4s | skipped, 0s | −9.4s |
| chair_fallback | 4.9s | 8.0s | (unchanged path) |
| **net per run** | | | **−19.6s** |

The review still posted. Job wall clock was 42s against a 70s median baseline on the same repo (n=7), but that baseline ranges 30–107s with PR size and council latency, so **the phase-level −19.6s is the real evidence; the job number is only consistent with it.**

## What I could not measure

**The live-token path in CI.** All three subscriptions are dead right now, so no CI run can exercise a `live` verdict end to end. The fail-open cases are verified locally against the real CLI (dead token, empty token, unparseable output, and a simulated genuine failure), and an empty token already returns `live` in the run above. When capacity returns, confirm one run where the probe says `live` and the chair actually reviews.

## Relationship to #27

[#27](https://github.com/pooriaarab/vibecodereview/pull/27) widens `--allowed-tools` to cut permission-denial turns. Its baseline (33.2% of turns denied, n=9) is real and its reasoning holds. But it tunes a code path that **currently never executes** — the chair it optimises has not run on the fleet in days. This PR is upstream of it: it makes the dead path cheap. #27 becomes measurable again only once tokens recover.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added concurrent validation of Claude OAuth tokens before processing.
  - Automatically excludes tokens confirmed to be unavailable.
  - Preserves tokens when validation encounters unexpected errors.

- **Bug Fixes**
  - Improved fallback handling across primary, backup, and additional attempts.
  - Reports successful backup recovery after any primary failure.
  - Includes token validation statuses when all attempts fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->