### PR TITLE
[VCR-38] Repair a chair reply that is not strict JSON

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
       - name: Selfcheck
-        run: node scripts/council-review.mjs --selfcheck
+        run: npm run selfcheck
       - name: Publish
         run: npm publish
         env:

--- a/.github/workflows/oxlint.yml
+++ b/.github/workflows/oxlint.yml
@@ -14,3 +14,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - name: oxlint (agent budgets — warn-only, ratchet to error later)
         run: bunx oxlint@^1 --config .oxlintrc.json
+      # The selfchecks used to run only at publish time, so a broken parser
+      # reached every consumer before anything went red. Run them per PR.
+      - name: selfcheck
+        run: npm run selfcheck

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "vibecodereview": "bin/vibecodereview.mjs"
   },
   "scripts": {
-    "selfcheck": "node scripts/council-review.mjs --selfcheck",
+    "selfcheck": "node scripts/council-review.mjs --selfcheck && node scripts/chair-fallback.mjs --selfcheck",
     "mcp": "node mcp/server.mjs"
   },
   "files": [

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -84,13 +84,55 @@ async function askChair(diff, council, diffTruncated) {
   }
 }
 
+// A model writing markdown inside a JSON string breaks that string two ways:
+// an escape JSON does not define (`\_`, `\*`, a lone backslash copied out of a
+// diff or a regex) and a raw newline or tab. Both are recoverable, and losing
+// an entire review to one stray backslash is exactly what a fallback exists to
+// prevent. Repairs only what is invalid; a well-formed reply is unchanged.
+const VALID_ESCAPE = new Set(['"', "\\", "/", "b", "f", "n", "r", "t", "u"]);
+const CONTROL_ESCAPE = { "\n": "\\n", "\r": "\\r", "\t": "\\t", "\b": "\\b", "\f": "\\f" };
+
+function repairJsonStrings(text) {
+  let out = "";
+  let inString = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (!inString) {
+      inString = ch === '"';
+      out += ch;
+    } else if (ch === '"') {
+      inString = false;
+      out += ch;
+    } else if (ch === "\\") {
+      const next = text[i + 1];
+      if (next === undefined) out += "\\\\";
+      else {
+        out += VALID_ESCAPE.has(next) ? ch + next : "\\\\" + next;
+        i++;
+      }
+    } else if (ch < " ") {
+      out += CONTROL_ESCAPE[ch] || `\\u${ch.charCodeAt(0).toString(16).padStart(4, "0")}`;
+    } else out += ch;
+  }
+  return out;
+}
+
 // A model told to emit JSON still sometimes wraps it in a fence or prose. Take
 // the outermost braces rather than failing the whole review on formatting.
 function parseVerdict(text) {
   const start = text.indexOf("{");
   const end = text.lastIndexOf("}");
   if (start === -1 || end <= start) throw new Error(`no JSON object in chair reply: ${truncate(text, 200)}`);
-  return JSON.parse(text.slice(start, end + 1));
+  const candidate = text.slice(start, end + 1);
+  try {
+    return JSON.parse(candidate);
+  } catch (err) {
+    try {
+      return JSON.parse(repairJsonStrings(candidate));
+    } catch {
+      throw new Error(`chair reply is not JSON even after repair: ${err.message}`);
+    }
+  }
 }
 
 // One normalization, used by both the rendered body and the verdict. Two
@@ -158,7 +200,37 @@ function renderBody(parsed, findings, { diffTruncated } = {}) {
   return lines.join("\n");
 }
 
