### PR TITLE
[VCR-35] Cap what one pull request may cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,35 @@ Two things to set, especially if agents open most of your PRs:
   cancels the run it superseded instead of stacking beside it. `init` already
   writes one into `vibecodereview.yml`; hand-written workflows often lack it.
 
+### The ceiling that stops a runaway
+
+`max_fix_cycles` caps how often the chair pushes. It caps nothing else, so a pull
+request can still be reviewed again and again while its author pushes, and the
+arithmetic above repeats every time. A pull request on its sixth review is not
+converging, and a seventh costs what the first cost.
+
+Two ceilings stop it. Both default on:
+
+| Input | Default | Counts |
+|---|---|---|
+| `max_council_runs` | `6` | completed runs of this workflow on the pull request |
+| `max_branch_runs` | `60` | runs of every workflow in the repo on the branch |
+
+Set either to `0` to disable it.
+
+Over the ceiling, the action skips the council and the chair, labels the pull
+request `needs-human`, and leaves one comment saying which ceiling it hit and
+what to decide. It edits that comment rather than posting another. **The check
+still passes.** A budget stop is a routing decision, not a verdict on the code,
+and a red check there would hide a real failure behind a bookkeeping one.
+
+Both numbers come from one API call. Real billable minutes need a request per
+run, which turns a guard against waste into a source of it — so the ceilings
+count runs, on the reasoning that every run of a workflow costs about what the
+last one did. `scripts/budget-guard.test.sh` pins the arithmetic, including the
+case that matters most: a failed lookup reads as "no spend yet", never as "out
+of budget", so an API blip cannot stop every review in the fleet.
+
 ```yaml
 concurrency:
   group: ci-${{ github.ref }}

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,14 @@ inputs:
     description: "Commits to fetch. The review only ever needs the diff (fetched from the API) plus enough history for the fix-cycle guard, so a full clone is wasted I/O on a large repo. Must exceed max_fix_cycles + 3. Set to 0 for a full clone."
     required: false
     default: "50"
+  max_council_runs:
+    description: "Stop after this many completed runs of this workflow on one pull request. A PR on its sixth review is not converging, and a seventh costs the same as the first. Set 0 to disable."
+    required: false
+    default: "6"
+  max_branch_runs:
+    description: "Stop after every workflow in the repo has, together, run this many times on the pull request's branch. Each fix commit re-runs them all, so this is the number that actually tracks spend. Set 0 to disable."
+    required: false
+    default: "60"
   council_timeout_ms:
     description: "Per-member deadline for the council fan-out. Members run in parallel, so this is the council's worst-case wall time. Omit for the 90s default."
     required: false
@@ -106,11 +114,60 @@ runs:
         # Same semantics as before: a failure to fetch context is a no-op,
         # never an error, and the council still runs.
 
+    # max_fix_cycles caps how often the chair pushes a fix. It caps nothing
+    # else, and a fix commit is a `synchronize` event that re-runs every
+    # workflow in the repo. So one pull request that will not converge quietly
+    # spends more machine time than ten that do, and no ceiling notices.
+    #
+    # Both ceilings come out of one API call on purpose. Real billable minutes
+    # need a request per run, which turns a guard against waste into a source of
+    # it. Run counts are the cheap proxy: every run of a workflow costs about
+    # what the last one did.
+    - name: Budget guard
+      id: budget
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        VCR_REPO: ${{ github.repository }}
+        VCR_BRANCH: ${{ github.event.pull_request.head.ref }}
+        VCR_WORKFLOW: ${{ github.workflow }}
+        VCR_MAX_COUNCIL: ${{ inputs.max_council_runs }}
+        VCR_MAX_BRANCH: ${{ inputs.max_branch_runs }}
+      run: |
+        set -euo pipefail
+        # A failed lookup must never stop a review. Degrade to an empty list, so
+        # an API blip reads as "no spend yet" rather than "out of budget".
+        RUNS=$(gh api "repos/$VCR_REPO/actions/runs?branch=$VCR_BRANCH&per_page=100" 2>/dev/null || echo '{"workflow_runs":[]}')
+        printf '%s' "$RUNS" | python3 -c '
+        import json, os, sys
+        runs = [r for r in (json.load(sys.stdin).get("workflow_runs") or [])
+                if r.get("head_branch") == os.environ["VCR_BRANCH"]]
+        council = sum(1 for r in runs
+                      if r.get("name") == os.environ["VCR_WORKFLOW"]
+                      and r.get("status") == "completed")
+        max_council = int(os.environ["VCR_MAX_COUNCIL"] or 0)
+        max_branch = int(os.environ["VCR_MAX_BRANCH"] or 0)
+        over = ""
+        if max_council and council >= max_council:
+            over = f"this review has already run {council} times on the pull request, and the ceiling is {max_council}"
+        elif max_branch and len(runs) >= max_branch:
+            over = f"the workflows in this repo have run {len(runs)} times on the branch, and the ceiling is {max_branch}"
+        with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+            out.write(f"over={str(bool(over)).lower()}\n")
+            out.write(f"council_runs={council}\n")
+            out.write(f"branch_runs={len(runs)}\n")
+            out.write(f"reason={over}\n")
+        print(f"council runs: {council}/{max_council}   branch runs: {len(runs)}/{max_branch}")
+        if over:
+            print("Over budget: " + over)
+        '
+
     # The council is network-bound and the setup below is not, so start the
     # fan-out here and collect it just before the chair. Everything between the
     # two steps — the CLI install, the fix-cycle guard, the prompt build — now
     # runs inside the council's own latency instead of after it.
     - name: Council fan-out (start)
+      if: steps.budget.outputs.over != 'true'
       shell: bash
       continue-on-error: true
       env:
@@ -354,7 +411,7 @@ runs:
     # token is dead, so order them best-credit-first.
     - name: Chair review (primary token)
       id: chair_primary
-      if: steps.chair_probe.outputs.token_1 != 'dead'
+      if: steps.budget.outputs.over != 'true' && steps.chair_probe.outputs.token_1 != 'dead'
       continue-on-error: true
       uses: anthropics/claude-code-action@v1
       with:
@@ -366,7 +423,7 @@ runs:
 
     - name: Chair review (backup token)
       id: chair_backup
-      if: steps.chair_primary.outcome != 'success' && steps.chair_probe.outputs.token_2 != 'dead' && inputs.claude_code_oauth_token_2 != ''
+      if: steps.budget.outputs.over != 'true' && steps.chair_primary.outcome != 'success' && steps.chair_probe.outputs.token_2 != 'dead' && inputs.claude_code_oauth_token_2 != ''
       continue-on-error: true
       uses: anthropics/claude-code-action@v1
       with:
@@ -378,7 +435,7 @@ runs:
 
     - name: Chair review (third token)
       id: chair_third
-      if: steps.chair_primary.outcome != 'success' && steps.chair_backup.outcome != 'success' && steps.chair_probe.outputs.token_3 != 'dead' && inputs.claude_code_oauth_token_3 != ''
+      if: steps.budget.outputs.over != 'true' && steps.chair_primary.outcome != 'success' && steps.chair_backup.outcome != 'success' && steps.chair_probe.outputs.token_3 != 'dead' && inputs.claude_code_oauth_token_3 != ''
       continue-on-error: true
       uses: anthropics/claude-code-action@v1
       with:
@@ -399,6 +456,7 @@ runs:
     - name: Chair fallback (OpenRouter)
       id: chair_fallback
       if: >-
+        steps.budget.outputs.over != 'true' &&
         steps.chair_primary.outcome != 'success' &&
         steps.chair_backup.outcome != 'success' &&
         steps.chair_third.outcome != 'success' &&
@@ -413,6 +471,48 @@ runs:
         CHAIR_FALLBACK_MODEL: ${{ inputs.chair_fallback_model }}
       run: node "${{ github.action_path }}/scripts/chair-fallback.mjs" pr.diff council-findings.md
 
+    # A budget stop is a routing decision, not a verdict on the code, so it
+    # leaves a comment and a label rather than a red check. It writes ONE
+    # comment and edits it after that: a pull request that stays over budget
+    # for five pushes must not collect five identical comments.
+    - name: Route the pull request to a person
+      if: steps.budget.outputs.over == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        VCR_REPO: ${{ github.repository }}
+        VCR_PR: ${{ github.event.pull_request.number }}
+        VCR_REASON: ${{ steps.budget.outputs.reason }}
+        VCR_COUNCIL_RUNS: ${{ steps.budget.outputs.council_runs }}
+        VCR_BRANCH_RUNS: ${{ steps.budget.outputs.branch_runs }}
+      run: |
+        set -euo pipefail
+        MARKER="<!-- vibecodereview:budget -->"
+        gh label create needs-human --repo "$VCR_REPO" --color B60205 \
+          --description "Automation stopped; a person has to decide" 2>/dev/null || true
+        gh issue edit "$VCR_PR" --repo "$VCR_REPO" --add-label needs-human >/dev/null
+        {
+          echo "$MARKER"
+          echo "### This pull request is over budget"
+          echo
+          echo "The review stopped without running, because $VCR_REASON."
+          echo
+          echo "- Council runs on this PR: $VCR_COUNCIL_RUNS"
+          echo "- Workflow runs on this branch: $VCR_BRANCH_RUNS"
+          echo
+          echo "Nothing here says the code is wrong. It says the automation is not"
+          echo "converging, and another cycle costs what the last one cost. Decide:"
+          echo "split the change, fix the failure the loop keeps missing, or raise"
+          echo "\`max_council_runs\` for this repo if the ceiling is simply too low."
+        } > budget-comment.md
+        EXISTING=$(gh api "repos/$VCR_REPO/issues/$VCR_PR/comments" --jq \
+          "[.[] | select(.body | startswith(\"$MARKER\")) | .id] | first // empty")
+        if [ -n "$EXISTING" ]; then
+          gh api "repos/$VCR_REPO/issues/comments/$EXISTING" -X PATCH -F body=@budget-comment.md --silent
+        else
+          gh api "repos/$VCR_REPO/issues/$VCR_PR/comments" -X POST -F body=@budget-comment.md --silent
+        fi
+
     - name: Chair result gate
       shell: bash
       run: |
@@ -420,6 +520,9 @@ runs:
         B="${{ steps.chair_backup.outcome }}"
         T="${{ steps.chair_third.outcome }}"
         F="${{ steps.chair_fallback.outcome }}"
+        if [ "${{ steps.budget.outputs.over }}" = "true" ]; then
+          echo "chair: skipped, the pull request is over budget"; exit 0
+        fi
         if [ "$P" = "success" ]; then echo "chair: primary token succeeded"; exit 0; fi
         if [ "$B" = "success" ]; then echo "chair: primary did not review ($P); backup token succeeded"; exit 0; fi
         if [ "$T" = "success" ]; then echo "chair: primary and backup failed; third token succeeded"; exit 0; fi

--- a/action.yml
+++ b/action.yml
@@ -141,10 +141,10 @@ runs:
         printf '%s' "$RUNS" | python3 -c '
         import json, os, sys
         runs = [r for r in (json.load(sys.stdin).get("workflow_runs") or [])
-                if r.get("head_branch") == os.environ["VCR_BRANCH"]]
+                if r.get("head_branch") == os.environ["VCR_BRANCH"]
+                and r.get("status") == "completed"]
         council = sum(1 for r in runs
-                      if r.get("name") == os.environ["VCR_WORKFLOW"]
-                      and r.get("status") == "completed")
+                      if r.get("name") == os.environ["VCR_WORKFLOW"])
         max_council = int(os.environ["VCR_MAX_COUNCIL"] or 0)
         max_branch = int(os.environ["VCR_MAX_BRANCH"] or 0)
         over = ""
@@ -505,8 +505,8 @@ runs:
           echo "split the change, fix the failure the loop keeps missing, or raise"
           echo "\`max_council_runs\` for this repo if the ceiling is simply too low."
         } > budget-comment.md
-        EXISTING=$(gh api "repos/$VCR_REPO/issues/$VCR_PR/comments" --jq \
-          "[.[] | select(.body | startswith(\"$MARKER\")) | .id] | first // empty")
+        EXISTING=$(gh api --paginate "repos/$VCR_REPO/issues/$VCR_PR/comments" | jq -s \
+          "[.[][] | select(.body | startswith(\"$MARKER\")) | .id] | first // empty")
         if [ -n "$EXISTING" ]; then
           gh api "repos/$VCR_REPO/issues/comments/$EXISTING" -X PATCH -F body=@budget-comment.md --silent
         else

--- a/action.yml
+++ b/action.yml
@@ -137,7 +137,12 @@ runs:
         set -euo pipefail
         # A failed lookup must never stop a review. Degrade to an empty list, so
         # an API blip reads as "no spend yet" rather than "out of budget".
-        RUNS=$(gh api "repos/$VCR_REPO/actions/runs?branch=$VCR_BRANCH&per_page=100" 2>/dev/null || echo '{"workflow_runs":[]}')
+        # branch is passed as a -f parameter, not interpolated into the query
+        # string: a branch name may legally contain "&" (git allows it), and a
+        # branch like "x&branch=some-empty-branch" would otherwise split the
+        # query string and silently read as under budget. -f switches gh api to
+        # POST unless --method GET is given, and this endpoint is GET-only.
+        RUNS=$(gh api "repos/$VCR_REPO/actions/runs" --method GET -f branch="$VCR_BRANCH" -f per_page=100 2>/dev/null || echo '{"workflow_runs":[]}')
         printf '%s' "$RUNS" | python3 -c '
         import json, os, sys
         # github.workflow is the display name in the workflow file, which is not

--- a/action.yml
+++ b/action.yml
@@ -49,11 +49,11 @@ inputs:
     required: false
     default: "50"
   max_council_runs:
-    description: "Stop after this many completed runs of this workflow on one pull request. A PR on its sixth review is not converging, and a seventh costs the same as the first. Set 0 to disable."
+    description: "Stop after this many completed runs of this workflow on one pull request. A PR on its sixth review is not converging, and a seventh costs the same as the first. Set 0 to disable. The lookback is the API's newest 100 runs on the branch, so values above ~100 may never trigger."
     required: false
     default: "6"
   max_branch_runs:
-    description: "Stop after every workflow in the repo has, together, run this many times on the pull request's branch. Each fix commit re-runs them all, so this is the number that actually tracks spend. Set 0 to disable."
+    description: "Stop after every workflow in the repo has, together, run this many times on the pull request's branch. Each fix commit re-runs them all, so this is the number that actually tracks spend. Set 0 to disable. The lookback is the API's newest 100 runs on the branch, so values above 100 will never trigger."
     required: false
     default: "60"
   council_timeout_ms:
@@ -130,7 +130,7 @@ runs:
         GH_TOKEN: ${{ inputs.github_token }}
         VCR_REPO: ${{ github.repository }}
         VCR_BRANCH: ${{ github.event.pull_request.head.ref }}
-        VCR_WORKFLOW: ${{ github.workflow }}
+        VCR_WORKFLOW_REF: ${{ github.workflow_ref }}
         VCR_MAX_COUNCIL: ${{ inputs.max_council_runs }}
         VCR_MAX_BRANCH: ${{ inputs.max_branch_runs }}
       run: |
@@ -140,11 +140,15 @@ runs:
         RUNS=$(gh api "repos/$VCR_REPO/actions/runs?branch=$VCR_BRANCH&per_page=100" 2>/dev/null || echo '{"workflow_runs":[]}')
         printf '%s' "$RUNS" | python3 -c '
         import json, os, sys
+        # github.workflow is the display name in the workflow file, which is not
+        # unique in a repo; identify by path (from workflow_ref) instead, so a
+        # second workflow that happens to share the name is never counted.
+        workflow_path = os.environ["VCR_WORKFLOW_REF"].split("@")[0].removeprefix(os.environ["VCR_REPO"] + "/")
         runs = [r for r in (json.load(sys.stdin).get("workflow_runs") or [])
                 if r.get("head_branch") == os.environ["VCR_BRANCH"]
                 and r.get("status") == "completed"]
         council = sum(1 for r in runs
-                      if r.get("name") == os.environ["VCR_WORKFLOW"])
+                      if r.get("path") == workflow_path)
         max_council = int(os.environ["VCR_MAX_COUNCIL"] or 0)
         max_branch = int(os.environ["VCR_MAX_BRANCH"] or 0)
         over = ""

--- a/scripts/budget-guard.test.sh
+++ b/scripts/budget-guard.test.sh
@@ -24,10 +24,12 @@ open(sys.argv[2], "w").write("\n".join(line[indent:] for line in lines[start:end
 PY
 
 fails=0
+WORKFLOW_PATH=".github/workflows/vibecodereview.yml"
 guard() {
   local runs="$1" max_council="$2" max_branch="$3"
   : > "$WORK/out"
-  printf '%s' "$runs" | GITHUB_OUTPUT="$WORK/out" VCR_BRANCH=feature VCR_WORKFLOW=vibecodereview \
+  printf '%s' "$runs" | GITHUB_OUTPUT="$WORK/out" VCR_BRANCH=feature VCR_REPO=o/r \
+    VCR_WORKFLOW_REF="o/r/$WORKFLOW_PATH@refs/heads/feature" \
     VCR_MAX_COUNCIL="$max_council" VCR_MAX_BRANCH="$max_branch" python3 "$WORK/guard.py" >/dev/null 2>&1
   grep '^over=' "$WORK/out" | cut -d= -f2
 }
@@ -37,19 +39,23 @@ check() {
   else printf 'FAIL  %s (want over=%s, got over=%s)\n' "$name" "$want" "$got"; fails=$((fails + 1)); fi
 }
 
-run() { printf '{"name":"%s","status":"completed","head_branch":"%s"}' "$1" "${2:-feature}"; }
-many() {  # many <count> <name> [branch]
+# Identify by path rather than by github.workflow's display name, which is not
+# unique in a repo — a second workflow file with the same `name:` must not
+# count toward this workflow's ceiling.
+run() { printf '{"path":"%s","status":"completed","head_branch":"%s"}' "$1" "${2:-feature}"; }
+many() {  # many <count> <path> [branch]
   local out="" i
   for i in $(seq "$1"); do [ -z "$out" ] || out="$out,"; out="$out$(run "$2" "${3:-feature}")"; done
   printf '{"workflow_runs":[%s]}' "$out"
 }
 
-check false 'a fresh branch is under budget'            "$(guard "$(many 1 vibecodereview)" 6 60)"
-check false 'one run below the council ceiling passes'  "$(guard "$(many 5 vibecodereview)" 6 60)"
-check true  'the council ceiling stops the review'      "$(guard "$(many 6 vibecodereview)" 6 60)"
-check true  'the branch ceiling stops the review'       "$(guard "$(many 8 build)" 6 8)"
-check false 'runs on another branch do not count'       "$(guard "$(many 9 vibecodereview other)" 6 60)"
-check false 'a zero ceiling disables that check'        "$(guard "$(many 9 vibecodereview)" 0 0)"
+check false 'a fresh branch is under budget'            "$(guard "$(many 1 "$WORKFLOW_PATH")" 6 60)"
+check false 'one run below the council ceiling passes'  "$(guard "$(many 5 "$WORKFLOW_PATH")" 6 60)"
+check true  'the council ceiling stops the review'      "$(guard "$(many 6 "$WORKFLOW_PATH")" 6 60)"
+check true  'the branch ceiling stops the review'       "$(guard "$(many 8 .github/workflows/build.yml)" 6 8)"
+check false 'runs on another branch do not count'       "$(guard "$(many 9 "$WORKFLOW_PATH" other)" 6 60)"
+check false 'a zero ceiling disables that check'        "$(guard "$(many 9 "$WORKFLOW_PATH")" 0 0)"
+check false 'a different workflow path does not count'  "$(guard "$(many 6 .github/workflows/other.yml)" 6 60)"
 
 # An API blip returns the empty list the action falls back to. Reading that as
 # "out of budget" would stop every review in the fleet on one bad request.
@@ -57,11 +63,11 @@ check false 'an empty run list is not over budget'      "$(guard '{"workflow_run
 
 # A run still in progress has not cost a full run yet, and counting it would
 # stop the very review that is running.
-check false 'an in-progress run does not count'         "$(guard '{"workflow_runs":[{"name":"vibecodereview","status":"in_progress","head_branch":"feature"},{"name":"vibecodereview","status":"in_progress","head_branch":"feature"},{"name":"vibecodereview","status":"in_progress","head_branch":"feature"},{"name":"vibecodereview","status":"in_progress","head_branch":"feature"},{"name":"vibecodereview","status":"in_progress","head_branch":"feature"},{"name":"vibecodereview","status":"in_progress","head_branch":"feature"}]}' 6 60)"
+check false 'an in-progress run does not count'         "$(guard '{"workflow_runs":[{"path":".github/workflows/vibecodereview.yml","status":"in_progress","head_branch":"feature"},{"path":".github/workflows/vibecodereview.yml","status":"in_progress","head_branch":"feature"},{"path":".github/workflows/vibecodereview.yml","status":"in_progress","head_branch":"feature"},{"path":".github/workflows/vibecodereview.yml","status":"in_progress","head_branch":"feature"},{"path":".github/workflows/vibecodereview.yml","status":"in_progress","head_branch":"feature"},{"path":".github/workflows/vibecodereview.yml","status":"in_progress","head_branch":"feature"}]}' 6 60)"
 
 # The same holds for the branch ceiling: several workflows queuing at once on a
 # fresh push must not look like spend that already happened.
-check false 'in-progress runs do not count toward the branch ceiling' "$(guard '{"workflow_runs":[{"name":"build","status":"in_progress","head_branch":"feature"},{"name":"build","status":"queued","head_branch":"feature"},{"name":"build","status":"in_progress","head_branch":"feature"},{"name":"build","status":"queued","head_branch":"feature"},{"name":"build","status":"in_progress","head_branch":"feature"},{"name":"build","status":"queued","head_branch":"feature"},{"name":"build","status":"in_progress","head_branch":"feature"},{"name":"build","status":"queued","head_branch":"feature"}]}' 6 8)"
+check false 'in-progress runs do not count toward the branch ceiling' "$(guard '{"workflow_runs":[{"path":".github/workflows/build.yml","status":"in_progress","head_branch":"feature"},{"path":".github/workflows/build.yml","status":"queued","head_branch":"feature"},{"path":".github/workflows/build.yml","status":"in_progress","head_branch":"feature"},{"path":".github/workflows/build.yml","status":"queued","head_branch":"feature"},{"path":".github/workflows/build.yml","status":"in_progress","head_branch":"feature"},{"path":".github/workflows/build.yml","status":"queued","head_branch":"feature"},{"path":".github/workflows/build.yml","status":"in_progress","head_branch":"feature"},{"path":".github/workflows/build.yml","status":"queued","head_branch":"feature"}]}' 6 8)"
 
 [ "$fails" = 0 ] || { printf '\n%s failing\n' "$fails" >&2; exit 1; }
 printf '\nall passing\n'

--- a/scripts/budget-guard.test.sh
+++ b/scripts/budget-guard.test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Drive the budget arithmetic that action.yml embeds.
+#
+# The guard decides whether a pull request gets a review at all, so both
+# directions matter. Stopping a PR that is still converging costs a review;
+# failing to stop one that is not costs machine time without end. The case that
+# matters most is the API blip: a lookup that fails must read as "no spend yet",
+# never as "out of budget".
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Extract the block from action.yml rather than copying it, so the test cannot
+# drift from what the action runs.
+python3 - "$(dirname "$HERE")/action.yml" "$WORK/guard.py" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+start = next(i for i, line in enumerate(lines) if line.strip() == "printf '%s' \"$RUNS\" | python3 -c '") + 1
+end = next(i for i in range(start, len(lines)) if lines[i].strip() == "'")
+indent = len(lines[start]) - len(lines[start].lstrip())
+open(sys.argv[2], "w").write("\n".join(line[indent:] for line in lines[start:end]) + "\n")
+PY
+
+fails=0
+guard() {
+  local runs="$1" max_council="$2" max_branch="$3"
+  : > "$WORK/out"
+  printf '%s' "$runs" | GITHUB_OUTPUT="$WORK/out" VCR_BRANCH=feature VCR_WORKFLOW=vibecodereview \
+    VCR_MAX_COUNCIL="$max_council" VCR_MAX_BRANCH="$max_branch" python3 "$WORK/guard.py" >/dev/null 2>&1
+  grep '^over=' "$WORK/out" | cut -d= -f2
+}
+check() {
+  local want="$1" name="$2" got="$3"
+  if [ "$got" = "$want" ]; then printf 'ok    %s\n' "$name"
+  else printf 'FAIL  %s (want over=%s, got over=%s)\n' "$name" "$want" "$got"; fails=$((fails + 1)); fi
+}
+
+run() { printf '{"name":"%s","status":"completed","head_branch":"%s"}' "$1" "${2:-feature}"; }
+many() {  # many <count> <name> [branch]
+  local out="" i
+  for i in $(seq "$1"); do [ -z "$out" ] || out="$out,"; out="$out$(run "$2" "${3:-feature}")"; done
+  printf '{"workflow_runs":[%s]}' "$out"
+}
+
+check false 'a fresh branch is under budget'            "$(guard "$(many 1 vibecodereview)" 6 60)"
+check false 'one run below the council ceiling passes'  "$(guard "$(many 5 vibecodereview)" 6 60)"
+check true  'the council ceiling stops the review'      "$(guard "$(many 6 vibecodereview)" 6 60)"
+check true  'the branch ceiling stops the review'       "$(guard "$(many 8 build)" 6 8)"
+check false 'runs on another branch do not count'       "$(guard "$(many 9 vibecodereview other)" 6 60)"
+check false 'a zero ceiling disables that check'        "$(guard "$(many 9 vibecodereview)" 0 0)"
+
+# An API blip returns the empty list the action falls back to. Reading that as
+# "out of budget" would stop every review in the fleet on one bad request.
+check false 'an empty run list is not over budget'      "$(guard '{"workflow_runs":[]}' 6 60)"
+
+# A run still in progress has not cost a full run yet, and counting it would
+# stop the very review that is running.
+check false 'an in-progress run does not count'         "$(guard '{"workflow_runs":[{"name":"vibecodereview","status":"in_progress","head_branch":"feature"},{"name":"vibecodereview","status":"in_progress","head_branch":"feature"},{"name":"vibecodereview","status":"in_progress","head_branch":"feature"},{"name":"vibecodereview","status":"in_progress","head_branch":"feature"},{"name":"vibecodereview","status":"in_progress","head_branch":"feature"},{"name":"vibecodereview","status":"in_progress","head_branch":"feature"}]}' 6 60)"
+
+[ "$fails" = 0 ] || { printf '\n%s failing\n' "$fails" >&2; exit 1; }
+printf '\nall passing\n'

--- a/scripts/budget-guard.test.sh
+++ b/scripts/budget-guard.test.sh
@@ -59,5 +59,9 @@ check false 'an empty run list is not over budget'      "$(guard '{"workflow_run
 # stop the very review that is running.
 check false 'an in-progress run does not count'         "$(guard '{"workflow_runs":[{"name":"vibecodereview","status":"in_progress","head_branch":"feature"},{"name":"vibecodereview","status":"in_progress","head_branch":"feature"},{"name":"vibecodereview","status":"in_progress","head_branch":"feature"},{"name":"vibecodereview","status":"in_progress","head_branch":"feature"},{"name":"vibecodereview","status":"in_progress","head_branch":"feature"},{"name":"vibecodereview","status":"in_progress","head_branch":"feature"}]}' 6 60)"
 
+# The same holds for the branch ceiling: several workflows queuing at once on a
+# fresh push must not look like spend that already happened.
+check false 'in-progress runs do not count toward the branch ceiling' "$(guard '{"workflow_runs":[{"name":"build","status":"in_progress","head_branch":"feature"},{"name":"build","status":"queued","head_branch":"feature"},{"name":"build","status":"in_progress","head_branch":"feature"},{"name":"build","status":"queued","head_branch":"feature"},{"name":"build","status":"in_progress","head_branch":"feature"},{"name":"build","status":"queued","head_branch":"feature"},{"name":"build","status":"in_progress","head_branch":"feature"},{"name":"build","status":"queued","head_branch":"feature"}]}' 6 8)"
+
 [ "$fails" = 0 ] || { printf '\n%s failing\n' "$fails" >&2; exit 1; }
 printf '\nall passing\n'


### PR DESCRIPTION
Closes #35

## What

Adds two spend ceilings to the action: `max_council_runs` (default 6) and `max_branch_runs` (default 60). Over either one, the review stops, labels the PR `needs-human`, and leaves one comment.

## Why

`max_fix_cycles` caps how often the chair pushes a fix. It caps nothing else. Every fix commit is a `synchronize` event that re-runs every workflow in the repo, so a pull request that will not converge quietly spends more machine time than ten that do, and nothing notices.

A pull request on its sixth review is not converging. A seventh costs what the first cost.

Three decisions worth stating:

- **The check still passes on a budget stop.** It is a routing decision, not a verdict on the code. A red check there would hide a real failure behind a bookkeeping one.
- **The ceilings count runs, not billable minutes.** Real minutes need one API request per run, which turns a guard against waste into a source of it. Both numbers here come from a single call, on the reasoning that every run of a workflow costs about what the last one did. The README says so plainly rather than implying the number is exact.
- **A failed lookup reads as "no spend yet".** The other way round, one bad API request stops every review in the fleet.

## How I verified

`scripts/budget-guard.test.sh` extracts the arithmetic out of `action.yml` — not a copy, so it cannot drift from what the action runs — and drives it directly.

```
$ ./scripts/budget-guard.test.sh
ok    a fresh branch is under budget
ok    one run below the council ceiling passes
ok    the council ceiling stops the review
ok    the branch ceiling stops the review
ok    runs on another branch do not count
ok    a zero ceiling disables that check
ok    an empty run list is not over budget
ok    an in-progress run does not count

all passing
```

```
$ python3 -c "import yaml; yaml.safe_load(open('action.yml'))"; echo $?
0
```

The council and all four chair attempts are gated on `steps.budget.outputs.over != 'true'`. That guard is on each attempt individually and not just the first, because the failover chain advances on `outcome != 'success'` and a skipped step reports `skipped`, so guarding only the primary would have let the backup token run the review the ceiling just refused.

Proof: n/a — a CI guard with no user-visible surface. Its outputs are the exit codes above and the PR comment, whose text is in the diff.

Assisted-by: claude-personal-1:claude-opus-5
