### PR TITLE
[VCR-51] Add a vision the council can judge

### DIFF
--- a/.github/workflows/vibecodereview.yml
+++ b/.github/workflows/vibecodereview.yml
@@ -2,7 +2,11 @@ name: vibecodereview
 on:
   pull_request:
     types: [opened, synchronize, review_requested]
-    paths-ignore: ["**.md"]
+    # VISION.md is what the council reads to judge whether every OTHER
+    # pull request belongs here, and the markdown skip meant it was the
+    # one file the council never saw. A later negative pattern re-includes
+    # a path an earlier one ignored, so the rest of the markdown still skips.
+    paths-ignore: ["**.md", "!VISION.md"]
 concurrency:
   group: vibecodereview-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,65 @@
+# Vision — vibecodereview
+
+## What this is
+
+vibecodereview reviews a pull request with a council of AI models. Each model
+reads the diff through its own lens: correctness, performance, security,
+maintainability, scope, or test strength. Claude chairs the council. It checks
+every finding against the code, drops the false positives, fixes what it can
+confirm, pushes the fix as a commit on the pull request branch, and posts one
+review. The check heals itself toward green. You can run the council as a
+GitHub Action, as a CLI command, or through an MCP tool, and the CLI also
+reviews a local diff before you push.
+
+## Who it is for
+
+Solo developers who maintain many personal repositories and review their own
+pull requests. The tool sends diffs to third-party model providers, so the
+confidentiality note limits it to personal and private repositories and
+forbids proprietary or employer code. The first fleet is the maintainer's own:
+about 80 repositories run the action pinned at `@v1`, and rollout scripts fan
+new versions out to them. <!-- CHECK -->
+
+## What good looks like
+
+- Every pull request gets one review comment, and the chair has verified each
+  finding against the code before posting it.
+- A confirmed finding becomes a commit on the pull request branch without the
+  author writing it. Fix cycles are capped at three by default.
+- A missing key or a dead provider removes a member or skips the council step.
+  It never fails the check, and the review script always exits 0.
+- When `PR_CONTEXT_FILE` supplies the author's claim, the scope lens flags a
+  diff that does not match the pull request title, body, or linked issues.
+
+## Explicitly not this
+
+- Adding an npm runtime dependency. The rule is zero runtime dependencies on
+  Node 20 or later with global `fetch` only, and AGENTS.md says "Do not add
+  npm dependencies."
+- Copying provider or lens logic into `action.yml`, the CLI, or the MCP
+  server. The engine is the single source of truth, and a member or lens is
+  added only in `council-config.mjs`.
+- Making a provider failure fail the check or block the pull request. A member
+  without a key must skip with a note, never throw, and every failure is
+  non-fatal.
+- Running the mutations that the mutation lens proposes against a real test
+  suite. The README keeps the lens at propose-only and calls execution a
+  separate feature with a separate cost. <!-- CHECK -->
+- Building for review of proprietary or employer code. The confidentiality
+  section restricts the tool to personal and private repositories.
+
+## How it pays for itself
+
+No revenue appears anywhere in the repository. <!-- CHECK --> The package is
+MIT-licensed and free on npm, and it is part of the Vibe Suite. It pays for
+itself as an internal tool: it does the first-pass review the maintainer would
+otherwise do alone across the fleet that follows the `@v1` tag. A new council
+member costs one model call per pull request in every one of those repos. A
+chair fix is a commit on the branch, so every other `pull_request` workflow in
+a consumer repo re-runs, up to three cycles by default.
+
+## The current bet
+
+As of 2026-08-31, the bet is that the mutation lens, off by default today,
+names real weak tests often enough to earn its model call on every
+test-bearing diff, and it must prove that by 2026-11-30. <!-- CHECK -->


### PR DESCRIPTION
Closes #51

## What

Adds `VISION.md` at the root: what this repo is, who it is for, what good looks like, what it explicitly is not, how it pays for itself, and the current bet.

## Why

The checker asks whether a pull request is one thing. The council asks whether it is well built. Neither can ask whether the change belongs here, because nothing in the repo said what the repo is for. A change can pass every check, do exactly one thing, carry real proof, and still be the wrong change.

**"Explicitly not this" is the section that does the work.** Every other section tells a reviewer what to accept. Only that one tells it what to reject, and a vision that rejects nothing changes no review.

## Why the workflow file is in this pull request

This repo's `vibecodereview.yml` skips markdown, and the reason is sound: a
README typo does not need a five-model council. But that skip covered
`VISION.md` — so the one file the council reads to judge whether every *other*
pull request belongs here was the one file the council never saw, and a
docs-only vision could never be approved.

One line, `"!VISION.md"`, re-includes it. A later negative pattern overrides an
earlier positive one, so the rest of the markdown still skips the council.

It is in this pull request rather than a separate one because it is the same
act: "a vision the council can judge" is not true until the council can read it.
It also makes this pull request contain a non-markdown file, which is what gets
the council to review the vision itself — the check this change exists to
enable, running on the change that enables it.

## Why the council still has not reviewed this

I added the `"!VISION.md"` line to this branch so the council would stop skipping
markdown and read the vision. It does fix the path filter — but it cannot work
on *this* pull request, and the reason is worth recording.

`claude-code-action` refuses to run when a pull request modifies its own workflow
file:

```
Skipping action due to workflow validation: Workflow validation failed.
The workflow file must exist and have identical content to the version on
the repository's default branch.
Error is not retryable, giving up immediately
```

That control is correct. A pull request must not be able to edit the reviewer
that judges it. So the line has to be on the default branch before it helps, and
a pull request that carries it can never be reviewed by the thing it enables.

Worse, the check went **green** anyway: a skipped action still exits 0, so the
chair gate read `success` and reported "backup token succeeded". Filed as
[vibecodereview#83](https://github.com/pooriaarab/vibecodereview/issues/83) — a
green check with no review behind it is worse than a red one, because red gets
investigated and green gets merged.

So this pull request needs a human merge. After it lands, every later pull
request in this repo gets its `VISION.md` reviewed, which is the point.

## How I verified

The draft is sourced, not invented. Every claim comes from this repo's own docs, its directory names, and its recent commit subjects — the same inputs a reader can list:

```
$ git ls-files | grep -cE '^(README|AGENTS|CLAUDE)\.md$'   ->  2
$ git log --oneline -60 | wc -l   ->  33
```

Every file the draft's sources cite is then checked to exist in the tree, so a citation cannot point at a file that is not there:

```
vibecodereview     5 cited files, 0 missing
```

Lines the draft is not certain of carry an inline CHECK comment rather than a confident claim. Read those first: under-claiming with a marker is right, and confident invention is the failure this file would otherwise cause, because the council judges real changes against whatever text is here.

Proof: n/a — a documentation file with no runtime path and no visible surface.

Assisted-by: pi:glm-5.3-flash
Assisted-by: claude-personal-1:claude-opus-5


