### PR TITLE
[VCR-61] Adopt oxfmt as the formatter (part 1 of 3)

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://unpkg.com/oxfmt@0.65.0/configuration_schema.json",
+  "ignorePatterns": [
+    "**/vendor/**",
+    "**/third_party/**",
+    "**/generated/**",
+    "**/*.generated.*",
+    "**/*.min.js",
+    "**/*.min.css",
+    "**/*.bundle.js",
+    "**/dist/**",
+    "**/build/**",
+    "**/.next/**",
+    "**/.wrangler/**",
+    "**/.open-next/**",
+    "**/coverage/**"
+  ]
+}

--- a/bin/rollout.mjs
+++ b/bin/rollout.mjs
@@ -26,73 +26,73 @@
  * repos whose default branch already has the workflow.
  */
 
-import { execFileSync } from 'node:child_process';
+import { execFileSync } from "node:child_process";
 
 const SECRET_NAMES = [
-  'CLAUDE_CODE_OAUTH_TOKEN',
+  "CLAUDE_CODE_OAUTH_TOKEN",
   // The failover tokens. Leaving these out of the roster meant a rollout
   // wrote a workflow that could only ever use ONE subscription, so the whole
   // fleet went down together the moment that one capped out.
-  'CLAUDE_CODE_OAUTH_TOKEN_2',
-  'CLAUDE_CODE_OAUTH_TOKEN_3',
-  'OPENAI_API_KEY',
-  'GEMINI_API_KEY',
-  'MOONSHOT_API_KEY',
-  'OPENROUTER_API_KEY',
+  "CLAUDE_CODE_OAUTH_TOKEN_2",
+  "CLAUDE_CODE_OAUTH_TOKEN_3",
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "MOONSHOT_API_KEY",
+  "OPENROUTER_API_KEY",
 ];
 
-const WORKFLOW_PATH = '.github/workflows/vibecodereview.yml';
-const BRANCH = 'add-vibecodereview';
-const COMMIT_MESSAGE = 'Add vibecodereview council PR review';
-const PR_TITLE = 'Add vibecodereview council PR review';
+const WORKFLOW_PATH = ".github/workflows/vibecodereview.yml";
+const BRANCH = "add-vibecodereview";
+const COMMIT_MESSAGE = "Add vibecodereview council PR review";
+const PR_TITLE = "Add vibecodereview council PR review";
 const PR_BODY =
