### PR TITLE
[VCR-33] Judge the evidence a pull request shows

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,23 @@ verdict, self-healing fix.
 
 | Member | Provider (called directly) | Secret | Lens |
 | --- | --- | --- | --- |
-| Chair | Claude (subscription OAuth) | `CLAUDE_CODE_OAUTH_TOKEN` | synthesis + conventions + tests + fixes |
+| Chair | Claude (subscription OAuth) | `CLAUDE_CODE_OAUTH_TOKEN` | synthesis + conventions + tests + proof + fixes |
 | GPT / Codex | api.openai.com | `OPENAI_API_KEY` | correctness, silent failures |
 | Gemini | generativelanguage.googleapis.com | `GEMINI_API_KEY` | performance, type design |
 | Kimi | api.moonshot.ai | `MOONSHOT_API_KEY` | security |
 | Grok / DeepSeek | openrouter.ai | `OPENROUTER_API_KEY` | maintainability, data integrity |
-| GPT-5.6 (scope) | openrouter.ai | `OPENROUTER_API_KEY` | scope and atomicity |
+| GPT-5.6 (scope) | openrouter.ai | `OPENROUTER_API_KEY` | scope, atomicity, and the evidence in the body |
 | Sonnet (mutation) | openrouter.ai | `OPENROUTER_API_KEY` | can these tests fail at all — **off by default** |
 
 A member with no key drops out. No key at all → the council step is skipped, and
 Claude still reviews alone. Nothing here blocks the PR on a provider outage. The scope lens reads the PR's title, body, and linked issues from `PR_CONTEXT_FILE` when available to verify the diff matches the author's claim.
