### PR TITLE
[VCR-17] Let the Claude subscriptions hold council seats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,11 @@ never fork its provider/lens logic into the surfaces.
 ## Rules
 
 - Zero runtime deps. Node ≥20, global `fetch` only. Do not add npm dependencies.
-- Providers: `openai`, `gemini`, `moonshot`, `openrouter`. Add one by extending
-  `PROVIDERS` + `DEFAULT_MODELS` in the engine only.
+- Providers: `openai`, `gemini`, `moonshot`, `openrouter`, `custom`, `claude`,
+  `claude2`. The last two are subscription-backed: they shell the Claude Code
+  CLI rather than POSTing, and add no npm dependency. Add one by extending
+  `PROVIDERS` in `council-config.mjs` (+ `DEFAULT_MODELS` if it should be on by
+  default).
 - A member with no API key must skip with a note, never throw.
 - The council uses a scope lens to verify atomicity and claim alignment. Set `PR_CONTEXT_FILE` to a file containing the author's claim (title, body, closed issues) to feed this lens.
 - A composite action's `inputs:` block must contain NO `${{ }}` expressions — not in a default AND not in a description string; GitHub parses them and fails at 'Set up job'. Callers pass github_token explicitly.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,33 @@ setting it cannot silently repoint the scope or maintainability lens (both also
 ride OpenRouter). It still shares `OPENROUTER_API_KEY` with those lenses, so an
 exhausted key takes all three out together, not just one.
 
+### Claude subscription seats
+
+Every other seat needs a metered API key, and those are what run dry — a repo
+can sit at three-of-four members returning HTTP 429 while the posted summary
+still lists four reviewers, so a PR looks multi-model reviewed when only the
+chair ran.
+
+A Claude Code OAuth token is not an API bearer, so it cannot hold a normal
+seat. The `claude` and `claude2` providers shell the Claude Code CLI (already
+installed for the chair) instead of POSTing, putting the cost on the
+subscription. `claude2` lets a second subscription hold a real seat rather
+than idling as the chair's failover token.
+
+```yaml
+council_models: >-
+  claude|claude-opus-5|Claude Opus 5|correctness,
+  claude2|claude-sonnet-5|Claude Sonnet 5|security,
+  openrouter|google/gemini-3.1-pro-preview|Gemini 3.1 Pro|performance,
+  openrouter|x-ai/grok-4.6|Grok 4.6|maintainability
+```
+
+The seats run with no tools, `--max-turns 1`, and a working directory outside
+the PR checkout — `claude -p` skips the workspace-trust prompt and would
+otherwise execute a repo-local `.claude/settings.json` hook with every secret
+in the step's environment. Set `CLI_TIMEOUT_MS` to change their budget
+(default 240000).
+
 ### Custom / OffRouter provider
 
 Point a council member at any OpenAI-compatible gateway: OpenRouter, a

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
     required: false
     default: "anthropic/claude-sonnet-5"
   council_models:
-    description: "Optional CSV override: provider|model|Name|lens,... (providers: openai, gemini, moonshot, openrouter)."
+    description: "Optional CSV override: provider|model|Name|lens,... (providers: openai, gemini, moonshot, openrouter, custom, claude, claude2). `claude`/`claude2` are subscription-backed seats that shell the Claude Code CLI using claude_code_oauth_token / _2 instead of a metered API key."
     required: false
   can_push_fixes:
     description: "If true, the chair may commit and push fixes to the PR branch."
@@ -193,6 +193,9 @@ runs:
         GEMINI_API_KEY: ${{ inputs.gemini_api_key }}
         MOONSHOT_API_KEY: ${{ inputs.moonshot_api_key }}
         OPENROUTER_API_KEY: ${{ inputs.openrouter_api_key }}
