### PR TITLE
[VCR-36] Retry the CLI download instead of losing the review

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -141,7 +141,15 @@ runs:
         if command -v claude >/dev/null 2>&1 || [ -x "$HOME/.local/bin/claude" ]; then
           echo "Claude Code CLI already present; skipping install."
         else
-          curl -fsSL https://claude.ai/install.sh | bash
+          # Retry the download. Every later step -- the council fan-out, all
+          # three chair attempts, the OpenRouter fallback -- runs after this
+          # one, so a single connection reset here loses the whole review and
+          # none of those fallbacks gets a turn. --retry-all-errors is the
+          # flag that makes a reset retryable: on its own --retry covers
+          # transient HTTP statuses and timeouts, and a reset is neither.
+          curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+            https://claude.ai/install.sh -o "$RUNNER_TEMP/install-claude.sh"
+          bash "$RUNNER_TEMP/install-claude.sh"
         fi
 
     - name: Fix-cycle guard


### PR DESCRIPTION
Closes #36

## What

Retries the Claude Code CLI download in `action.yml`, with `--retry-all-errors` so a connection reset counts as retryable.

## Why

The install ran as one unretried request. On `pooriaarab/scripts` PR #67 it returned `curl: (35) Recv failure: Connection reset by peer` after 436ms, and the step's `pipefail` turned that into a red check. Everything downstream was skipped — the council fan-out, all three chair attempts, and the OpenRouter fallback.

That chain exists so one dead component cannot lose a review. All of it sits after this step, so this step was the one link with no fallback of its own.

`--retry-all-errors` is the load-bearing flag, not `--retry`. On its own, `--retry` covers transient HTTP statuses and timeouts. A connection reset is neither, so plain `--retry` would not have saved that run.

## How I verified

Reading the flag documentation is not evidence, so I reproduced the exact failure against a local server that resets its first two connections and serves the third.

Without the flag, curl gives up on the first reset:

```
$ curl -fsSL --retry 5 --retry-delay 1 "http://127.0.0.1:$PORT/install.sh" -o out.sh
curl: (56) Recv failure: Connection reset by peer
exit=56
```

With it, both resets are absorbed and the script downloads and runs:

```
$ curl -fsSL --retry 5 --retry-delay 1 --retry-all-errors "http://127.0.0.1:$PORT/install.sh" -o out.sh
curl: (56) Recv failure: Connection reset by peer
curl: (56) Recv failure: Connection reset by peer
exit=0
$ bash out.sh
INSTALLED
```

`action.yml` still parses as YAML after the change.

Proof: n/a — a CI-only change with no user-visible surface; its behaviour is the exit codes above.

Assisted-by: claude-personal-1:claude-opus-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI installation reliability by retrying interrupted or failed downloads.
  - Added delays between retry attempts and handling for broader download errors.
  - Downloads are now completed before installation begins, reducing failures caused by interrupted transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->