+
+A pull request also has to show its work: a visible change carries before and after
+screenshots, a command carries its result. The scope member judges that evidence against
+the diff, and the chair asks for the capture that would settle it. Neither of them ever
+produces the evidence itself. Set `require_proof: false` in a repo where no change is
+ever visible. The rule the check enforces lives in `pr-standards.md` in
+[pooriaarab/scripts](https://github.com/pooriaarab/scripts).
 
 ## Use it in a repo
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ produces the evidence itself. Set `require_proof: false` in a repo where no chan
 ever visible. The rule the check enforces lives in `pr-standards.md` in
 [pooriaarab/scripts](https://github.com/pooriaarab/scripts).
 
+Evidence has to cover the diff it claims to cover. The check flags a body whose
+`## How I verified` leaves untested a code path the PR changes, and one whose
+capture predates the newest commit touching a path that capture exercises. It does
+not ask for a recapture on every push: a commit that changes nothing the evidence
+shows leaves that evidence good. `scripts/proof-gate.test.sh` pins both paths the
+`require_proof` flag travels — the council scope lens and the chair's own bullet —
+because the first version gated only one of them.
+
 ## Use it in a repo
 
 ```bash

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: "If true, the chair may commit and push fixes to the PR branch."
     required: false
     default: "true"
+  require_proof:
+    description: "If true, the chair checks that the PR body's evidence matches the diff — a UI change needs before/after screenshots, a command needs its result. Set false in a repo where no change is ever visible. See pr-standards.md in pooriaarab/scripts."
+    required: false
+    default: "true"
   max_fix_cycles:
     description: "Stop auto-pushing fixes after this many of our own consecutive commits (loop guard). Each fix commit is a new `synchronize` event, so it re-runs every other pull_request workflow in the repo — budget this against how many you have. See 'What a fix cycle costs' in the README."
     required: false
@@ -198,6 +202,7 @@ runs:
         MUTATION_LENS: ${{ inputs.mutation_lens }}
         MUTATION_MODEL: ${{ inputs.mutation_model }}
         PR_CONTEXT_FILE: ${{ runner.temp }}/pr-context.txt
+        REQUIRE_PROOF: ${{ inputs.require_proof }}
       run: |
         gh pr diff ${{ github.event.pull_request.number }} > pr.diff || true
         nohup node "${{ github.action_path }}/scripts/council-review.mjs" \
@@ -265,6 +270,7 @@ runs:
         VCR_BRANCH: ${{ github.event.pull_request.head.ref }}
         VCR_CANPUSH: ${{ steps.cycle.outputs.can_push }}
         VCR_CYCLES: ${{ steps.cycle.outputs.cycles }}
+        VCR_REQUIRE_PROOF: ${{ inputs.require_proof }}
       run: |
         cat > "$RUNNER_TEMP/chair-prompt.txt" <<'VCR_PROMPT_EOF'
         You chair an LLM council reviewing PR #__PR__ in __REPO__.
@@ -290,8 +296,19 @@ runs:
         3. Repo conventions: CLAUDE.md is already loaded into your context, so do not re-read
            it. Read AGENTS.md and the `.claude/rules/` files that match the paths this diff
            touches — those only. Do not enumerate the whole rules directory.
-        4. Add your own lens: conventions + test coverage. Assume the author is competent;
-           flag only diff-introduced defects with a concrete failure trigger.
+           Read VISION.md when the repo has one: it states what this repo is for, and it is
+           the only thing that can tell you a change is well-built and still does not belong
+           here.
+        4. Add your own lenses. Assume the author is competent; flag only diff-introduced
+           defects with a concrete failure trigger.
+           - conventions and test coverage.
+           - proof (required in this repo: __REQUIREPROOF__). The body's `## How I verified`
+             must carry evidence that matches the diff. Flag it when a UI change shows no
+             before/after screenshot, when an embedded screenshot shows a screen this diff does
+             not touch, when a named command has no result, when the evidence predates the
+             newest commit that changed what it shows, or when a `Proof: n/a` reason does not
+             hold. Name the capture that would settle it. Never push a proof fix: evidence is
+             the author's to produce, and a chair that invents it defeats the check.
         5. If "Can push fixes" is true and you find clear, confirmed bugs/security/convention
            issues, fix them (Edit/Write), then:
            `git add -A && git commit -m "fix: <what>" && git push origin __BRANCH__`
@@ -336,6 +353,7 @@ runs:
         PROMPT="${PROMPT//__BRANCH__/$VCR_BRANCH}"
         PROMPT="${PROMPT//__CANPUSH__/$VCR_CANPUSH}"
         PROMPT="${PROMPT//__CYCLES__/$VCR_CYCLES}"
+        PROMPT="${PROMPT//__REQUIREPROOF__/${VCR_REQUIRE_PROOF:-true}}"
         # An empty prompt is the one failure this step can produce, and it fails
         # SILENTLY downstream: claude-code-action skips and reports success, so
         # the PR gets a green review check with no review behind it. Fail here

--- a/action.yml
+++ b/action.yml
@@ -302,13 +302,7 @@ runs:
         4. Add your own lenses. Assume the author is competent; flag only diff-introduced
            defects with a concrete failure trigger.
            - conventions and test coverage.
-           - proof (required in this repo: __REQUIREPROOF__). The body's `## How I verified`
-             must carry evidence that matches the diff. Flag it when a UI change shows no
-             before/after screenshot, when an embedded screenshot shows a screen this diff does
-             not touch, when a named command has no result, when the evidence predates the
-             newest commit that changed what it shows, or when a `Proof: n/a` reason does not
-             hold. Name the capture that would settle it. Never push a proof fix: evidence is
-             the author's to produce, and a chair that invents it defeats the check.
+           __PROOFLENS__
         5. If "Can push fixes" is true and you find clear, confirmed bugs/security/convention
            issues, fix them (Edit/Write), then:
            `git add -A && git commit -m "fix: <what>" && git push origin __BRANCH__`
@@ -353,7 +347,21 @@ runs:
         PROMPT="${PROMPT//__BRANCH__/$VCR_BRANCH}"
         PROMPT="${PROMPT//__CANPUSH__/$VCR_CANPUSH}"
         PROMPT="${PROMPT//__CYCLES__/$VCR_CYCLES}"
-        PROMPT="${PROMPT//__REQUIREPROOF__/${VCR_REQUIRE_PROOF:-true}}"
+        # Mirror council-config.mjs: when proof is off, drop the whole bullet
+        # rather than interpolate the flag into a still-mandatory instruction
+        # the chair could follow regardless of what the flag says.
+        if [ "${VCR_REQUIRE_PROOF:-true}" = "false" ]; then
+          PROOF_LENS="- proof: disabled for this repo (require_proof: false). Do not ask for screenshots or command results."
+        else
+          PROOF_LENS="- proof (required in this repo: true). The body's \`## How I verified\`
+             must carry evidence that matches the diff. Flag it when a UI change shows no
+             before/after screenshot, when an embedded screenshot shows a screen this diff does
+             not touch, when a named command has no result, when the evidence predates the
+             newest commit that changed what it shows, or when a \`Proof: n/a\` reason does not
+             hold. Name the capture that would settle it. Never push a proof fix: evidence is
+             the author's to produce, and a chair that invents it defeats the check."
+        fi
+        PROMPT="${PROMPT//__PROOFLENS__/$PROOF_LENS}"
         # An empty prompt is the one failure this step can produce, and it fails
         # SILENTLY downstream: claude-code-action skips and reports success, so
         # the PR gets a green review check with no review behind it. Fail here

--- a/action.yml
+++ b/action.yml
@@ -558,6 +558,11 @@ runs:
         GITHUB_REPOSITORY: ${{ github.repository }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         CHAIR_FALLBACK_MODEL: ${{ inputs.chair_fallback_model }}
+        # The proof lens must reach every chair. Without these two the fallback
+        # reviewed without it, so a subscription outage turned proof off and the
+        # check still reported green.
+        PR_CONTEXT_FILE: ${{ runner.temp }}/pr-context.txt
+        VCR_REQUIRE_PROOF: ${{ inputs.require_proof }}
       run: node "${{ github.action_path }}/scripts/chair-fallback.mjs" pr.diff council-findings.md
 
     # A budget stop is a routing decision, not a verdict on the code, so it

--- a/action.yml
+++ b/action.yml
@@ -356,9 +356,10 @@ runs:
           PROOF_LENS="- proof (required in this repo: true). The body's \`## How I verified\`
              must carry evidence that matches the diff. Flag it when a UI change shows no
              before/after screenshot, when an embedded screenshot shows a screen this diff does
-             not touch, when a named command has no result, when the evidence predates the
-             newest commit that changed what it shows, or when a \`Proof: n/a\` reason does not
-             hold. Name the capture that would settle it. Never push a proof fix: evidence is
+             not touch, when a named command has no result, when the evidence
+             leaves untested a code path this PR changes, when the evidence predates the
+             newest commit that touched a path it exercises, or when a
+             \`Proof: n/a\` reason does not hold. Name the capture that would settle it. Never push a proof fix: evidence is
              the author's to produce, and a chair that invents it defeats the check."
         fi
         PROMPT="${PROMPT//__PROOFLENS__/$PROOF_LENS}"

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -15,6 +15,7 @@
 
 import fs from "node:fs";
 import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
 const MAX_DIFF_CHARS = 180_000;
 const TIMEOUT_MS = Number(process.env.CHAIR_FALLBACK_TIMEOUT_MS) || 180_000;
@@ -25,17 +26,26 @@ const SEVERITIES = { critical: "Critical", major: "Major", minor: "Minor" };
 // chair's prompt, and this one. It reached the first two and not this one, so a
 // subscription outage silently turned proof off — the failure mode this file
 // exists to prevent, arriving through the file itself.
-const REQUIRE_PROOF = process.env.VCR_REQUIRE_PROOF !== "false";
-const PROOF_RULE = REQUIRE_PROOF
-  ? `
+// Only the criteria this chair can actually apply. It has no tools: it never
+// receives image bytes, and it never receives a commit list or commit dates. So
+// it cannot check what a screenshot depicts, and it cannot check whether a
+// capture predates a commit. The other two paths keep both criteria; claiming
+// them here would be a guarantee this chair cannot keep, and a claimed check is
+// worse than an admitted gap in the one path that only runs during an outage.
+export function buildProofRule(requireProof = process.env.VCR_REQUIRE_PROOF !== "false") {
+  if (!requireProof) return "";
+  return `
 - Judge the evidence too. The body's \`## How I verified\` must carry evidence that
   matches the diff. Flag it when a visible change shows no before/after capture,
-  when an embedded screenshot shows a screen this diff does not touch, when a named
-  command has no result, when the evidence leaves untested a code path this PR
-  changes, when the evidence predates the newest commit that touched a path it
-  exercises, or when a \`Proof: n/a\` reason does not hold. Name the capture that
-  would settle it. Never invent evidence: it is the author's to produce.`
-  : "";
+  when a named command has no result, when the evidence leaves untested a code path
+  this PR changes, or when a \`Proof: n/a\` reason does not hold. Name the capture
+  that would settle it. Never invent evidence: it is the author's to produce.
+- You cannot see images or commit dates, so do NOT rule on what a screenshot
+  depicts or on whether a capture is stale. Say the full-tool chair must judge
+  those.`;
+}
+
+const PROOF_RULE = buildProofRule();
 
 const SYSTEM = `You chair a multi-model code review council. You receive a pull request diff and
 the council's per-lens findings. Produce ONE review.
@@ -369,7 +379,11 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error("Fallback chair failed:", err?.message || err);
-  process.exit(1);
-});
+// Run only when invoked directly. A test that imports this file to check the
+// proof rule must not fire the network calls and the process.exit in main().
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error("Fallback chair failed:", err?.message || err);
+    process.exit(1);
+  });
+}

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -10,7 +10,8 @@
 //
 // Usage: node chair-fallback.mjs <diff-file> <council-findings-file>
 // Env: OPENROUTER_API_KEY, GH_TOKEN, GITHUB_REPOSITORY, PR_NUMBER,
-//      CHAIR_FALLBACK_MODEL (default anthropic/claude-sonnet-5)
+//      CHAIR_FALLBACK_MODEL (default anthropic/claude-sonnet-5),
+//      PR_CONTEXT_FILE, VCR_REQUIRE_PROOF
 
 import fs from "node:fs";
 import { execFileSync } from "node:child_process";
@@ -19,6 +20,20 @@ const MAX_DIFF_CHARS = 180_000;
 const TIMEOUT_MS = Number(process.env.CHAIR_FALLBACK_TIMEOUT_MS) || 180_000;
 const MODEL = process.env.CHAIR_FALLBACK_MODEL || "anthropic/claude-sonnet-5";
 const SEVERITIES = { critical: "Critical", major: "Major", minor: "Minor" };
+
+// The proof lens travels three code paths: the council scope lens, the primary
+// chair's prompt, and this one. It reached the first two and not this one, so a
+// subscription outage silently turned proof off — the failure mode this file
+// exists to prevent, arriving through the file itself.
+const REQUIRE_PROOF = process.env.VCR_REQUIRE_PROOF !== "false";
+const PROOF_RULE = REQUIRE_PROOF
+  ? `
+- Judge the evidence too. The body's \`## How I verified\` must carry evidence that
+  matches the diff. Flag it when a visible change shows no before/after capture,
+  when a named command has no result, when the evidence leaves untested a code path
+  this PR changes, or when a \`Proof: n/a\` reason does not hold. Name the capture
+  that would settle it. Never invent evidence: it is the author's to produce.`
+  : "";
 
 const SYSTEM = `You chair a multi-model code review council. You receive a pull request diff and
 the council's per-lens findings. Produce ONE review.
@@ -36,7 +51,7 @@ Rules:
 - Assume the author is competent. Report only diff-introduced defects that have
   a concrete failure trigger.
 - Severity: Critical (security, crash, data loss), Major (real bug or
-  convention violation), Minor (everything else).
+  convention violation), Minor (everything else).${PROOF_RULE}
 
 Reply with STRICT JSON and nothing else:
 {"verdict":"approve"|"request_changes"|"comment","summary":"<markdown>","findings":[{"severity":"Critical"|"Major"|"Minor","file":"<path>","line":<number|null>,"body":"<markdown>"}]}
@@ -46,6 +61,18 @@ when nothing Critical or Major survives. Otherwise "comment".`;
 
 function truncate(s, n) {
   return s.length > n ? s.slice(0, n) : s;
+}
+
+function prContext() {
+  const path = process.env.PR_CONTEXT_FILE;
+  if (!path) return "";
+  try {
+    return truncate(fs.readFileSync(path, "utf8"), 20_000);
+  } catch {
+    // The context file is written by an earlier step. A review without it is
+    // weaker; a review that throws because of it is none at all.
+    return "";
+  }
 }
 
 async function askChair(diff, council, diffTruncated) {
@@ -69,6 +96,7 @@ async function askChair(diff, council, diffTruncated) {
             role: "user",
             content:
               (diffTruncated ? "NOTE: this diff was truncated for length. Judge only what you can see.\n\n" : "") +
+              (prContext() ? `PR title, body and linked issues:\n\n${prContext()}\n\n---\n\n` : "") +
               `PR diff:\n\n${diff}\n\n---\n\nCouncil findings:\n\n${council}`,
           },
         ],

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -30,9 +30,11 @@ const PROOF_RULE = REQUIRE_PROOF
   ? `
 - Judge the evidence too. The body's \`## How I verified\` must carry evidence that
   matches the diff. Flag it when a visible change shows no before/after capture,
-  when a named command has no result, when the evidence leaves untested a code path
-  this PR changes, or when a \`Proof: n/a\` reason does not hold. Name the capture
-  that would settle it. Never invent evidence: it is the author's to produce.`
+  when an embedded screenshot shows a screen this diff does not touch, when a named
+  command has no result, when the evidence leaves untested a code path this PR
+  changes, when the evidence predates the newest commit that touched a path it
+  exercises, or when a \`Proof: n/a\` reason does not hold. Name the capture that
+  would settle it. Never invent evidence: it is the author's to produce.`
   : "";
 
 const SYSTEM = `You chair a multi-model code review council. You receive a pull request diff and
@@ -79,6 +81,7 @@ async function askChair(diff, council, diffTruncated) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
+    const context = prContext();
     const res = await fetch("https://openrouter.ai/api/v1/chat/completions", {
       method: "POST",
       signal: controller.signal,
@@ -96,7 +99,7 @@ async function askChair(diff, council, diffTruncated) {
             role: "user",
             content:
               (diffTruncated ? "NOTE: this diff was truncated for length. Judge only what you can see.\n\n" : "") +
-              (prContext() ? `PR title, body and linked issues:\n\n${prContext()}\n\n---\n\n` : "") +
+              (context ? `PR title, body and linked issues:\n\n${context}\n\n---\n\n` : "") +
               `PR diff:\n\n${diff}\n\n---\n\nCouncil findings:\n\n${council}`,
           },
         ],

--- a/scripts/council-config.mjs
+++ b/scripts/council-config.mjs
@@ -35,7 +35,7 @@ export const LENSES = {
     // collecting findings its author can never satisfy.
     (process.env.REQUIRE_PROOF === "false"
       ? ""
-      : " ALSO judge the evidence in the body: a visible change with no before/after screenshot, an embedded screenshot of a screen this diff does not touch, a named command with no result, or a `Proof: n/a` reason that does not hold.") +
+      : " ALSO judge the evidence in the body: a visible change with no before/after screenshot, an embedded screenshot of a screen this diff does not touch, a named command with no result, evidence that leaves a code path this PR changes untested or that predates the newest commit touching a path it exercises, or a `Proof: n/a` reason that does not hold.") +
     " Do NOT report bugs, performance, security, or style (other members cover those).",
 };
 

--- a/scripts/council-config.mjs
+++ b/scripts/council-config.mjs
@@ -35,7 +35,7 @@ export const LENSES = {
     // collecting findings its author can never satisfy.
     (process.env.REQUIRE_PROOF === "false"
       ? ""
-      : " ALSO judge the evidence in the body: a visible change with no before/after screenshot, an embedded screenshot of a screen this diff does not touch, a named command with no result, evidence that leaves a code path this PR changes untested or that predates the newest commit touching a path it exercises, or a `Proof: n/a` reason that does not hold.") +
+      : " ALSO judge the evidence in the body: a visible change with no before/after screenshot, an embedded screenshot of a screen this diff does not touch, a named command with no result, evidence that leaves untested a code path this PR changes or that predates the newest commit touching a path it exercises, or a `Proof: n/a` reason that does not hold.") +
     " Do NOT report bugs, performance, security, or style (other members cover those).",
 };
 

--- a/scripts/council-config.mjs
+++ b/scripts/council-config.mjs
@@ -28,7 +28,15 @@ export const LENSES = {
   mutation:
     "whether the tests in this diff can fail at all. For EACH test added or changed, name ONE concrete mutation to the NON-TEST code it covers that the test must catch. Write every finding as `<test path:line> -- <mutation path:line> -- replace <before> with <after>`. Without the test's own location the chair cannot tell which test the mutation is supposed to break, and cannot check the claim. Report a finding only when the test would still pass after that mutation, or when it asserts something the code cannot get wrong: the test and the code share the same helper so they agree regardless, the assertion restates the implementation, the fixture never reaches the code path, or a value is compared against itself. Also report a test that can only fail by hanging or by timing out, since in CI that is a job timeout rather than a red. Do NOT report missing coverage in general, and do NOT report bugs, performance, security or style (other members cover those)",
   scope:
-    "scope and atomicity: the diff doing more than one thing (a fix plus a refactor plus a rename), changes with no connection to the stated purpose of the PR, opportunistic edits to files the stated change did not require, or a stated purpose the diff does not actually accomplish. Do NOT report bugs, performance, security, or style (other members cover those).",
+    "scope and atomicity: the diff doing more than one thing (a fix plus a refactor plus a rename), changes with no connection to the stated purpose of the PR, opportunistic edits to files the stated change did not require, or a stated purpose the diff does not actually accomplish." +
+    // Evidence lives in the PR body, which this member already receives as
+    // context, so it costs nothing to judge here. A repo where no change is
+    // ever visible sets REQUIRE_PROOF=false and drops the clause rather than
+    // collecting findings its author can never satisfy.
+    (process.env.REQUIRE_PROOF === "false"
+      ? ""
+      : " ALSO judge the evidence in the body: a visible change with no before/after screenshot, an embedded screenshot of a screen this diff does not touch, a named command with no result, or a `Proof: n/a` reason that does not hold.") +
+    " Do NOT report bugs, performance, security, or style (other members cover those).",
 };
 
 // A native provider key that is present but out of credit answers in well under

--- a/scripts/proof-gate.test.sh
+++ b/scripts/proof-gate.test.sh
@@ -28,6 +28,15 @@ grep -q 'VCR_REQUIRE_PROOF: ${{ inputs.require_proof }}' "$ROOT/action.yml" \
   && report 0 'action.yml wires require_proof input to VCR_REQUIRE_PROOF' \
   || report 1 'action.yml wires require_proof input to VCR_REQUIRE_PROOF'
 
+grep -q 'VCR_REQUIRE_PROOF: ${{ inputs.require_proof }}' "$ROOT/action.yml" \
+  && report 0 'action.yml wires require_proof to the fallback chair too' \
+  || report 1 'action.yml wires require_proof to the fallback chair too'
+# The fallback chair judges nothing it cannot see. Without the PR body it can
+# never apply the proof rule, however well the rule is worded.
+[ "$(grep -c 'PR_CONTEXT_FILE: ${{ runner.temp }}/pr-context.txt' "$ROOT/action.yml")" -ge 2 ] \
+  && report 0 'action.yml gives the fallback chair the PR body' \
+  || report 1 'action.yml gives the fallback chair the PR body'
+
 # Path 1: the council scope lens.
 lens() { REQUIRE_PROOF="$1" node -e 'import("./scripts/council-config.mjs").then(m => process.stdout.write(m.LENSES.scope))'; }
 ( cd "$ROOT" && lens false | grep -q 'judge the evidence' ) && report 1 'scope lens drops the proof clause when off' || report 0 'scope lens drops the proof clause when off'
@@ -58,6 +67,29 @@ chair ""    | grep -q 'must carry evidence'         && report 0 'an unset flag d
 # The rule the chair applies must name the gap that this PR's own review found:
 # evidence that tests one file while a later commit changed another.
 chair true | grep -q 'leaves untested a code path this PR changes' && report 0 'chair asks for evidence covering every changed path' || report 1 'chair asks for evidence covering every changed path'
+
+# The scope lens must carry the same changed-path rule as the chair. One of the
+# two carrying it is how a rule reaches a review only when a subscription is up.
+( cd "$ROOT" && lens true | grep -q 'leaves untested a code path this PR changes' ) \
+  && report 0 'scope lens asks for evidence covering every changed path' \
+  || report 1 'scope lens asks for evidence covering every changed path'
+
+# Path 3: the OpenRouter fallback chair. It runs only when every Claude
+# subscription has failed, and it had no proof rule at all — so an outage
+# silently turned proof off while the check still reported green.
+fallback() { VCR_REQUIRE_PROOF="$1" node --input-type=module -e '
+const src = await import("node:fs").then(m => m.readFileSync("scripts/chair-fallback.mjs", "utf8"));
+const on = process.env.VCR_REQUIRE_PROOF !== "false";
+const rule = src.includes("Judge the evidence too");
+const gated = src.includes("VCR_REQUIRE_PROOF !== \"false\"");
+process.stdout.write(rule && gated ? (on ? "on" : "off") : "missing");
+'; }
+( cd "$ROOT" && [ "$(fallback true)" = on ] ) \
+  && report 0 'fallback chair carries a proof rule, gated on the flag' \
+  || report 1 'fallback chair carries a proof rule, gated on the flag'
+( cd "$ROOT" && grep -q 'PR title, body and linked issues' scripts/chair-fallback.mjs ) \
+  && report 0 'fallback chair is sent the body it must judge' \
+  || report 1 'fallback chair is sent the body it must judge'
 
 [ "$fails" = 0 ] || { printf '\n%s failing\n' "$fails" >&2; exit 1; }
 printf '\nall passing\n'

--- a/scripts/proof-gate.test.sh
+++ b/scripts/proof-gate.test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Prove that `require_proof: false` really turns the proof lens off.
+#
+# The flag reaches the review through TWO independent code paths: the council
+# scope lens in council-config.mjs, and the chair's own proof bullet built in
+# action.yml. The first version gated only the first path, so a repo that set
+# require_proof: false still got a chair demanding screenshots. One path passing
+# says nothing about the other, so both are checked here.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(dirname "$HERE")"
+fails=0
+
+report() {
+  if [ "$1" = 0 ]; then printf 'ok    %s\n' "$2"
+  else printf 'FAIL  %s\n' "$2"; fails=$((fails + 1)); fi
+}
+
+# Path 1: the council scope lens.
+lens() { REQUIRE_PROOF="$1" node -e 'import("./scripts/council-config.mjs").then(m => process.stdout.write(m.LENSES.scope))'; }
+( cd "$ROOT" && lens false | grep -q 'judge the evidence' ) && report 1 'scope lens drops the proof clause when off' || report 0 'scope lens drops the proof clause when off'
+( cd "$ROOT" && lens true  | grep -q 'judge the evidence' ) && report 0 'scope lens keeps the proof clause when on'  || report 1 'scope lens keeps the proof clause when on'
+
+# Path 2: the chair's proof bullet, run as the action runs it. The block is
+# extracted from action.yml rather than copied, so this test cannot drift from
+# what the workflow actually executes.
+extract() {
+  python3 - "$ROOT/action.yml" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+start = next(i for i, l in enumerate(lines) if 'if [ "${VCR_REQUIRE_PROOF:-true}" = "false" ]; then' in l)
+end = next(i for i in range(start, len(lines)) if lines[i].strip() == "fi")
+indent = len(lines[start]) - len(lines[start].lstrip())
+print("\n".join(l[indent:] for l in lines[start:end + 1]))
+PY
+}
+BLOCK="$(extract)"
+# The bullet is wrapped over several lines, so squeeze the whitespace before
+# matching. Otherwise a grep for a phrase fails on where the line happens to break.
+chair() { VCR_REQUIRE_PROOF="$1" bash -c "$BLOCK"'; printf "%s" "$PROOF_LENS"' | tr -s '[:space:]' ' '; }
+chair false | grep -q 'Do not ask for screenshots' && report 0 'chair bullet turns off when require_proof is false' || report 1 'chair bullet turns off when require_proof is false'
+chair false | grep -q 'must carry evidence'         && report 1 'chair bullet drops the demand when off'          || report 0 'chair bullet drops the demand when off'
+chair true  | grep -q 'must carry evidence'         && report 0 'chair bullet demands evidence by default'        || report 1 'chair bullet demands evidence by default'
+chair ""    | grep -q 'must carry evidence'         && report 0 'an unset flag defaults to demanding evidence'    || report 1 'an unset flag defaults to demanding evidence'
+
+# The rule the chair applies must name the gap that this PR's own review found:
+# evidence that tests one file while a later commit changed another.
+chair true | grep -q 'leaves untested a code path this PR changes' && report 0 'chair asks for evidence covering every changed path' || report 1 'chair asks for evidence covering every changed path'
+
+[ "$fails" = 0 ] || { printf '\n%s failing\n' "$fails" >&2; exit 1; }
+printf '\nall passing\n'

--- a/scripts/proof-gate.test.sh
+++ b/scripts/proof-gate.test.sh
@@ -95,10 +95,15 @@ process.stdout.write(rule && gated ? (on ? "on" : "off") : "missing");
 # and the scope lens's, not just any proof rule. A rule that demands evidence
 # but never checks for a wrong-screen screenshot or a stale capture is a
 # weaker gate hiding behind the same "proof required" label.
-( cd "$ROOT" && grep -q 'embedded screenshot shows a screen this diff does not touch' scripts/chair-fallback.mjs ) \
+# The rule is wrapped over several lines in the source, so squeeze the
+# whitespace before matching. A grep for a phrase that happens to straddle a
+# line break fails on the formatting rather than on the rule, which is how a
+# passing test starts reporting a missing criterion that is right there.
+fallback_rule() { tr -s '[:space:]' ' ' < "$ROOT/scripts/chair-fallback.mjs"; }
+fallback_rule | grep -q 'embedded screenshot shows a screen this diff does not touch' \
   && report 0 'fallback chair rejects a wrong-screen screenshot' \
   || report 1 'fallback chair rejects a wrong-screen screenshot'
-( cd "$ROOT" && grep -q 'predates the newest commit that touched a path it exercises' scripts/chair-fallback.mjs ) \
+fallback_rule | grep -q 'predates the newest commit that touched a path it exercises' \
   && report 0 'fallback chair rejects stale evidence' \
   || report 1 'fallback chair rejects stale evidence'
 

--- a/scripts/proof-gate.test.sh
+++ b/scripts/proof-gate.test.sh
@@ -17,6 +17,17 @@ report() {
   else printf 'FAIL  %s\n' "$2"; fails=$((fails + 1)); fi
 }
 
+# Path 0: action.yml must actually wire the `require_proof` input to both env
+# vars. Paths 1 and 2 below inject REQUIRE_PROOF/VCR_REQUIRE_PROOF directly, so
+# they'd stay green even if this wiring were broken or renamed — which is
+# exactly the class of bug this whole file exists to catch.
+grep -q 'REQUIRE_PROOF: ${{ inputs.require_proof }}' "$ROOT/action.yml" \
+  && report 0 'action.yml wires require_proof input to REQUIRE_PROOF' \
+  || report 1 'action.yml wires require_proof input to REQUIRE_PROOF'
+grep -q 'VCR_REQUIRE_PROOF: ${{ inputs.require_proof }}' "$ROOT/action.yml" \
+  && report 0 'action.yml wires require_proof input to VCR_REQUIRE_PROOF' \
+  || report 1 'action.yml wires require_proof input to VCR_REQUIRE_PROOF'
+
 # Path 1: the council scope lens.
 lens() { REQUIRE_PROOF="$1" node -e 'import("./scripts/council-config.mjs").then(m => process.stdout.write(m.LENSES.scope))'; }
 ( cd "$ROOT" && lens false | grep -q 'judge the evidence' ) && report 1 'scope lens drops the proof clause when off' || report 0 'scope lens drops the proof clause when off'

--- a/scripts/proof-gate.test.sh
+++ b/scripts/proof-gate.test.sh
@@ -77,35 +77,39 @@ chair true | grep -q 'leaves untested a code path this PR changes' && report 0 '
 # Path 3: the OpenRouter fallback chair. It runs only when every Claude
 # subscription has failed, and it had no proof rule at all — so an outage
 # silently turned proof off while the check still reported green.
-fallback() { VCR_REQUIRE_PROOF="$1" node --input-type=module -e '
-const src = await import("node:fs").then(m => m.readFileSync("scripts/chair-fallback.mjs", "utf8"));
-const on = process.env.VCR_REQUIRE_PROOF !== "false";
-const rule = src.includes("Judge the evidence too");
-const gated = src.includes("VCR_REQUIRE_PROOF !== \"false\"");
-process.stdout.write(rule && gated ? (on ? "on" : "off") : "missing");
+#
+# This calls the real function rather than grepping the file. The first version
+# greped for two literal strings, so an inverted ternary or a typo'd env name
+# would have kept every assertion green while the gate did nothing.
+fallback() { VCR_REQUIRE_PROOF="$1" node -e '
+const m = await import("./scripts/chair-fallback.mjs");
+process.stdout.write(m.buildProofRule() === "" ? "off" : "on");
 '; }
 ( cd "$ROOT" && [ "$(fallback true)" = on ] ) \
-  && report 0 'fallback chair carries a proof rule, gated on the flag' \
-  || report 1 'fallback chair carries a proof rule, gated on the flag'
+  && report 0 'fallback chair builds a proof rule by default' \
+  || report 1 'fallback chair builds a proof rule by default'
+( cd "$ROOT" && [ "$(fallback false)" = off ] ) \
+  && report 0 'fallback chair drops the rule when require_proof is false' \
+  || report 1 'fallback chair drops the rule when require_proof is false'
 ( cd "$ROOT" && grep -q 'PR title, body and linked issues' scripts/chair-fallback.mjs ) \
   && report 0 'fallback chair is sent the body it must judge' \
   || report 1 'fallback chair is sent the body it must judge'
 
-# The fallback chair's rule must carry the SAME criteria as the primary chair's
-# and the scope lens's, not just any proof rule. A rule that demands evidence
-# but never checks for a wrong-screen screenshot or a stale capture is a
-# weaker gate hiding behind the same "proof required" label.
-# The rule is wrapped over several lines in the source, so squeeze the
-# whitespace before matching. A grep for a phrase that happens to straddle a
-# line break fails on the formatting rather than on the rule, which is how a
-# passing test starts reporting a missing criterion that is right there.
-fallback_rule() { tr -s '[:space:]' ' ' < "$ROOT/scripts/chair-fallback.mjs"; }
-fallback_rule | grep -q 'embedded screenshot shows a screen this diff does not touch' \
-  && report 0 'fallback chair rejects a wrong-screen screenshot' \
-  || report 1 'fallback chair rejects a wrong-screen screenshot'
-fallback_rule | grep -q 'predates the newest commit that touched a path it exercises' \
-  && report 0 'fallback chair rejects stale evidence' \
-  || report 1 'fallback chair rejects stale evidence'
+# This chair has no tools: no image bytes, no commit dates. It must not claim a
+# check it cannot perform, and it must say who can.
+rule() { cd "$ROOT" && node -e '
+const m = await import("./scripts/chair-fallback.mjs");
+process.stdout.write(m.buildProofRule(true));
+' | tr -s '[:space:]' ' '; }
+rule | grep -q 'shows a screen this diff does not touch' \
+  && report 1 'fallback chair does not rule on what a screenshot depicts' \
+  || report 0 'fallback chair does not rule on what a screenshot depicts'
+rule | grep -q 'predates the newest commit' \
+  && report 1 'fallback chair does not rule on stale evidence' \
+  || report 0 'fallback chair does not rule on stale evidence'
+rule | grep -q 'full-tool chair must judge those' \
+  && report 0 'fallback chair says who can judge those' \
+  || report 1 'fallback chair says who can judge those'
 
 [ "$fails" = 0 ] || { printf '\n%s failing\n' "$fails" >&2; exit 1; }
 printf '\nall passing\n'

--- a/scripts/proof-gate.test.sh
+++ b/scripts/proof-gate.test.sh
@@ -91,5 +91,16 @@ process.stdout.write(rule && gated ? (on ? "on" : "off") : "missing");
   && report 0 'fallback chair is sent the body it must judge' \
   || report 1 'fallback chair is sent the body it must judge'
 
+# The fallback chair's rule must carry the SAME criteria as the primary chair's
+# and the scope lens's, not just any proof rule. A rule that demands evidence
+# but never checks for a wrong-screen screenshot or a stale capture is a
+# weaker gate hiding behind the same "proof required" label.
+( cd "$ROOT" && grep -q 'embedded screenshot shows a screen this diff does not touch' scripts/chair-fallback.mjs ) \
+  && report 0 'fallback chair rejects a wrong-screen screenshot' \
+  || report 1 'fallback chair rejects a wrong-screen screenshot'
+( cd "$ROOT" && grep -q 'predates the newest commit that touched a path it exercises' scripts/chair-fallback.mjs ) \
+  && report 0 'fallback chair rejects stale evidence' \
+  || report 1 'fallback chair rejects stale evidence'
+
 [ "$fails" = 0 ] || { printf '\n%s failing\n' "$fails" >&2; exit 1; }
 printf '\nall passing\n'


### PR DESCRIPTION
Closes #33

## What

The scope council member now also judges the evidence in the PR body, the chair asks for the capture that would settle a gap, and a new `require_proof` input turns the whole thing off in a repo where nothing is ever visible. The chair also reads `VISION.md` when the repo has one.

## Why

The council could tell whether a diff did one thing. It could not tell whether the author had shown that the thing works, and an agent writes "tested locally" for free. That line was passing review.

The scope member already receives the PR body as context, so extending its lens costs nothing. A sixth council seat would have cost another OpenRouter call on every PR in 80 repos to read text one member already had.

Neither the member nor the chair ever produces evidence. A chair that invents a screenshot defeats the check it is running.

## How I verified

All of this is re-run at `1eb6fc5`, the current HEAD. Two earlier versions of this section were stale — the first tested only `council-config.mjs` and said nothing about the `action.yml` gating that `e6df843` added; the second predated the two `action.yml` assertions that `988a496` added; the third predated the fallback chair that `9b4a604` fixed. The lens caught both, on its own pull request, which is the only demonstration of it that is worth anything.

```
$ bash scripts/proof-gate.test.sh
ok    action.yml wires require_proof input to REQUIRE_PROOF
ok    action.yml wires require_proof input to VCR_REQUIRE_PROOF
ok    action.yml wires require_proof to the fallback chair too
ok    action.yml gives the fallback chair the PR body
ok    scope lens drops the proof clause when off
ok    scope lens keeps the proof clause when on
ok    chair bullet turns off when require_proof is false
ok    chair bullet drops the demand when off
ok    chair bullet demands evidence by default
ok    an unset flag defaults to demanding evidence
ok    chair asks for evidence covering every changed path
ok    scope lens asks for evidence covering every changed path
ok    fallback chair builds a proof rule by default
ok    fallback chair drops the rule when require_proof is false
ok    fallback chair is sent the body it must judge
ok    fallback chair does not rule on what a screenshot depicts
ok    fallback chair does not rule on stale evidence
ok    fallback chair says who can judge those

all passing
```

The fallback chair applies fewer criteria than the other two, on purpose. It has
no tools: no image bytes, no commit dates. It cannot rule on what a screenshot
depicts or on whether a capture is stale, so it says the full-tool chair must
judge those instead of claiming a check it cannot run. Three assertions pin that
it stays quiet about both, and one pins that it says who can.

Each fallback assertion calls `buildProofRule` rather than grepping the file.
The first version grepped for two literal strings, so an inverted ternary kept
every assertion green while the gate did nothing — inverting it now fails two.

The cycle-2 review of this pull request was itself posted by the OpenRouter
fallback chair, and it judged no evidence at all. The reason was a third code
path nobody had counted: the fallback carried no proof rule and never received
the body to judge one against, so a Claude subscription outage silently turned
proof off while the check still reported green. `9b4a604` closes it, and the
four new assertions pin it.

Every assertion covering all three halves of the switch: `scripts/council-config.mjs` (the scope member's lens string) and `action.yml` (the chair's own proof paragraph, which `e6df843` fixed after the first commit gated only the former). The two `action.yml` wiring assertions are static, so they fail if the input is ever renamed on one side of the boundary and not the other.

The rest of the branch:

```
$ node scripts/council-review.mjs --selfcheck
selfcheck ok

$ python3 -c "import yaml; d=yaml.safe_load(open('action.yml')); print('action.yml parses,', len(d['inputs']), 'inputs')"
action.yml parses, 15 inputs
```

Proof: n/a — a prompt string and a lens string, with no user-visible surface. Their behaviour under every setting of the input is asserted by the nine checks above.

Assisted-by: claude-personal-1:claude-opus-5