-  'Adds owner-gated LLM-council PR review (pooriaarab/vibecodereview@v1). ' +
-  'Set secrets are handled separately. Review before merge.';
+  "Adds owner-gated LLM-council PR review (pooriaarab/vibecodereview@v1). " +
+  "Set secrets are handled separately. Review before merge.";
 
 // The `${{ ... }}` sequences are literal GitHub Actions syntax. They sit in
 // plain JS strings, so JS never evaluates them. Do not convert to a template
 // literal.
 const WORKFLOW_YAML =
   [
-    'name: vibecodereview',
-    'on:',
-    '  pull_request:',
-    '    types: [opened, synchronize, review_requested]',
+    "name: vibecodereview",
+    "on:",
+    "  pull_request:",
+    "    types: [opened, synchronize, review_requested]",
     '    paths-ignore: ["**.md", "docs/**"]',
-    'concurrency:',
-    '  group: vibecodereview-${{ github.event.pull_request.number }}',
-    '  cancel-in-progress: true',
-    'jobs:',
-    '  review:',
+    "concurrency:",
+    "  group: vibecodereview-${{ github.event.pull_request.number }}",
+    "  cancel-in-progress: true",
+    "jobs:",
+    "  review:",
     "    # Only review the repo owner's own PRs (cost + injection guard on public repos).",
-    '    if: github.event.pull_request.user.login == github.repository_owner',
-    '    runs-on: ubuntu-latest',
-    '    timeout-minutes: 30',
-    '    permissions:',
-    '      contents: write',
-    '      pull-requests: write',
-    '      id-token: write',
-    '    steps:',
-    '      - uses: pooriaarab/vibecodereview@v1',
-    '        with:',
-    '          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}',
-    '          claude_code_oauth_token_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}',
-    '          claude_code_oauth_token_3: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_3 }}',
-    '          github_token: ${{ github.token }}',
-    '          openai_api_key: ${{ secrets.OPENAI_API_KEY }}',
-    '          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}',
-    '          moonshot_api_key: ${{ secrets.MOONSHOT_API_KEY }}',
-    '          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}',
-  ].join('\n') + '\n';
+    "    if: github.event.pull_request.user.login == github.repository_owner",
+    "    runs-on: ubuntu-latest",
+    "    timeout-minutes: 30",
+    "    permissions:",
+    "      contents: write",
+    "      pull-requests: write",
+    "      id-token: write",
+    "    steps:",
+    "      - uses: pooriaarab/vibecodereview@v1",
+    "        with:",
+    "          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}",
+    "          claude_code_oauth_token_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}",
+    "          claude_code_oauth_token_3: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_3 }}",
+    "          github_token: ${{ github.token }}",
+    "          openai_api_key: ${{ secrets.OPENAI_API_KEY }}",
+    "          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}",
+    "          moonshot_api_key: ${{ secrets.MOONSHOT_API_KEY }}",
+    "          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}",
+  ].join("\n") + "\n";
 
 function stderrOf(err) {
-  return String(err.stderr || '').trim() || String(err.code || 'unknown error');
+  return String(err.stderr || "").trim() || String(err.code || "unknown error");
 }
 
 function gh(args) {
-  return execFileSync('gh', args, {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
+  return execFileSync("gh", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
     maxBuffer: 16 * 1024 * 1024,
   });
 }
@@ -121,14 +121,14 @@ function setSecrets(repo, log, dryRun) {
     // Do not rethrow the raw error: execFileSync error messages quote the
     // full command line, which would leak the secret.
     try {
-      gh(['secret', 'set', name, '--repo', repo, '--body', value]);
+      gh(["secret", "set", name, "--repo", repo, "--body", value]);
     } catch (err) {
       throw new Error(`gh secret set ${name} failed: ${stderrOf(err)}`);
     }
     log(`secret ${name} set`);
   }
   if (!process.env.CLAUDE_CODE_OAUTH_TOKEN) {
-    log('WARNING: CLAUDE_CODE_OAUTH_TOKEN is empty; the chair reviewer will fail without it');
+    log("WARNING: CLAUDE_CODE_OAUTH_TOKEN is empty; the chair reviewer will fail without it");
   }
 }
 
@@ -138,9 +138,9 @@ function workflowExists(repo, log, dryRun) {
     log(`[dry-run] would run: gh api repos/${repo}/contents/${WORKFLOW_PATH}`);
     return false;
   }
-  const check = tryGh(['api', `repos/${repo}/contents/${WORKFLOW_PATH}`]);
+  const check = tryGh(["api", `repos/${repo}/contents/${WORKFLOW_PATH}`]);
   if (check.ok) {
-    log('workflow exists, skipping PR');
+    log("workflow exists, skipping PR");
     return true;
   }
   return false;
