### PR TITLE
[VCR-31] Add a release process with immutable tags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,29 @@ never fork its provider/lens logic into the surfaces.
   `total_cost_usd: 0` and an empty `modelUsage` never reached the model — that is
   an exhausted or invalid subscription, not a bad prompt. Fix the token.
 
+## Releasing
+
+Two tags per release, never one.
+
+| Tag | Mutable | Who follows it |
+|---|---|---|
+| `vX.Y.Z` | never moved | anyone who pins a version, and rollback |
+| `vX` | force-moved to the newest `vX.Y.Z` | the ~80 repos whose workflow says `@v1` |
+
+    node bin/release.mjs 1.2.0            # dry run, prints the plan
+    node bin/release.mjs 1.2.0 --apply    # create v1.2.0, move v1 to it
+    gh release create v1.2.0 --notes "..."
+
+The immutable tag is the point. Without it there is no way to say which version
+a repo is on, and no way back except a SHA dug out of `git log`. This repo ran
+that way until `v1.0.0` was cut retroactively at whatever `v1` happened to point
+at, purely so a rollback target existed.
+
+**Moving `vX` is a deployment to every repo that follows it.** Nothing else in
+this repo reaches production; merging to `main` changes nothing for a consumer.
+So treat the move as the release, say what it costs in the notes, and remember a
+new council member costs a model call per PR in all of them.
+
 ## Confidentiality
 
 vibecodereview sends diffs to third-party model providers. Use it on **personal /

--- a/bin/release.mjs
+++ b/bin/release.mjs
@@ -26,25 +26,38 @@ const tag = `v${version}`;
 const gh = (args, input) =>
   execFileSync("gh", args, { encoding: "utf8", input, stdio: ["pipe", "pipe", "inherit"] }).trim();
 