+// Offline shape check, no network: node chair-fallback.mjs --selfcheck
+function selfcheck() {
+  // The reply that lost a whole review on PR #27: markdown underscores escaped
+  // the markdown way, which JSON does not define.
+  const escaped = parseVerdict(String.raw`{"verdict":"comment","summary":"see \_foo\_ and C:\path","findings":[]}`);
+  if (!escaped.summary.includes("foo")) throw new Error("selfcheck: invalid escape not repaired");
+
+  // A raw newline inside a string is the other way a markdown-writing model
+  // breaks its own JSON.
+  const raw = parseVerdict('{"verdict":"comment","summary":"line one\nline two","findings":[]}');
+  if (!raw.summary.includes("line two")) throw new Error("selfcheck: raw control character not repaired");
+
+  // Well-formed JSON must survive untouched — the repair is a fallback, not a
+  // rewrite. \n stays a newline; it must not become a literal backslash-n.
+  const clean = parseVerdict('{"verdict":"approve","summary":"a\\nb","findings":[]}');
+  if (clean.summary !== "a\nb") throw new Error("selfcheck: valid escape was mangled: " + JSON.stringify(clean.summary));
+
+  // Repair is not a licence to accept anything: a truncated object still fails.
+  let threw = false;
+  try {
+    parseVerdict('{"verdict":"comment","summary":');
+  } catch {
+    threw = true;
+  }
+  if (!threw) throw new Error("selfcheck: malformed JSON was accepted");
+
+  console.log("chair-fallback selfcheck passed");
+}
+
 async function main() {
+  if (process.argv.includes("--selfcheck")) return selfcheck();
   const [diffFile, councilFile] = process.argv.slice(2);
   const repo = process.env.GITHUB_REPOSITORY;
   const pr = process.env.PR_NUMBER;

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -91,6 +91,13 @@ async function askChair(diff, council, diffTruncated) {
 // prevent. Repairs only what is invalid; a well-formed reply is unchanged.
 const VALID_ESCAPE = new Set(['"', "\\", "/", "b", "f", "n", "r", "t", "u"]);
 const CONTROL_ESCAPE = { "\n": "\\n", "\r": "\\r", "\t": "\\t", "\b": "\\b", "\f": "\\f" };
+const HEX4 = /^[0-9a-fA-F]{4}/;
+// A backslash right before a quote is a genuine `\"` escape only if the string
+// keeps going afterward. If what follows (past whitespace) is a structural
+// JSON character, that quote is the real closing quote and the backslash is a
+// stray one — e.g. a Windows path ending in `\` — so treating it as `\"`
+// would swallow the closing quote and run the string past the object's end.
+const STRUCTURAL_AFTER_STRING = /^\s*[,:}\]]/;
 
 function repairJsonStrings(text) {
   let out = "";
@@ -106,7 +113,13 @@ function repairJsonStrings(text) {
     } else if (ch === "\\") {
       const next = text[i + 1];
       if (next === undefined) out += "\\\\";
-      else if (VALID_ESCAPE.has(next)) {
+      else if (next === '"' && STRUCTURAL_AFTER_STRING.test(text.slice(i + 2))) {
+        out += "\\\\";
+      } else if (next === "u" && !HEX4.test(text.slice(i + 2, i + 6))) {
+        // `\u` is only a valid escape when 4 hex digits follow; otherwise it's
+        // a path like `C:\users`, and only the backslash is invalid.
+        out += "\\\\";
+      } else if (VALID_ESCAPE.has(next)) {
         out += ch + next;
         i++;
       } else {
@@ -228,6 +241,21 @@ function selfcheck() {
   const backslashNewline = parseVerdict('{"verdict":"comment","summary":"end \\\nnext","findings":[]}');
   if (!backslashNewline.summary.includes("next")) {
     throw new Error("selfcheck: control char after invalid escape not repaired");
+  }
+
+  // A path like `C:\users` has `\u` followed by non-hex characters — not a
+  // valid unicode escape. Only the backslash should be escaped; `u` and the
+  // rest of the path must survive untouched.
+  const badUnicode = parseVerdict(String.raw`{"verdict":"comment","summary":"see C:\users\config","findings":[]}`);
+  if (!badUnicode.summary.includes("C:\\users\\config")) {
+    throw new Error("selfcheck: invalid \\u escape not repaired: " + JSON.stringify(badUnicode.summary));
+  }
+
+  // A value ending in a lone backslash right before the real closing quote
+  // (e.g. a Windows path) must not have that quote swallowed as `\"`.
+  const trailingBackslash = parseVerdict(String.raw`{"verdict":"comment","summary":"C:\path\","findings":[]}`);
+  if (trailingBackslash.summary !== "C:\\path\\") {
+    throw new Error("selfcheck: trailing backslash before closing quote not repaired: " + JSON.stringify(trailingBackslash.summary));
   }
 
   // Repair is not a licence to accept anything: a truncated object still fails.

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -106,9 +106,14 @@ function repairJsonStrings(text) {
     } else if (ch === "\\") {
       const next = text[i + 1];
       if (next === undefined) out += "\\\\";
-      else {
-        out += VALID_ESCAPE.has(next) ? ch + next : "\\\\" + next;
+      else if (VALID_ESCAPE.has(next)) {
+        out += ch + next;
         i++;
+      } else {
+        // Only escape the backslash; leave `next` for the next iteration so a
+        // control character right after an invalid escape still gets escaped
+        // instead of being copied into the string raw.
+        out += "\\\\";
       }
     } else if (ch < " ") {
       out += CONTROL_ESCAPE[ch] || `\\u${ch.charCodeAt(0).toString(16).padStart(4, "0")}`;
@@ -216,6 +221,14 @@ function selfcheck() {
   // rewrite. \n stays a newline; it must not become a literal backslash-n.
   const clean = parseVerdict('{"verdict":"approve","summary":"a\\nb","findings":[]}');
   if (clean.summary !== "a\nb") throw new Error("selfcheck: valid escape was mangled: " + JSON.stringify(clean.summary));
+
+  // A raw control character right after an invalid escape (e.g. a stray
+  // backslash at the end of a copied line, immediately followed by the
+  // newline that ends it) must still get escaped, not copied through raw.
+  const backslashNewline = parseVerdict('{"verdict":"comment","summary":"end \\\nnext","findings":[]}');
+  if (!backslashNewline.summary.includes("next")) {
+    throw new Error("selfcheck: control char after invalid escape not repaired");
+  }
 
   // Repair is not a licence to accept anything: a truncated object still fails.
   let threw = false;

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -93,11 +93,14 @@ const VALID_ESCAPE = new Set(['"', "\\", "/", "b", "f", "n", "r", "t", "u"]);
 const CONTROL_ESCAPE = { "\n": "\\n", "\r": "\\r", "\t": "\\t", "\b": "\\b", "\f": "\\f" };
 const HEX4 = /^[0-9a-fA-F]{4}/;
 // A backslash right before a quote is a genuine `\"` escape only if the string
-// keeps going afterward. If what follows (past whitespace) is a structural
-// JSON character, that quote is the real closing quote and the backslash is a
-// stray one — e.g. a Windows path ending in `\` — so treating it as `\"`
-// would swallow the closing quote and run the string past the object's end.
-const STRUCTURAL_AFTER_STRING = /^\s*[,:}\]]/;
+// keeps going afterward. If what follows is unambiguously the START of the
+// NEXT token — end of container (`}`/`]`), a bare `:` (this string was a key),
+// or `,` followed by another quoted key and `:` — that quote is the real
+// closing quote and the backslash is a stray one, e.g. a Windows path ending
+// in `\`. A bare `,` is NOT enough on its own: prose routinely quotes a word
+// and continues with a comma ("say \"hi\", and ..."), which is a `\"` mid-string,
+// not a closing quote, even though a comma follows it too.
+const STRUCTURAL_AFTER_STRING = /^\s*(?:[}\]]|:|,\s*"[^"\\]*"\s*:)/;
 
 function repairJsonStrings(text) {
   let out = "";
@@ -147,8 +150,8 @@ function parseVerdict(text) {
   } catch (err) {
     try {
       return JSON.parse(repairJsonStrings(candidate));
-    } catch {
-      throw new Error(`chair reply is not JSON even after repair: ${err.message}`);
+    } catch (repairErr) {
+      throw new Error(`chair reply is not JSON even after repair: ${err.message} (repair attempt: ${repairErr.message})`);
     }
   }
 }
@@ -256,6 +259,19 @@ function selfcheck() {
   const trailingBackslash = parseVerdict(String.raw`{"verdict":"comment","summary":"C:\path\","findings":[]}`);
   if (trailingBackslash.summary !== "C:\\path\\") {
     throw new Error("selfcheck: trailing backslash before closing quote not repaired: " + JSON.stringify(trailingBackslash.summary));
+  }
+
+  // A genuine `\"` mid-sentence (a quoted word) followed by a comma must NOT
+  // be mistaken for the real closing quote just because a comma follows it —
+  // prose does this constantly ("say \"hi\", and ..."). Combined with an
+  // unrelated invalid escape elsewhere (forcing the repair path to run at
+  // all), this used to truncate the string at the quoted word and fail the
+  // whole reply.
+  const quoteThenComma = parseVerdict(
+    String.raw`{"verdict":"comment","summary":"say \"hi\", and \_bold\_ done","findings":[]}`
+  );
+  if (quoteThenComma.summary !== 'say "hi", and \\_bold\\_ done') {
+    throw new Error("selfcheck: quoted phrase before comma misread as closing quote: " + JSON.stringify(quoteThenComma.summary));
   }
 
   // Repair is not a licence to accept anything: a truncated object still fails.


### PR DESCRIPTION
Closes #38

## What

`parseVerdict` in `scripts/chair-fallback.mjs` now parses strictly first and, only on failure, repairs the two ways a markdown-writing model breaks its own JSON string: an escape JSON does not define (`\_`, `\*`, a lone backslash out of a diff or a regex) and a raw control character. A well-formed reply is untouched. A genuinely malformed one still throws.

The selfchecks also now run on every pull request, not only in `npm-publish`, and `npm run selfcheck` covers the fallback chair's parser as well as the council's.

## Why

The fallback chair is the last line of defence when every Claude token fails. On #27 it lost the entire review to one stray backslash:

```
Fallback chair failed: Bad escaped character in JSON at position 608 (line 1 column 609)
chair review failed (primary=failure, backup=failure, third=skipped, fallback=failure)
```

A fallback that deletes the review it exists to preserve is worse than no fallback, because the red check reads as a code problem.

Running the selfchecks only at publish time meant a broken parser shipped to every consumer before anything went red.

## How I verified

- `node scripts/chair-fallback.mjs --selfcheck` passes. It covers the exact reply shape that failed on #27, a raw newline inside a string, a well-formed reply surviving untouched (`\n` stays a newline and does not become a literal backslash-n), and a truncated object still throwing.
- Confirmed the check is load-bearing: `JSON.parse` on the same input without the repair fails with the reported error.
- `npm run selfcheck` runs both checks green.
- `bunx oxlint@^1 --config .oxlintrc.json` reports no new findings for the changed file.

Assisted-by: claude-personal-1:claude-opus-5