+        # Subscription-backed council seats (provider `claude` / `claude2`).
+        CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
+        CLAUDE_CODE_OAUTH_TOKEN_2: ${{ inputs.claude_code_oauth_token_2 }}
         COUNCIL_MODELS: ${{ inputs.council_models }}
         COUNCIL_TIMEOUT_MS: ${{ inputs.council_timeout_ms }}
         MUTATION_LENS: ${{ inputs.mutation_lens }}

--- a/scripts/claude-cli-seat.mjs
+++ b/scripts/claude-cli-seat.mjs
@@ -1,0 +1,82 @@
+// A Claude subscription seat: there is no OpenAI-compatible URL that accepts a
+// Claude Code OAuth token, so this seat shells the Claude Code CLI the action
+// already installs for the chair instead of POSTing to a chat endpoint.
+export async function callClaudeCli(model, diff, oauthToken, { instructions, timeoutMs }) {
+  const { execFile } = await import("node:child_process");
+  const os = await import("node:os");
+  // Short lens instructions on argv, the diff on stdin. Both forms work —
+  // `claude -p` does read a stdin-only prompt — but keeping the diff off argv
+  // is what avoids ARGV_MAX at MAX_DIFF_CHARS.
+  // Strip every other Anthropic auth source. The CLI PREFERS ANTHROPIC_API_KEY
+  // (and the Bedrock/Vertex switches) over a claude.ai login, so a caller that
+  // sets one at job level would silently take both seats off their own
+  // subscriptions — the precedence hole is invisible from the output.
+  //
+  // Also strip the unrelated secrets this step's env carries (GH_TOKEN, the
+  // other provider API keys). --allowed-tools "" and the os.tmpdir() cwd below
+  // already close the known ways a prompt-injected diff could get the CLI to
+  // read its env, but the seat never needs these values to do its job — don't
+  // leave them reachable as a second line of defense against a bypass in either
+  // of those controls.
+  const env = { ...process.env, CLAUDE_CODE_OAUTH_TOKEN: oauthToken };
+  for (const k of [
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_BASE_URL",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "CLAUDE_CODE_OAUTH_TOKEN_2", // a seat must only ever hold its own token
+    "GH_TOKEN",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "MOONSHOT_API_KEY",
+    "OPENROUTER_API_KEY",
+    "CUSTOM_API_KEY",
+  ]) {
+    delete env[k];
+  }
+  return new Promise((resolve) => {
+    const child = execFile(
+      "claude",
+      [
+        "-p",
+        instructions,
+        "--model",
+        model.model,
+        // No tools: the seat needs nothing but the diff on stdin. This also
+        // keeps an agentic loop from eating the timeout.
+        "--allowed-tools",
+        "",
+        "--max-turns",
+        "1",
+      ],
+      {
+        timeout: timeoutMs,
+        maxBuffer: 32 * 1024 * 1024,
+        env,
+        // NOT the PR checkout. `claude -p` skips the workspace-trust prompt and
+        // WILL execute a repo-local .claude/settings.json hook, and this step's
+        // env holds every API key plus GH_TOKEN. Running in the untrusted head
+        // branch would hand a PR author arbitrary execution with those secrets.
+        cwd: os.tmpdir(),
+      },
+      (err, stdout, stderr) => {
+        if (err) {
+          // The CLI reports auth failures on STDOUT and exits 1, so stderr is
+          // empty exactly when the reason matters most (dead/expired token).
+          const why = err.killed
+            ? "timed out"
+            : String(stderr || stdout || err.message).slice(0, 300);
+          return resolve({ model, error: why });
+        }
+        const text = String(stdout || "").trim();
+        resolve(text ? { model, text } : { model, error: "empty response" });
+      },
+    );
+    // A pending write to a child killed mid-stream emits EPIPE. Unhandled, that
+    // is an uncaughtException that exits non-zero BEFORE the findings file is
+    // written — one hung seat would destroy every other seat's review.
+    child.stdin?.on("error", () => {});
+    child.stdin?.end(diff);
+  });
+}