@@ -150,10 +150,20 @@ function resolveHead(repo, log, dryRun) {
   // 3a. Default branch.
   let defaultBranch;
   if (dryRun) {
-    log(`[dry-run] would run: gh repo view ${repo} --json defaultBranchRef --jq .defaultBranchRef.name`);
-    defaultBranch = '<default>';
+    log(
+      `[dry-run] would run: gh repo view ${repo} --json defaultBranchRef --jq .defaultBranchRef.name`,
+    );
+    defaultBranch = "<default>";
   } else {
-    defaultBranch = gh(['repo', 'view', repo, '--json', 'defaultBranchRef', '--jq', '.defaultBranchRef.name']).trim();
+    defaultBranch = gh([
+      "repo",
+      "view",
+      repo,
+      "--json",
+      "defaultBranchRef",
+      "--jq",
+      ".defaultBranchRef.name",
+    ]).trim();
     log(`default branch: ${defaultBranch}`);
   }
 
@@ -161,9 +171,9 @@ function resolveHead(repo, log, dryRun) {
   let sha;
   if (dryRun) {
     log(`[dry-run] would run: gh api repos/${repo}/git/ref/heads/<default> --jq .object.sha`);
-    sha = '<sha>';
+    sha = "<sha>";
   } else {
-    sha = gh(['api', `repos/${repo}/git/ref/heads/${defaultBranch}`, '--jq', '.object.sha']).trim();
+    sha = gh(["api", `repos/${repo}/git/ref/heads/${defaultBranch}`, "--jq", ".object.sha"]).trim();
   }
   return { defaultBranch, sha };
 }
@@ -171,12 +181,19 @@ function resolveHead(repo, log, dryRun) {
 function ensureBranch(repo, log, dryRun, sha) {
   // 3c. Create the scratch branch (reuse it if it already exists).
   if (dryRun) {
-    log(`[dry-run] would run: gh api --method POST repos/${repo}/git/refs -f ref=refs/heads/${BRANCH} -f sha=<sha>`);
+    log(
+      `[dry-run] would run: gh api --method POST repos/${repo}/git/refs -f ref=refs/heads/${BRANCH} -f sha=<sha>`,
+    );
   } else {
     const res = tryGh([
-      'api', '--method', 'POST', `repos/${repo}/git/refs`,
-      '-f', `ref=refs/heads/${BRANCH}`,
-      '-f', `sha=${sha}`,
+      "api",
+      "--method",
+      "POST",
+      `repos/${repo}/git/refs`,
+      "-f",
+      `ref=refs/heads/${BRANCH}`,
+      "-f",
+      `sha=${sha}`,
     ]);
     if (res.ok) {
       log(`branch ${BRANCH} created`);
@@ -190,20 +207,33 @@ function ensureBranch(repo, log, dryRun, sha) {
 
 function writeWorkflowFile(repo, log, dryRun) {
   // 3d. Write the workflow file on the scratch branch.
-  const contentB64 = Buffer.from(WORKFLOW_YAML).toString('base64');
+  const contentB64 = Buffer.from(WORKFLOW_YAML).toString("base64");
   if (dryRun) {
-    log(`[dry-run] would run: gh api --method PUT repos/${repo}/contents/${WORKFLOW_PATH} -f message="${COMMIT_MESSAGE}" -f branch=${BRANCH} -f content=<BASE64>`);
+    log(
+      `[dry-run] would run: gh api --method PUT repos/${repo}/contents/${WORKFLOW_PATH} -f message="${COMMIT_MESSAGE}" -f branch=${BRANCH} -f content=<BASE64>`,
+    );
   } else {
     const putArgs = [
-      'api', '--method', 'PUT', `repos/${repo}/contents/${WORKFLOW_PATH}`,
-      '-f', `message=${COMMIT_MESSAGE}`,
-      '-f', `branch=${BRANCH}`,
-      '-f', `content=${contentB64}`,
+      "api",
+      "--method",
+      "PUT",
+      `repos/${repo}/contents/${WORKFLOW_PATH}`,
+      "-f",
+      `message=${COMMIT_MESSAGE}`,
+      "-f",
+      `branch=${BRANCH}`,
+      "-f",
+      `content=${contentB64}`,
     ];
     // Re-runs: if the file already exists on the scratch branch, the Contents
     // API needs its current sha to update it.
-    const existing = tryGh(['api', `repos/${repo}/contents/${WORKFLOW_PATH}?ref=${BRANCH}`, '--jq', '.sha']);
-    if (existing.ok) putArgs.push('-f', `sha=${existing.stdout.trim()}`);
+    const existing = tryGh([
+      "api",
+      `repos/${repo}/contents/${WORKFLOW_PATH}?ref=${BRANCH}`,
+      "--jq",
+      ".sha",
+    ]);
+    if (existing.ok) putArgs.push("-f", `sha=${existing.stdout.trim()}`);
     gh(putArgs);
     log(`workflow file written to branch ${BRANCH}`);
   }
@@ -212,21 +242,32 @@ function writeWorkflowFile(repo, log, dryRun) {
 function openPr(repo, log, dryRun, defaultBranch) {
   // 3e. Open the PR.
   if (dryRun) {
-    log(`[dry-run] would run: gh pr create --repo ${repo} --base <default> --head ${BRANCH} --title "${PR_TITLE}" --body "${PR_BODY}"`);
-    return 'dry-run';
+    log(
+      `[dry-run] would run: gh pr create --repo ${repo} --base <default> --head ${BRANCH} --title "${PR_TITLE}" --body "${PR_BODY}"`,
+    );
+    return "dry-run";
   }
   const pr = tryGh([
-    'pr', 'create', '--repo', repo,
-    '--base', defaultBranch, '--head', BRANCH,
-    '--title', PR_TITLE, '--body', PR_BODY,
+    "pr",
+    "create",
+    "--repo",
+    repo,
+    "--base",
+    defaultBranch,
+    "--head",
+    BRANCH,
+    "--title",
+    PR_TITLE,
+    "--body",
+    PR_BODY,
   ]);
   if (pr.ok) {
     log(`PR opened: ${pr.stdout.trim()}`);
-    return 'PR opened';
+    return "PR opened";
   }
   if (/already exists/i.test(pr.stderr)) {
-    log('PR already exists, nothing to do');
-    return 'PR already exists';
+    log("PR already exists, nothing to do");
+    return "PR already exists";
   }
   throw new Error(`gh pr create failed: ${pr.stderr}`);
 }
@@ -234,7 +275,7 @@ function openPr(repo, log, dryRun, defaultBranch) {
 function processRepo(repo, log, dryRun) {
   setSecrets(repo, log, dryRun);
   if (workflowExists(repo, log, dryRun)) {
-    return 'skipped (workflow exists)';
+    return "skipped (workflow exists)";
   }
   const { defaultBranch, sha } = resolveHead(repo, log, dryRun);
   ensureBranch(repo, log, dryRun, sha);
@@ -243,25 +284,25 @@ function processRepo(repo, log, dryRun) {
 }
 
 function collectRepos(argv) {
-  const dryRun = argv.includes('--dry-run');
-  const argvRepos = argv.filter((a) => a !== '--dry-run');
+  const dryRun = argv.includes("--dry-run");
+  const argvRepos = argv.filter((a) => a !== "--dry-run");
 
-  const unknownFlags = argvRepos.filter((a) => a.startsWith('-'));
+  const unknownFlags = argvRepos.filter((a) => a.startsWith("-"));
   if (unknownFlags.length) {
-    console.error(`error: unknown flag(s): ${unknownFlags.join(', ')}`);
+    console.error(`error: unknown flag(s): ${unknownFlags.join(", ")}`);
     process.exit(1);
   }
 
-  const envRepos = (process.env.REPOS || '')
-    .split(',')
+  const envRepos = (process.env.REPOS || "")
+    .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
   // argv repos win when both sources are given.
   const repos = [...new Set(argvRepos.length ? argvRepos : envRepos)];
 
   if (!repos.length) {
-    console.error('usage: node rollout.mjs [--dry-run] <owner/repo> [<owner/repo> ...]');
-    console.error('       or:   REPOS=owner/repo,owner/repo2 node rollout.mjs [--dry-run]');
+    console.error("usage: node rollout.mjs [--dry-run] <owner/repo> [<owner/repo> ...]");
+    console.error("       or:   REPOS=owner/repo,owner/repo2 node rollout.mjs [--dry-run]");
     process.exit(1);
   }
   for (const repo of repos) {
@@ -272,9 +313,11 @@ function collectRepos(argv) {
   }
 
   if (!dryRun) {
-    const ghOk = tryGh(['--version']);
+    const ghOk = tryGh(["--version"]);
     if (!ghOk.ok) {
-      console.error('error: `gh` CLI not found or not working. Install it and run `gh auth login` first.');
+      console.error(
+        "error: `gh` CLI not found or not working. Install it and run `gh auth login` first.",
+      );
       process.exit(1);
     }
   }
@@ -294,13 +337,13 @@ function runAll(repos, dryRun) {
       log(`ERROR: ${err.message}`);
     }
     summary.push({ repo, status });
-    console.log('');
+    console.log("");
   }
   return summary;
 }
 
 function printSummary(summary) {
-  console.log('Summary:');
+  console.log("Summary:");
   for (const { repo, status } of summary) {
     console.log(`  ${repo}: ${status}`);
   }
@@ -308,9 +351,9 @@ function printSummary(summary) {
 
 function main() {
   const argv = process.argv.slice(2);
-  const dryRun = argv.includes('--dry-run');
+  const dryRun = argv.includes("--dry-run");
   const repos = collectRepos(argv);
-  if (dryRun) console.log('[dry-run] no changes will be made\n');
+  if (dryRun) console.log("[dry-run] no changes will be made\n");
   const summary = runAll(repos, dryRun);
   printSummary(summary);
 }

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -66,7 +66,6 @@ function parseModels() {
     .filter((m) => m.provider && m.model && PROVIDERS[m.provider]);
 }
 
-
 function systemPrompt(lens) {
   const focus = LENSES[lens] || LENSES.correctness;
   return [
@@ -96,11 +95,14 @@ async function callModel(model, diff) {
     const token = process.env[provider.keyEnv]?.trim();
     if (!token) return timed({ model, error: `skipped: ${provider.keyEnv} not set` });
     const instructions = `${systemPrompt(model.lens)}\n\nReview the PR diff piped on stdin.`;
-    return timed(await callClaudeCli(model, diff, token, { instructions, timeoutMs: CLI_TIMEOUT_MS }));
+    return timed(
+      await callClaudeCli(model, diff, token, { instructions, timeoutMs: CLI_TIMEOUT_MS }),
+    );
   }
   if (provider && !provider.url) return timed({ model, error: "skipped: CUSTOM_BASE_URL not set" });
   const apiKey = provider && process.env[provider.keyEnv]?.trim();
-  if (!apiKey) return timed({ model, error: `skipped: ${provider?.keyEnv || model.provider} not set` });
+  if (!apiKey)
+    return timed({ model, error: `skipped: ${provider?.keyEnv || model.provider} not set` });
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
@@ -123,14 +125,21 @@ async function callModel(model, diff) {
     });
     if (!res.ok) {
       const body = await res.text().catch(() => "");
-      return timed({ model, error: `HTTP ${res.status}: ${body.slice(0, 300)}`, status: res.status });
+      return timed({
+        model,
+        error: `HTTP ${res.status}: ${body.slice(0, 300)}`,
+        status: res.status,
+      });
     }
     const json = await res.json();
     const text = json?.choices?.[0]?.message?.content?.trim();
     if (!text) return timed({ model, error: "empty response" });
     return timed({ model, text });
   } catch (err) {
-    return timed({ model, error: err?.name === "AbortError" ? "timed out" : String(err?.message || err) });
+    return timed({
+      model,
+      error: err?.name === "AbortError" ? "timed out" : String(err?.message || err),
+    });
   } finally {
     clearTimeout(timer);
   }
@@ -157,7 +166,10 @@ async function callModelWithFallback(model, diff) {
     console.log(`- ${model.name}: no ${PROVIDERS[model.provider]?.keyEnv}; routing via openrouter`);
     const only = await callModel(route, diff);
     if (only.error) {
-      return { ...only, error: `${PROVIDERS[model.provider]?.keyEnv} not set, openrouter: ${only.error}` };
+      return {
+        ...only,
+        error: `${PROVIDERS[model.provider]?.keyEnv} not set, openrouter: ${only.error}`,
+      };
     }
     return { ...only, model: { ...route, name: `${model.name} (via OpenRouter)` } };
   }
@@ -165,10 +177,15 @@ async function callModelWithFallback(model, diff) {
   if (!first.error || !CREDENTIAL_FAILURE_STATUSES.includes(first.status)) return first;
   const fallback = openRouterFallbackFor(model);
   if (!fallback) return first;
-  console.log(`- ${model.name}: ${model.provider} returned ${first.status}; retrying via openrouter`);
+  console.log(
+    `- ${model.name}: ${model.provider} returned ${first.status}; retrying via openrouter`,
+  );
   const second = await callModel(fallback, diff);
   if (second.error) {
-    return { ...second, error: `${model.provider} HTTP ${first.status}, openrouter: ${second.error}` };
+    return {
+      ...second,
+      error: `${model.provider} HTTP ${first.status}, openrouter: ${second.error}`,
+    };
   }
   return { ...second, model: { ...fallback, name: `${model.name} (via OpenRouter)` } };
 }
@@ -180,11 +197,17 @@ function buildFindingsMarkdown(results, { diffTruncated, contextTruncated, mutat
     "",
   );
   if (diffTruncated && contextTruncated) {
-    lines.push("> ⚠️ Diff and PR context were truncated for length; council saw the first portion of each.", "");
+    lines.push(
+      "> ⚠️ Diff and PR context were truncated for length; council saw the first portion of each.",
+      "",
+    );
   } else if (diffTruncated) {
     lines.push("> ⚠️ Diff was truncated for length; council saw the first portion only.", "");
   } else if (contextTruncated) {
-    lines.push("> ⚠️ PR context (title, body, linked issues) was truncated for length; the diff is complete.", "");
+    lines.push(
+      "> ⚠️ PR context (title, body, linked issues) was truncated for length; the diff is complete.",
+      "",
+    );
   }
   // An enabled lens that produced nothing must say why. Silence here reads as
   // "the mutation lens found nothing", which is the opposite of "it never ran".
@@ -199,12 +222,14 @@ function buildFindingsMarkdown(results, { diffTruncated, contextTruncated, mutat
   return lines.join("\n");
 }
 
-
 async function main() {
   if (process.argv.includes("--selfcheck")) {
     const md = buildFindingsMarkdown(
       [
-        { model: { name: "M1", lens: "security" }, text: "- **🔴 Critical** `a.ts:10` — bad. fix it." },
+        {
+          model: { name: "M1", lens: "security" },
+          text: "- **🔴 Critical** `a.ts:10` — bad. fix it.",
+        },
         { model: { name: "M2", lens: "performance" }, error: "timed out" },
       ],
       { diffTruncated: true, contextTruncated: false },
@@ -221,13 +246,15 @@ async function main() {
       [{ model: { name: "M1", lens: "correctness" }, text: "ok" }],
       { diffTruncated: false, contextTruncated: true },
     );
-    if (!mdCtx.includes("PR context")) throw new Error("selfcheck: context-only truncation message wrong");
+    if (!mdCtx.includes("PR context"))
+      throw new Error("selfcheck: context-only truncation message wrong");
     // Verify both-truncated message.
     const mdBoth = buildFindingsMarkdown(
       [{ model: { name: "M1", lens: "correctness" }, text: "ok" }],
       { diffTruncated: true, contextTruncated: true },
     );
-    if (!mdBoth.includes("Diff and PR context")) throw new Error("selfcheck: both-truncated message wrong");
+    if (!mdBoth.includes("Diff and PR context"))
+      throw new Error("selfcheck: both-truncated message wrong");
     // also verify a member with no key resolves to a skip, not a throw. Clear
     // the key for this call regardless of the ambient env so the check stays
     // offline even when OPENAI_API_KEY happens to be set in the shell.
@@ -235,27 +262,36 @@ async function main() {
     delete process.env.OPENAI_API_KEY;
     let r;
     try {
-      r = await callModel({ provider: "openai", model: "x", name: "X", lens: "correctness" }, "diff");
+      r = await callModel(
+        { provider: "openai", model: "x", name: "X", lens: "correctness" },
+        "diff",
+      );
     } finally {
       if (savedKey !== undefined) process.env.OPENAI_API_KEY = savedKey;
     }
-    if (!r.error?.includes("OPENAI_API_KEY")) throw new Error("selfcheck: missing-key path wrong: " + r.error);
+    if (!r.error?.includes("OPENAI_API_KEY"))
+      throw new Error("selfcheck: missing-key path wrong: " + r.error);
     // a custom member with no CUSTOM_BASE_URL must also skip, not throw — even
     // when the ambient env sets one, so the check stays offline.
     const savedUrl = PROVIDERS.custom.url;
     PROVIDERS.custom.url = undefined;
     let r2;
     try {
-      r2 = await callModel({ provider: "custom", model: "x", name: "X", lens: "correctness" }, "diff");
+      r2 = await callModel(
+        { provider: "custom", model: "x", name: "X", lens: "correctness" },
+        "diff",
+      );
     } finally {
       PROVIDERS.custom.url = savedUrl;
     }
-    if (!r2.error?.includes("CUSTOM_BASE_URL")) throw new Error("selfcheck: custom no-url path wrong: " + r2.error);
+    if (!r2.error?.includes("CUSTOM_BASE_URL"))
+      throw new Error("selfcheck: custom no-url path wrong: " + r2.error);
 
     // Assert DEFAULT_MODELS, not parseModels(): parseModels reads COUNCIL_MODELS
     // from the environment, so a repo that legitimately overrides the member list
     // would fail the selfcheck that AGENTS.md requires it to run.
-    if (!DEFAULT_MODELS.some((m) => m.lens === "scope")) throw new Error("selfcheck: scope lens missing from default members");
+    if (!DEFAULT_MODELS.some((m) => m.lens === "scope"))
+      throw new Error("selfcheck: scope lens missing from default members");
     selfcheckMutationRoster(buildFindingsMarkdown);
 
     // A unique temp dir, not a fixed name in the working directory: the old
@@ -265,39 +301,66 @@ async function main() {
     fs.writeFileSync(testCtx, "my PR claim");
     try {
       const { diff } = prepareDiff("my diff", testCtx, MAX_DIFF_CHARS);
-      if (!diff.includes("my PR claim") || !diff.includes("my diff")) throw new Error("selfcheck: context not prepended");
+      if (!diff.includes("my PR claim") || !diff.includes("my diff"))
+        throw new Error("selfcheck: context not prepended");
     } finally {
       fs.rmSync(testDir, { recursive: true, force: true });
     }
-    const { diff: noCtxDiff } = prepareDiff("my diff", path.join(testDir, "nonexistent.tmp"), MAX_DIFF_CHARS);
+    const { diff: noCtxDiff } = prepareDiff(
+      "my diff",
+      path.join(testDir, "nonexistent.tmp"),
+      MAX_DIFF_CHARS,
+    );
     if (noCtxDiff !== "my diff") throw new Error("selfcheck: missing context file is not a no-op");
 
     fs.mkdirSync(testDir, { recursive: true });
     fs.writeFileSync(testCtx, "A".repeat(10000));
     try {
       const { diff: truncCtx } = prepareDiff("my diff", testCtx, MAX_DIFF_CHARS);
-      if (!truncCtx.includes("context truncated") || truncCtx.length > 9000) throw new Error("selfcheck: context not truncated at 8000");
+      if (!truncCtx.includes("context truncated") || truncCtx.length > 9000)
+        throw new Error("selfcheck: context not truncated at 8000");
       const bigDiff = "D".repeat(MAX_DIFF_CHARS);
-      const { diff: truncCombined, diffTruncated, contextTruncated } = prepareDiff(bigDiff, testCtx, MAX_DIFF_CHARS);
+      const {
+        diff: truncCombined,
+        diffTruncated,
+        contextTruncated,
+      } = prepareDiff(bigDiff, testCtx, MAX_DIFF_CHARS);
       // Context was cut but the diff (which fills the whole budget) is intact.
       if (diffTruncated) throw new Error("selfcheck: diff was truncated when it filled the budget");
-      if (!contextTruncated) throw new Error("selfcheck: context should have been marked truncated");
-      if (truncCombined.length > MAX_DIFF_CHARS) throw new Error("selfcheck: combined truncation failed");
+      if (!contextTruncated)
+        throw new Error("selfcheck: context should have been marked truncated");
+      if (truncCombined.length > MAX_DIFF_CHARS)
+        throw new Error("selfcheck: combined truncation failed");
       // A diff that already fills the budget must keep every character of it.
-      if (truncCombined !== bigDiff) throw new Error("selfcheck: diff was truncated to make room for context");
-      const { diff: partial } = prepareDiff("D".repeat(MAX_DIFF_CHARS - 4000), testCtx, MAX_DIFF_CHARS);
-      if (!partial.startsWith("===== PR CONTEXT")) throw new Error("selfcheck: context dropped when it still fit");
-      if (partial.length > MAX_DIFF_CHARS) throw new Error("selfcheck: partial context exceeded the cap");
+      if (truncCombined !== bigDiff)
+        throw new Error("selfcheck: diff was truncated to make room for context");
+      const { diff: partial } = prepareDiff(
+        "D".repeat(MAX_DIFF_CHARS - 4000),
+        testCtx,
+        MAX_DIFF_CHARS,
+      );
+      if (!partial.startsWith("===== PR CONTEXT"))
+        throw new Error("selfcheck: context dropped when it still fit");
+      if (partial.length > MAX_DIFF_CHARS)
+        throw new Error("selfcheck: partial context exceeded the cap");
       // A truncated context must still be closed by the DIFF marker, or author
       // text runs straight into a diff hunk.
-      if (!partial.includes("\n===== DIFF =====\n")) throw new Error("selfcheck: truncation clipped the DIFF marker");
+      if (!partial.includes("\n===== DIFF =====\n"))
+        throw new Error("selfcheck: truncation clipped the DIFF marker");
       // A second, tighter cut must announce itself too, not just the first.
       const ctxPart = partial.slice(0, partial.indexOf("===== DIFF ====="));
-      if (!ctxPart.includes("context truncated")) throw new Error("selfcheck: second cut left no truncation marker");
-      if (partial.split("===== DIFF =====").length !== 2) throw new Error("selfcheck: DIFF marker not exactly once");
+      if (!ctxPart.includes("context truncated"))
+        throw new Error("selfcheck: second cut left no truncation marker");
+      if (partial.split("===== DIFF =====").length !== 2)
+        throw new Error("selfcheck: DIFF marker not exactly once");
       // Too little room for meaningful context means no context, not a fragment.
-      const { diff: noRoom } = prepareDiff("D".repeat(MAX_DIFF_CHARS - 50), testCtx, MAX_DIFF_CHARS);
-      if (noRoom.includes("===== PR CONTEXT")) throw new Error("selfcheck: shipped a context fragment with no room");
+      const { diff: noRoom } = prepareDiff(
+        "D".repeat(MAX_DIFF_CHARS - 50),
+        testCtx,
+        MAX_DIFF_CHARS,
+      );
+      if (noRoom.includes("===== PR CONTEXT"))
+        throw new Error("selfcheck: shipped a context fragment with no room");
       // A short context (never hit the 8000-char cap) dropped whole for lack of
       // room must still be reported as truncated, or the scope lens silently
       // loses the claim with no warning anywhere in the findings.
@@ -307,12 +370,15 @@ async function main() {
         testCtx,
         MAX_DIFF_CHARS,
       );
-      if (shortNoRoom.includes("===== PR CONTEXT")) throw new Error("selfcheck: shipped a short context fragment with no room");
-      if (!shortDropped) throw new Error("selfcheck: short context dropped for lack of room was not marked truncated");
+      if (shortNoRoom.includes("===== PR CONTEXT"))
+        throw new Error("selfcheck: shipped a short context fragment with no room");
+      if (!shortDropped)
+        throw new Error(
+          "selfcheck: short context dropped for lack of room was not marked truncated",
+        );
     } finally {
       fs.rmSync(testDir, { recursive: true, force: true });
     }
-
 
     // A CLI-backed seat with no oauth token must skip too, not shell out --
     // even when the ambient env sets one, so the check stays offline.
@@ -320,7 +386,10 @@ async function main() {
     delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
     let cliSkip;
     try {
-      cliSkip = await callModel({ provider: "claude", model: "x", name: "X", lens: "correctness" }, "diff");
+      cliSkip = await callModel(
+        { provider: "claude", model: "x", name: "X", lens: "correctness" },
+        "diff",
+      );
     } finally {
       if (savedToken !== undefined) process.env.CLAUDE_CODE_OAUTH_TOKEN = savedToken;
     }
@@ -356,7 +425,11 @@ async function main() {
   }
 
   const diffRaw = diffFile && fs.existsSync(diffFile) ? fs.readFileSync(diffFile, "utf8") : "";
-  const { diff, diffTruncated, contextTruncated } = prepareDiff(diffRaw, process.env.PR_CONTEXT_FILE, MAX_DIFF_CHARS);
+  const { diff, diffTruncated, contextTruncated } = prepareDiff(
+    diffRaw,
+    process.env.PR_CONTEXT_FILE,
+    MAX_DIFF_CHARS,
+  );
 
   if (!diff) {
     write("# 🧑‍⚖️ LLM Council findings\n\n_Council skipped: empty diff._\n");


### PR DESCRIPTION
Closes #61

## What
Adds `.oxfmtrc.json` and runs `oxfmt --write` over the 3 files it covers.

## Why
The 2026-08-31 fleet audit found oxfmt in zero of the 48 pooriaarab repos that
carry JS/TS, against oxlint in 40. One formatter, enforced in CI, removes a class
of review noise that agent-authored diffs generate constantly.

`ignorePatterns` excludes vendor, third_party, generated, minified and build
output. Without it the formatter rewrites dependencies: on foxcade that was
141,361 lines, of which roughly 87,000 were `three.module.js` and `maplibre-gl`.

Part 1 of 3, stacked on `main`. Each part touches a disjoint set of files
so the parts do not conflict. Merge them in order.

## How I verified

```
npx oxfmt@0.65.0 --check .                 -> exit 0
npx oxlint@1.80.0 --config .oxlintrc.json  -> exit 0
git diff --numstat main                 -> 3 files, 392 lines
```

No source was hand-edited. Every change is `oxfmt --write` output.

Assisted-by: claude-personal-1:claude-opus-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added standardized formatting configuration and exclusions for generated, vendor, bundled, deployment, and coverage files.
* **Style**
  * Applied consistent code formatting across rollout and review tooling without changing behavior.
* **Tests**
  * Expanded self-check coverage for skipped credentials, custom provider URLs, context truncation, CLI tokens, diff markers, and size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->