### PR TITLE
[VCR-47] Keep the council's scratch out of the commit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -199,7 +199,10 @@ runs:
         # Patterns are anchored to the workspace root (leading `/`) so a
         # legitimately named file elsewhere in the tree, e.g. tests/probe.js
         # or docs/pr.diff, is not silently excluded from the chair's commit.
-        printf '%s\n' /pr.diff /council-findings.md /council.log /council.pid '/probe.*' \
+        # Listed exactly (no `probe.*` glob) so a legitimately named
+        # `probe.<ext>` file elsewhere at the root is never swallowed.
+        printf '%s\n' /pr.diff /council-findings.md /council.log /council.pid \
+          /probe.1 /probe.2 /probe.3 /reason.1 /reason.2 /reason.3 \
           >> "$(git rev-parse --git-dir)/info/exclude"
         gh pr diff ${{ github.event.pull_request.number }} > pr.diff || true
         nohup node "${{ github.action_path }}/scripts/council-review.mjs" \

--- a/action.yml
+++ b/action.yml
@@ -189,6 +189,15 @@ runs:
         COUNCIL_TIMEOUT_MS: ${{ inputs.council_timeout_ms }}
         PR_CONTEXT_FILE: ${{ runner.temp }}/pr-context.txt
       run: |
+        # The council's scratch files live in the workspace, because the chair
+        # prompt tells it to `cat pr.diff` and read `council-findings.md`. But
+        # the chair's fix step runs `git add -A`, which sweeps them into the
+        # commit -- pooriaarab/skills#209 shipped council.log, council.pid,
+        # pr.diff and probe.1-3 into a public repo that way. Exclude them
+        # locally so `git add -A` cannot see them. .git/info/exclude is not
+        # committed, so this never touches the consumer repo's .gitignore.
+        printf '%s\n' pr.diff council-findings.md council.log council.pid 'probe.*' \
+          >> "$(git rev-parse --git-dir)/info/exclude"
         gh pr diff ${{ github.event.pull_request.number }} > pr.diff || true
         nohup node "${{ github.action_path }}/scripts/council-review.mjs" \
           pr.diff council-findings.md > council.log 2>&1 &

--- a/action.yml
+++ b/action.yml
@@ -196,7 +196,10 @@ runs:
         # pr.diff and probe.1-3 into a public repo that way. Exclude them
         # locally so `git add -A` cannot see them. .git/info/exclude is not
         # committed, so this never touches the consumer repo's .gitignore.
-        printf '%s\n' pr.diff council-findings.md council.log council.pid 'probe.*' \
+        # Patterns are anchored to the workspace root (leading `/`) so a
+        # legitimately named file elsewhere in the tree, e.g. tests/probe.js
+        # or docs/pr.diff, is not silently excluded from the chair's commit.
+        printf '%s\n' /pr.diff /council-findings.md /council.log /council.pid '/probe.*' \
           >> "$(git rev-parse --git-dir)/info/exclude"
         gh pr diff ${{ github.event.pull_request.number }} > pr.diff || true
         nohup node "${{ github.action_path }}/scripts/council-review.mjs" \


### PR DESCRIPTION
Closes #47

## What

Appends the council's scratch filenames to `.git/info/exclude` before the council starts, so the chair's `git add -A` cannot stage them.

## Why

`pooriaarab/skills#209` shipped `council-findings.md`, `council.log`, `council.pid`, `pr.diff`, `probe.1`, `probe.2` and `probe.3` into a public repository. The council's own review caught it as a Major finding, which is the only reason they did not stay.

The scratch files are in the workspace deliberately — the chair prompt tells it to `cat pr.diff` and read `council-findings.md`. The chair's fix step then runs `git add -A && git commit && git push`, and `git add -A` cannot tell the review's working files from the author's.

So this fires in **every** consumer repo, on any run where the chair pushes a fix. It went unnoticed because most runs comment and push nothing.

## Why this approach

`.git/info/exclude` is local and never committed, so a consumer repo's `.gitignore` is untouched, the paths stay where the prompt expects them, and the chair needs no change.

Two alternatives rejected:

- **Move the scratch to `$RUNNER_TEMP`.** Tidier as root-cause fixes go, but `claude-code-action` restricts the chair's file access to the workspace, so `cat pr.diff` would break and it would need prompt and permission changes too.
- **Narrow `git add -A` to `git add -u`.** Would stop the chair legitimately adding a new file as part of a fix.

## How I verified

In a scratch repository, with the exclude line applied and `pr.diff`, `council.log`, `probe.1`, `probe.2` and `real-file.md` all present, `git add -A` staged **only** `real-file.md`:

    A  real-file.md

Also `yaml.safe_load` on `action.yml`, and re-read the rendered block to confirm the `printf` and the heredoc quoting survived.

This is the third defect in this class found today, all of the same shape: a step that behaves correctly in isolation and wrongly once another step's output shares its directory. The other two were #43 (verdict cites pre-fix state) and #39 (chair reply not strict JSON).

Assisted-by: claude-personal-1:claude-opus-5