--- a/scripts/council-config.mjs
+++ b/scripts/council-config.mjs
@@ -13,6 +13,15 @@ export const PROVIDERS = {
   // Generic OpenAI-compatible endpoint (OpenRouter, self-hosted proxy, local
   // OffRouter). URL comes from env at call time; unset means the member skips.
   custom: { url: process.env.CUSTOM_BASE_URL, keyEnv: "CUSTOM_API_KEY" },
+  // Subscription-backed seats. These do NOT post to a chat endpoint -- no
+  // OpenAI-compatible URL accepts a Claude Code OAuth token -- so they shell
+  // the Claude Code CLI the action already installs for the chair. The cost
+  // lands on the Claude subscription instead of a metered API key, which is the
+  // whole point: the metered keys are what keep running dry.
+  // `claude2` exists so a second subscription can hold its own seat rather than
+  // idling as the chair's failover token.
+  claude: { cli: true, keyEnv: "CLAUDE_CODE_OAUTH_TOKEN" },
+  claude2: { cli: true, keyEnv: "CLAUDE_CODE_OAUTH_TOKEN_2" },
 };
 
 // Diverse lenses so each model catches what the others miss.

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -36,13 +36,15 @@ const MAX_DIFF_CHARS = 180_000; // bound tokens/cost on large PRs
 // reasoning model on a large diff. Raise COUNCIL_TIMEOUT_MS if a member you
 // value is being cut off — the per-member timings logged below tell you.
 const REQUEST_TIMEOUT_MS = Number(process.env.COUNCIL_TIMEOUT_MS) || 90_000;