+// Like `gh`, but captures stderr instead of inheriting it, so a 404 (ref
+// missing) can be told apart from an auth/network/rate-limit/5xx failure.
+const refExists = (ref) => {
+  try {
+    execFileSync("gh", ["api", `repos/${REPO}/git/refs/${ref}`], {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return true;
+  } catch (e) {
+    if (typeof e.stderr === "string" && /HTTP 404/.test(e.stderr)) return false;
+    console.error(e.stderr || e.message);
+    process.exit(1);
+  }
+};
+
 const sha = JSON.parse(gh(["api", `repos/${REPO}/git/refs/heads/main`])).object.sha;
 
 // Refuse to reuse an immutable tag. Moving one would silently change what a
 // pinned consumer resolves to, which is the whole thing immutability buys.
-let exists = false;
-try {
-  gh(["api", `repos/${REPO}/git/refs/tags/${tag}`]);
-  exists = true;
-} catch {
-  exists = false;
-}
-if (exists) {
+if (refExists(`tags/${tag}`)) {
   console.error(`${tag} already exists. Immutable tags are never moved. Pick the next version.`);
   process.exit(1);
 }
+// A brand-new major (e.g. the first 2.0.0) has no vX ref to move yet, so it
+// must be created (POST) rather than moved (PATCH), or the release half-completes:
+// vX.Y.Z gets tagged and the major pointer is never created.
+const majorExists = refExists(`tags/${major}`);
 
 console.log(`main      ${sha}`);
 console.log(`create    ${tag} -> ${sha.slice(0, 7)}`);
-console.log(`move      ${major} -> ${sha.slice(0, 7)}`);
+console.log(`${majorExists ? "move     " : "create   "} ${major} -> ${sha.slice(0, 7)}`);
 if (!apply) {
   console.log("\ndry run. Nothing was written. Re-run with --apply.");
   process.exit(0);
@@ -54,6 +67,11 @@ gh(["api", `repos/${REPO}/git/refs`, "-X", "POST", "-f", `ref=refs/tags/${tag}`,
 console.log(`created ${tag}`);
 // The major pointer is the only tag this force-updates, and it is the one
 // consumers opted into by writing @v1 rather than a pinned version.
-gh(["api", `repos/${REPO}/git/refs/tags/${major}`, "-X", "PATCH", "-f", `sha=${sha}`, "-F", "force=true"]);
-console.log(`moved ${major} -> ${tag}`);
+if (majorExists) {
+  gh(["api", `repos/${REPO}/git/refs/tags/${major}`, "-X", "PATCH", "-f", `sha=${sha}`, "-F", "force=true"]);
+  console.log(`moved ${major} -> ${tag}`);
+} else {
+  gh(["api", `repos/${REPO}/git/refs`, "-X", "POST", "-f", `ref=refs/tags/${major}`, "-f", `sha=${sha}`]);
+  console.log(`created ${major} -> ${tag}`);
+}
 console.log(`\nNow write the release notes:\n  gh release create ${tag} --repo ${REPO} --title "${tag}" --notes "..."`);

--- a/bin/release.mjs
+++ b/bin/release.mjs
@@ -16,7 +16,7 @@ const REPO = "pooriaarab/vibecodereview";
 const version = process.argv[2];
 const apply = process.argv.includes("--apply");
 
-if (!/^\d+\.\d+\.\d+$/.test(version || "")) {
+if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version || "")) {
   console.error("usage: release.mjs <major.minor.patch> [--apply]");
   process.exit(2);
 }
@@ -65,28 +65,36 @@ const tagExists = existingTagSha !== null;
 const majorExists = refSha(`tags/${major}`) !== null;
 
 // vX is documented as always pointing at the newest vX.Y.Z of that major line.
-// Releasing an older/out-of-order version (a typo, or an old branch cut by
-// mistake) would force-move vX backward — a regression shipped to every
-// consuming repo pinned to @vX. Refuse unless this version is the highest
-// vX.*.* tag that exists.
-if (!tagExists) {
-  const majorNum = major.slice(1);
-  const siblingRefs = JSON.parse(gh(["api", `repos/${REPO}/git/matching-refs/tags/${major}.`]) || "[]");
-  const verRe = new RegExp(`^v${majorNum}\\.(\\d+)\\.(\\d+)$`);
-  const existingVersions = siblingRefs
-    .map((r) => r.ref.split("/").pop().match(verRe))
-    .filter(Boolean)
-    .map((m) => [Number(majorNum), Number(m[1]), Number(m[2])]);
-  const newVer = version.split(".").map(Number);
-  const cmp = (a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
-  const highest = existingVersions.sort(cmp).pop();
-  if (highest && cmp(newVer, highest) <= 0) {
-    console.error(
-      `${tag} is not newer than existing v${highest.join(".")}. ` +
-        `Moving ${major} backward would regress every repo pinned to @${major}. Pick a version above v${highest.join(".")}.`,
-    );
-    process.exit(1);
-  }
+// Releasing an older/out-of-order version (a typo, an old branch cut by mistake,
+// or resuming a stale partial-apply after a newer version has since shipped from
+// a later main) would force-move vX backward — a regression shipped to every
+// consuming repo pinned to @vX. Refuse unless this version is at least as new as
+// every other vX.*.* tag that exists. This runs even when resuming (tagExists):
+// this tag already pointing at the current sha says nothing about whether a
+// higher sibling was tagged in the meantime, so it is excluded from the
+// comparison rather than used to skip it. --paginate/--slurp because a major
+// line can outgrow the API's single-page default and silently hide the highest
+// version otherwise.
+const majorNum = major.slice(1);
+const siblingRefs = JSON.parse(
+  gh(["api", "--paginate", "--slurp", `repos/${REPO}/git/matching-refs/tags/${major}.`]) || "[]",
+).flat();
+const verRe = new RegExp(`^v${majorNum}\\.(\\d+)\\.(\\d+)$`);
+const existingVersions = siblingRefs
+  .map((r) => r.ref.split("/").pop())
+  .filter((name) => name !== tag)
+  .map((name) => name.match(verRe))
+  .filter(Boolean)
+  .map((m) => [Number(majorNum), Number(m[1]), Number(m[2])]);
+const newVer = version.split(".").map(Number);
+const cmp = (a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+const highest = existingVersions.sort(cmp).pop();
+if (highest && cmp(newVer, highest) <= 0) {
+  console.error(
+    `${tag} is not newer than existing v${highest.join(".")}. ` +
+      `Moving ${major} backward would regress every repo pinned to @${major}. Pick a version above v${highest.join(".")}.`,
+  );
+  process.exit(1);
 }
 
 console.log(`main      ${sha}`);

--- a/bin/release.mjs
+++ b/bin/release.mjs
@@ -28,15 +28,16 @@ const gh = (args, input) =>
 
 // Like `gh`, but captures stderr instead of inheriting it, so a 404 (ref
 // missing) can be told apart from an auth/network/rate-limit/5xx failure.
-const refExists = (ref) => {
+// Returns the ref's sha, or null if the ref does not exist.
+const refSha = (ref) => {
   try {
-    execFileSync("gh", ["api", `repos/${REPO}/git/refs/${ref}`], {
+    const out = execFileSync("gh", ["api", `repos/${REPO}/git/refs/${ref}`], {
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
     });
-    return true;
+    return JSON.parse(out).object.sha;
   } catch (e) {
-    if (typeof e.stderr === "string" && /HTTP 404/.test(e.stderr)) return false;
+    if (typeof e.stderr === "string" && /HTTP 404/.test(e.stderr)) return null;
     console.error(e.stderr || e.message);
     process.exit(1);
   }
@@ -44,27 +45,64 @@ const refExists = (ref) => {
 
 const sha = JSON.parse(gh(["api", `repos/${REPO}/git/refs/heads/main`])).object.sha;
 
-// Refuse to reuse an immutable tag. Moving one would silently change what a
-// pinned consumer resolves to, which is the whole thing immutability buys.
-if (refExists(`tags/${tag}`)) {
-  console.error(`${tag} already exists. Immutable tags are never moved. Pick the next version.`);
+// An immutable tag that already points at this same main sha means a
+// previous --apply created it but failed before (or during) the vX step —
+// resume from there instead of refusing. Only a tag pointing somewhere else
+// is the immutability violation this guards against.
+const existingTagSha = refSha(`tags/${tag}`);
+if (existingTagSha && existingTagSha !== sha) {
+  console.error(
+    `${tag} already exists at ${existingTagSha.slice(0, 7)}, not main (${sha.slice(0, 7)}). ` +
+      `Immutable tags are never moved. Pick the next version.`,
+  );
   process.exit(1);
 }
+const tagExists = existingTagSha !== null;
+
 // A brand-new major (e.g. the first 2.0.0) has no vX ref to move yet, so it
 // must be created (POST) rather than moved (PATCH), or the release half-completes:
 // vX.Y.Z gets tagged and the major pointer is never created.
-const majorExists = refExists(`tags/${major}`);
+const majorExists = refSha(`tags/${major}`) !== null;
+
+// vX is documented as always pointing at the newest vX.Y.Z of that major line.
+// Releasing an older/out-of-order version (a typo, or an old branch cut by
+// mistake) would force-move vX backward — a regression shipped to every
+// consuming repo pinned to @vX. Refuse unless this version is the highest
+// vX.*.* tag that exists.
+if (!tagExists) {
+  const majorNum = major.slice(1);
+  const siblingRefs = JSON.parse(gh(["api", `repos/${REPO}/git/matching-refs/tags/${major}.`]) || "[]");
+  const verRe = new RegExp(`^v${majorNum}\\.(\\d+)\\.(\\d+)$`);
+  const existingVersions = siblingRefs
+    .map((r) => r.ref.split("/").pop().match(verRe))
+    .filter(Boolean)
+    .map((m) => [Number(majorNum), Number(m[1]), Number(m[2])]);
+  const newVer = version.split(".").map(Number);
+  const cmp = (a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+  const highest = existingVersions.sort(cmp).pop();
+  if (highest && cmp(newVer, highest) <= 0) {
+    console.error(
+      `${tag} is not newer than existing v${highest.join(".")}. ` +
+        `Moving ${major} backward would regress every repo pinned to @${major}. Pick a version above v${highest.join(".")}.`,
+    );
+    process.exit(1);
+  }
+}
 
 console.log(`main      ${sha}`);
-console.log(`create    ${tag} -> ${sha.slice(0, 7)}`);
+console.log(tagExists ? `exists    ${tag} -> ${sha.slice(0, 7)} (resuming)` : `create    ${tag} -> ${sha.slice(0, 7)}`);
 console.log(`${majorExists ? "move     " : "create   "} ${major} -> ${sha.slice(0, 7)}`);
 if (!apply) {
   console.log("\ndry run. Nothing was written. Re-run with --apply.");
   process.exit(0);
 }
 
-gh(["api", `repos/${REPO}/git/refs`, "-X", "POST", "-f", `ref=refs/tags/${tag}`, "-f", `sha=${sha}`]);
-console.log(`created ${tag}`);
+if (tagExists) {
+  console.log(`${tag} already exists at this sha, skipping`);
+} else {
+  gh(["api", `repos/${REPO}/git/refs`, "-X", "POST", "-f", `ref=refs/tags/${tag}`, "-f", `sha=${sha}`]);
+  console.log(`created ${tag}`);
+}
 // The major pointer is the only tag this force-updates, and it is the one
 // consumers opted into by writing @v1 rather than a pinned version.
 if (majorExists) {

--- a/bin/release.mjs
+++ b/bin/release.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Cut a release: an immutable vX.Y.Z tag, then move the vX pointer to it.
+//
+// Two tags, not one. The immutable tag is what makes "which version are we on"
+// and "put it back" answerable; the moving major tag is what the 80 consuming
+// repos follow to get fixes without editing 80 workflows. Skipping the
+// immutable one leaves no rollback target except a SHA dug out of git log,
+// which is where this repo was until v1.0.0 was cut retroactively.
+//
+// Usage:
+//   node bin/release.mjs 1.2.0            # dry run, prints the plan
+//   node bin/release.mjs 1.2.0 --apply
+import { execFileSync } from "node:child_process";
+
+const REPO = "pooriaarab/vibecodereview";
+const version = process.argv[2];
+const apply = process.argv.includes("--apply");
+
+if (!/^\d+\.\d+\.\d+$/.test(version || "")) {
+  console.error("usage: release.mjs <major.minor.patch> [--apply]");
+  process.exit(2);
+}
+const major = `v${version.split(".")[0]}`;
+const tag = `v${version}`;
+
+const gh = (args, input) =>
+  execFileSync("gh", args, { encoding: "utf8", input, stdio: ["pipe", "pipe", "inherit"] }).trim();
+
+const sha = JSON.parse(gh(["api", `repos/${REPO}/git/refs/heads/main`])).object.sha;
+
+// Refuse to reuse an immutable tag. Moving one would silently change what a
+// pinned consumer resolves to, which is the whole thing immutability buys.
+let exists = false;
+try {
+  gh(["api", `repos/${REPO}/git/refs/tags/${tag}`]);
+  exists = true;
+} catch {
+  exists = false;
+}
+if (exists) {
+  console.error(`${tag} already exists. Immutable tags are never moved. Pick the next version.`);
+  process.exit(1);
+}
+
+console.log(`main      ${sha}`);
+console.log(`create    ${tag} -> ${sha.slice(0, 7)}`);
+console.log(`move      ${major} -> ${sha.slice(0, 7)}`);
+if (!apply) {
+  console.log("\ndry run. Nothing was written. Re-run with --apply.");
+  process.exit(0);
+}
+
+gh(["api", `repos/${REPO}/git/refs`, "-X", "POST", "-f", `ref=refs/tags/${tag}`, "-f", `sha=${sha}`]);
+console.log(`created ${tag}`);
+// The major pointer is the only tag this force-updates, and it is the one
+// consumers opted into by writing @v1 rather than a pinned version.
+gh(["api", `repos/${REPO}/git/refs/tags/${major}`, "-X", "PATCH", "-f", `sha=${sha}`, "-F", "force=true"]);
+console.log(`moved ${major} -> ${tag}`);
+console.log(`\nNow write the release notes:\n  gh release create ${tag} --repo ${REPO} --title "${tag}" --notes "..."`);

--- a/bin/release.mjs
+++ b/bin/release.mjs
@@ -35,7 +35,20 @@ const refSha = (ref) => {
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
     });
-    return JSON.parse(out).object.sha;
+    const obj = JSON.parse(out).object;
+    // An annotated tag's ref points at the TAG object, not at the commit. Every
+    // tag here is lightweight today, so this never mattered; one `git tag -a`
+    // or a differently-cut release would make the sha comparison below compare
+    // a tag object against a commit, never match, and refuse to resume a
+    // version that is in fact correct. Resolve through to the commit.
+    if (obj.type === "tag") {
+      const tagObj = execFileSync("gh", ["api", `repos/${REPO}/git/tags/${obj.sha}`], {
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      return JSON.parse(tagObj).object.sha;
+    }
+    return obj.sha;
   } catch (e) {
     if (typeof e.stderr === "string" && /HTTP 404/.test(e.stderr)) return null;
     console.error(e.stderr || e.message);


### PR DESCRIPTION
Closes #31

## What

Adds `bin/release.mjs` and a Releasing section in `AGENTS.md`. Also cuts the two tags that were missing: `v1.0.0` retroactively at whatever `v1` pointed at, and `v1.1.0` at current main.

## Why

`v1` was force-moved on every release and nothing else was tagged. That leaves no answer to "which version is this repo on", no rollback target except a SHA from `git log`, and no release notes. About 80 repos follow `@v1`, so a bad move reaches all of them with nothing named to go back to.

Two tags per release is the Actions convention for exactly this reason: the immutable `vX.Y.Z` is what makes a version nameable and reversible, and the moving `vX` is what saves editing 80 workflows to ship a fix.

The script refuses to reuse an existing immutable tag. Moving one would silently change what a pinned consumer resolves to, which is the entire thing immutability buys.

One thing worth stating in `AGENTS.md` because it is easy to miss: **merging to main changes nothing for a consumer.** Moving `vX` is the deployment. A new council member costs a model call per PR across every repo that follows it, so the notes should say so.

## How I verified

```
node bin/release.mjs 1.1.0    -> refuses: already exists, immutable tags are never moved
node bin/release.mjs 9.9.9    -> dry run prints create v9.9.9 + move v9, writes nothing
```

Tags and releases already created out of band: v1.0.0 (rollback target) and v1.1.0 (scope lens). `v1` itself has **not** been moved; that is a deployment decision.

Assisted-by: claude-personal-2:claude-opus-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a release workflow with semantic version validation, immutable version tags, and movable major-version tags.
  * Added a safe dry-run mode to preview release actions before applying them.
  * Added an apply mode that creates version tags, updates major tags, and provides a release-notes command.
  * Added safeguards for conflicting, invalid, or out-of-order releases and support for resuming interrupted releases.

* **Documentation**
  * Documented release commands, tag behavior, rollback considerations, and deployment impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->