+// A CLI seat spawns a process rather than issuing one POST, so it needs a
+// longer ceiling than the HTTP members.
+const CLI_TIMEOUT_MS = Number(process.env.CLI_TIMEOUT_MS || 240_000);
 
 // All providers expose an OpenAI-compatible /chat/completions endpoint
 // (Gemini via its OpenAI-compat URL), so one request shape serves all.
 import {
   PROVIDERS,
   LENSES,
-  OPENROUTER_EQUIVALENT,
   CREDENTIAL_FAILURE_STATUSES,
   openRouterFallbackFor,
   DEFAULT_MODELS,
@@ -50,6 +52,7 @@ import {
   diffAddsTestLines,
   selfcheckMutationRoster,
 } from "./council-config.mjs";
+import { callClaudeCli } from "./claude-cli-seat.mjs";
 
 function parseModels() {
   const csv = process.env.COUNCIL_MODELS?.trim();
@@ -88,6 +91,13 @@ async function callModel(model, diff) {
   const startedAt = Date.now();
   const timed = (r) => ({ ...r, ms: Date.now() - startedAt });
   const provider = PROVIDERS[model.provider];
+  // A subscription seat has no chat endpoint to POST to.
+  if (provider?.cli) {
+    const token = process.env[provider.keyEnv]?.trim();
+    if (!token) return timed({ model, error: `skipped: ${provider.keyEnv} not set` });
+    const instructions = `${systemPrompt(model.lens)}\n\nReview the PR diff piped on stdin.`;
+    return timed(await callClaudeCli(model, diff, token, { instructions, timeoutMs: CLI_TIMEOUT_MS }));
+  }
   if (provider && !provider.url) return timed({ model, error: "skipped: CUSTOM_BASE_URL not set" });
   const apiKey = provider && process.env[provider.keyEnv]?.trim();
   if (!apiKey) return timed({ model, error: `skipped: ${provider?.keyEnv || model.provider} not set` });
@@ -303,6 +313,20 @@ async function main() {
       fs.rmSync(testDir, { recursive: true, force: true });
     }
 
+
+    // A CLI-backed seat with no oauth token must skip too, not shell out --
+    // even when the ambient env sets one, so the check stays offline.
+    const savedToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    let cliSkip;
+    try {
+      cliSkip = await callModel({ provider: "claude", model: "x", name: "X", lens: "correctness" }, "diff");
+    } finally {
+      if (savedToken !== undefined) process.env.CLAUDE_CODE_OAUTH_TOKEN = savedToken;
+    }
+    if (!cliSkip.error?.includes("CLAUDE_CODE_OAUTH_TOKEN")) {
+      throw new Error("selfcheck: claude missing-token path wrong: " + cliSkip.error);
+    }
     console.log("selfcheck ok");
     return;
   }


### PR DESCRIPTION
Supersedes #17. Closes #17.

## What

Adds two subscription-backed council providers, `claude` and `claude2`, that shell the Claude Code CLI instead of POSTing to a chat endpoint. Transport lives in a new `scripts/claude-cli-seat.mjs`.

## Why

Every seat does one thing: `POST <url>/chat/completions` with a bearer token. So only a metered API key can hold a seat, and those are exactly what run dry. Observed on this account today, while doing other work:

| Member | Result |
| --- | --- |
| GPT-5.6 (Codex) | `429 insufficient_quota` |
| Gemini 3 Pro | `429` monthly spend cap exceeded |
| Kimi K3 | `429` account suspended |
| Grok 4.5 | ran |

The posted summary still listed four reviewers. A pull request looked multi-model reviewed when only the chair had run — the same false-completion shape as #43 and #47, and worse than the outage itself.

A Claude Code OAuth token is not an API bearer and no OpenAI-compatible URL accepts one, so the subscriptions with headroom could not be spent here. `claude2` also means a second subscription holds a real seat rather than idling as the chair's failover token.

## Security

The seat runs with no tools, `--max-turns 1`, a stripped environment (every other Anthropic auth source, the sibling seat's token, `GH_TOKEN`, and every provider key), and `cwd` outside the PR checkout. That last one matters: `claude -p` skips the workspace-trust prompt and would otherwise execute a repo-local `.claude/settings.json` hook with every secret in the step's environment — arbitrary execution for a PR author. A pending stdin write to a killed child is swallowed, because an unhandled `EPIPE` exits before the findings file is written and one hung seat would destroy every other seat's review.

## Why this supersedes #17 instead of rebasing it

#17 could not be replayed. Main has since moved `PROVIDERS`/`LENSES`/`DEFAULT_MODELS` into `council-config.mjs`, added a `timed()` wrapper, and added the scope and mutation lenses. Rebasing replayed six commits of the branch's own fix history, conflicted on each, and taking its `README.md`/`AGENTS.md` wholesale reverted 144 lines of newer documentation including the entire mutation-lens section.

This branch carries #17's **final** state, not its first draft — the hardening in `5588d06` and `ebb8724`, and the `84141f7` fix that puts the prompt on argv (`claude -p` needs a positional prompt; the first draft passed none, so every seat would have run promptless).

Two deliberate changes to what #17 had:

- The example `council_models` cited `claude-opus-4-5` and `claude-sonnet-4-5`. Updated to `claude-opus-5` / `claude-sonnet-5`.
- The seats went into `council-config.mjs` with the other providers, not back into the engine file.

## How I verified

- `npm run selfcheck` passes, including the ported check that a CLI seat with no token **skips** rather than shelling out — with `CLAUDE_CODE_OAUTH_TOKEN` deleted from the environment first, so the check stays offline.
- `oxlint` exits 0. It caught this at 301 lines against the 300-line cap; fixed by deleting a genuinely dead `OPENROUTER_EQUIVALENT` import rather than by raising the budget.
- `node --check` on both scripts, `yaml.safe_load` on `action.yml`.
- Confirmed a CLI seat survives the `servable` filter: `hasNativeKey` tests `keyEnv`, not `url`, so a seat with its token set is not dropped.
- Confirmed `README.md`/`AGENTS.md` now differ from `main` only by additions.

Not verified: a live seat actually reviewing. That needs the workflow to run with `council_models` naming a `claude` seat, which is the first thing to try after merge.

Assisted-by: claude-personal-1:claude-opus-5