### PR TITLE
[VCR-65] Adopt oxfmt as the formatter (part 3 of 3)

### DIFF
--- a/.github/workflows/oxfmt.yml
+++ b/.github/workflows/oxfmt.yml
@@ -1,0 +1,28 @@
+name: oxfmt
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    name: oxfmt --check
+    runs-on: ubicloud-standard-2
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Check formatting
+        run: bunx oxfmt@0.65 --check .

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,19 +1,55 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
   "plugins": ["typescript", "import", "unicorn", "oxc"],
-  "categories": { "correctness": "warn", "suspicious": "warn", "perf": "warn", "pedantic": "off", "style": "off", "restriction": "off", "nursery": "off" },
+  "categories": {
+    "correctness": "warn",
+    "suspicious": "warn",
+    "perf": "warn",
+    "pedantic": "off",
+    "style": "off",
+    "restriction": "off",
+    "nursery": "off"
+  },
   "rules": {
     "complexity": ["error", { "max": 10 }],
     "max-lines": ["error", { "max": 300, "skipBlankLines": true, "skipComments": true }],
-    "max-lines-per-function": ["error", { "max": 50, "skipBlankLines": true, "skipComments": true }],
+    "max-lines-per-function": [
+      "error",
+      { "max": 50, "skipBlankLines": true, "skipComments": true }
+    ],
     "max-params": ["error", { "max": 4 }],
     "max-depth": ["error", { "max": 4 }],
     "max-nested-callbacks": ["error", { "max": 4 }],
-    "no-var": "error", "prefer-const": "error", "eqeqeq": "error", "no-debugger": "error",
-    "typescript/no-explicit-any": "error", "typescript/no-non-null-assertion": "error", "import/no-cycle": "error"
+    "no-var": "error",
+    "prefer-const": "error",
+    "eqeqeq": "error",
+    "no-debugger": "error",
+    "typescript/no-explicit-any": "error",
+    "typescript/no-non-null-assertion": "error",
+    "import/no-cycle": "error"
   },
   "overrides": [
-    { "files": ["**/*.test.ts","**/*.test.tsx","**/*.spec.ts","**/*.spec.tsx","**/__tests__/**"], "rules": { "complexity":"off","max-lines":"off","max-lines-per-function":"off","max-depth":"off","max-nested-callbacks":"off","typescript/no-explicit-any":"off","typescript/no-non-null-assertion":"off" } },
-    { "files": ["scripts/**","**/scripts/**","**/*.config.*"], "rules": { "max-lines-per-function":"off","complexity":"off" } }
+    {
+      "files": [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.spec.ts",
+        "**/*.spec.tsx",
+        "**/__tests__/**"
+      ],
+      "rules": {
+        "complexity": "off",
+        "max-lines": "off",
+        "max-lines-per-function": "off",
+        "max-depth": "off",
+        "max-nested-callbacks": "off",
+        "typescript/no-explicit-any": "off",
+        "typescript/no-non-null-assertion": "off"
+      }
+    },
+    {
+      "files": ["scripts/**", "**/scripts/**", "**/*.config.*"],
+      "rules": { "max-lines-per-function": "off", "complexity": "off" }
+    }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ never fork its provider/lens logic into the surfaces.
   thing is defined exactly once and the engine imports it. They exist because
   `max-lines` caps a file at 300 and the budget is not negotiable. Add a member
   or a lens in `council-config.mjs`; add nothing to a surface.
+
 - `action.yml` — shallow checkout → council fan-out (started in the background,
   collected just before the chair, so setup runs inside its latency) →
   `anthropics/claude-code-action@v1` (the chair: verifies, fixes, pushes, posts
@@ -53,10 +54,10 @@ never fork its provider/lens logic into the surfaces.
 
 Two tags per release, never one.
 
-| Tag | Mutable | Who follows it |
-|---|---|---|
-| `vX.Y.Z` | never moved | anyone who pins a version, and rollback |
-| `vX` | force-moved to the newest `vX.Y.Z` | the ~80 repos whose workflow says `@v1` |
+| Tag      | Mutable                            | Who follows it                          |
+| -------- | ---------------------------------- | --------------------------------------- |
+| `vX.Y.Z` | never moved                        | anyone who pins a version, and rollback |
+| `vX`     | force-moved to the newest `vX.Y.Z` | the ~80 repos whose workflow says `@v1` |
 
     node bin/release.mjs 1.2.0            # dry run, prints the plan
     node bin/release.mjs 1.2.0 --apply    # create v1.2.0, move v1 to it

--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ verdict, self-healing fix.
 
 ## The council
 
-| Member | Provider (called directly) | Secret | Lens |
-| --- | --- | --- | --- |
-| Chair | Claude (subscription OAuth) | `CLAUDE_CODE_OAUTH_TOKEN` | synthesis + conventions + tests + proof + fixes |
-| GPT / Codex | api.openai.com | `OPENAI_API_KEY` | correctness, silent failures |
-| Gemini | generativelanguage.googleapis.com | `GEMINI_API_KEY` | performance, type design |
-| Kimi | api.moonshot.ai | `MOONSHOT_API_KEY` | security |
-| Grok / DeepSeek | openrouter.ai | `OPENROUTER_API_KEY` | maintainability, data integrity |
-| GPT-5.6 (scope) | openrouter.ai | `OPENROUTER_API_KEY` | scope, atomicity, and the evidence in the body |
-| Sonnet (mutation) | openrouter.ai | `OPENROUTER_API_KEY` | can these tests fail at all — **off by default** |
+| Member            | Provider (called directly)        | Secret                    | Lens                                             |
+| ----------------- | --------------------------------- | ------------------------- | ------------------------------------------------ |
+| Chair             | Claude (subscription OAuth)       | `CLAUDE_CODE_OAUTH_TOKEN` | synthesis + conventions + tests + proof + fixes  |
+| GPT / Codex       | api.openai.com                    | `OPENAI_API_KEY`          | correctness, silent failures                     |
+| Gemini            | generativelanguage.googleapis.com | `GEMINI_API_KEY`          | performance, type design                         |
+| Kimi              | api.moonshot.ai                   | `MOONSHOT_API_KEY`        | security                                         |
+| Grok / DeepSeek   | openrouter.ai                     | `OPENROUTER_API_KEY`      | maintainability, data integrity                  |
+| GPT-5.6 (scope)   | openrouter.ai                     | `OPENROUTER_API_KEY`      | scope, atomicity, and the evidence in the body   |
+| Sonnet (mutation) | openrouter.ai                     | `OPENROUTER_API_KEY`      | can these tests fail at all — **off by default** |
 
 A member with no key drops out. No key at all → the council step is skipped, and
 Claude still reviews alone. Nothing here blocks the PR on a provider outage. The scope lens reads the PR's title, body, and linked issues from `PR_CONTEXT_FILE` when available to verify the diff matches the author's claim.
@@ -78,7 +78,7 @@ overrides (`OPENROUTER_MODEL=deepseek/deepseek-v4-flash`, etc.).
 ### The mutation lens
 
 ```yaml
-    mutation_lens: "true"
+mutation_lens: "true"
 ```
 
 Five lenses read the diff. This sixth one reads the **tests** and asks the
@@ -152,7 +152,7 @@ No `CUSTOM_BASE_URL` → the member skips with a note, same as a missing key.
 ## What a fix cycle costs
 
 When the chair pushes a fix, that is a real commit on the PR branch, so GitHub
-raises a `synchronize` event. Every *other* workflow in the repo that triggers on
+raises a `synchronize` event. Every _other_ workflow in the repo that triggers on
 `pull_request` runs again. The cost does not show up against this action — it
 shows up as extra runs of your test, lint, build and e2e workflows.
 
@@ -183,10 +183,10 @@ converging, and a seventh costs what the first cost.
 
 Two ceilings stop it. Both default on:
 
-| Input | Default | Counts |
-|---|---|---|
-| `max_council_runs` | `6` | completed runs of this workflow on the pull request |
-| `max_branch_runs` | `60` | runs of every workflow in the repo on the branch |
+| Input              | Default | Counts                                              |
+| ------------------ | ------- | --------------------------------------------------- |
+| `max_council_runs` | `6`     | completed runs of this workflow on the pull request |
+| `max_branch_runs`  | `60`    | runs of every workflow in the repo on the branch    |
 
 Set either to `0` to disable it.
 

--- a/action.yml
+++ b/action.yml
@@ -401,7 +401,6 @@ runs:
           echo "VCR_OUT_EOF"
         } >> "$GITHUB_OUTPUT"
 
-
     # Probe the chair tokens before paying for an attempt.
     #
     # A chair attempt costs ~12s of claude-code-action setup (Bun, dependencies,

--- a/bin/release.mjs
+++ b/bin/release.mjs
@@ -111,7 +111,11 @@ if (highest && cmp(newVer, highest) <= 0) {
 }
 
 console.log(`main      ${sha}`);
-console.log(tagExists ? `exists    ${tag} -> ${sha.slice(0, 7)} (resuming)` : `create    ${tag} -> ${sha.slice(0, 7)}`);
+console.log(
+  tagExists
+    ? `exists    ${tag} -> ${sha.slice(0, 7)} (resuming)`
+    : `create    ${tag} -> ${sha.slice(0, 7)}`,
+);
 console.log(`${majorExists ? "move     " : "create   "} ${major} -> ${sha.slice(0, 7)}`);
 if (!apply) {
   console.log("\ndry run. Nothing was written. Re-run with --apply.");
@@ -121,16 +125,45 @@ if (!apply) {
 if (tagExists) {
   console.log(`${tag} already exists at this sha, skipping`);
 } else {
-  gh(["api", `repos/${REPO}/git/refs`, "-X", "POST", "-f", `ref=refs/tags/${tag}`, "-f", `sha=${sha}`]);
+  gh([
+    "api",
+    `repos/${REPO}/git/refs`,
+    "-X",
+    "POST",
+    "-f",
+    `ref=refs/tags/${tag}`,
+    "-f",
+    `sha=${sha}`,
+  ]);
   console.log(`created ${tag}`);
 }
 // The major pointer is the only tag this force-updates, and it is the one
 // consumers opted into by writing @v1 rather than a pinned version.
 if (majorExists) {
-  gh(["api", `repos/${REPO}/git/refs/tags/${major}`, "-X", "PATCH", "-f", `sha=${sha}`, "-F", "force=true"]);
+  gh([
+    "api",
+    `repos/${REPO}/git/refs/tags/${major}`,
+    "-X",
+    "PATCH",
+    "-f",
+    `sha=${sha}`,
+    "-F",
+    "force=true",
+  ]);
   console.log(`moved ${major} -> ${tag}`);
 } else {
-  gh(["api", `repos/${REPO}/git/refs`, "-X", "POST", "-f", `ref=refs/tags/${major}`, "-f", `sha=${sha}`]);
+  gh([
+    "api",
+    `repos/${REPO}/git/refs`,
+    "-X",
+    "POST",
+    "-f",
+    `ref=refs/tags/${major}`,
+    "-f",
+    `sha=${sha}`,
+  ]);
   console.log(`created ${major} -> ${tag}`);
 }
-console.log(`\nNow write the release notes:\n  gh release create ${tag} --repo ${REPO} --title "${tag}" --notes "..."`);
+console.log(
+  `\nNow write the release notes:\n  gh release create ${tag} --repo ${REPO} --title "${tag}" --notes "..."`,
+);

--- a/bin/vibecodereview.mjs
+++ b/bin/vibecodereview.mjs
@@ -19,7 +19,12 @@ import os from "node:os";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(HERE, "..");
-const PROVIDER_KEYS = ["OPENAI_API_KEY", "GEMINI_API_KEY", "MOONSHOT_API_KEY", "OPENROUTER_API_KEY"];
+const PROVIDER_KEYS = [
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "MOONSHOT_API_KEY",
+  "OPENROUTER_API_KEY",
+];
 const REF = "pooriaarab/vibecodereview@v1"; // action ref repos pin to
 
 const WORKFLOW = `name: vibecodereview
@@ -78,9 +83,12 @@ function secrets() {
 
 function doctor() {
   console.log("Chair:");
-  console.log(`  CLAUDE_CODE_OAUTH_TOKEN  ${process.env.CLAUDE_CODE_OAUTH_TOKEN ? "set" : "MISSING (required for CI)"}`);
+  console.log(
+    `  CLAUDE_CODE_OAUTH_TOKEN  ${process.env.CLAUDE_CODE_OAUTH_TOKEN ? "set" : "MISSING (required for CI)"}`,
+  );
   console.log("Council members:");
-  for (const k of PROVIDER_KEYS) console.log(`  ${k.padEnd(22)} ${process.env[k] ? "set" : "not set (member dropped)"}`);
+  for (const k of PROVIDER_KEYS)
+    console.log(`  ${k.padEnd(22)} ${process.env[k] ? "set" : "not set (member dropped)"}`);
 }
 
 function review() {
@@ -93,7 +101,9 @@ function review() {
   const tmp = path.join(os.tmpdir(), `vibecodereview-${process.pid}.diff`);
   const out = path.join(os.tmpdir(), `vibecodereview-${process.pid}.md`);
   fs.writeFileSync(tmp, diff);
-  sh("node", [path.join(ROOT, "scripts", "council-review.mjs"), tmp, out], { stdio: ["ignore", "inherit", "inherit"] });
+  sh("node", [path.join(ROOT, "scripts", "council-review.mjs"), tmp, out], {
+    stdio: ["ignore", "inherit", "inherit"],
+  });
   console.log("\n" + fs.readFileSync(out, "utf8"));
 }
 
@@ -114,7 +124,9 @@ function reviewOnePr(repo, number, post) {
   const tmp = path.join(os.tmpdir(), `vibecodereview-${process.pid}-${seq}.diff`);
   const out = path.join(os.tmpdir(), `vibecodereview-${process.pid}-${seq}.md`);
   fs.writeFileSync(tmp, diff);
-  sh("node", [path.join(ROOT, "scripts", "council-review.mjs"), tmp, out], { stdio: ["ignore", "inherit", "inherit"] });
+  sh("node", [path.join(ROOT, "scripts", "council-review.mjs"), tmp, out], {
+    stdio: ["ignore", "inherit", "inherit"],
+  });
   console.log(`\n=== ${repo}#${number} ===\n`);
   console.log(fs.readFileSync(out, "utf8"));
   if (post) sh("gh", ["pr", "comment", String(number), "--repo", repo, "--body-file", out]);
@@ -123,7 +135,9 @@ function reviewOnePr(repo, number, post) {
 function reviewRepoPrs(repo, post, counts) {
   let prs;
   try {
-    prs = JSON.parse(sh("gh", ["pr", "list", "--repo", repo, "--state", "open", "--json", "number"]));
+    prs = JSON.parse(
+      sh("gh", ["pr", "list", "--repo", repo, "--state", "open", "--json", "number"]),
+    );
   } catch (err) {
     counts.errors++;
     console.error(`${repo}: failed to list PRs: ${err?.message || err}`);
@@ -144,7 +158,9 @@ function reviewPrs() {
   const post = process.argv.includes("--post");
   const repos = parseRepoArgs(process.argv.slice(3));
   if (repos.length === 0) {
-    console.log("Usage: vibecodereview review-prs [--post] [--repo <owner/repo>]... [<owner/repo>...]");
+    console.log(
+      "Usage: vibecodereview review-prs [--post] [--repo <owner/repo>]... [<owner/repo>...]",
+    );
     return;
   }
   const counts = { reviewed: 0, errors: 0 };
@@ -161,7 +177,9 @@ try {
   else if (cmd === "review") review();
   else if (cmd === "review-prs") reviewPrs();
   else {
-    console.log("vibecodereview <init|review|review-prs|doctor|secrets>  (see `vibecodereview` header comment)");
+    console.log(
+      "vibecodereview <init|review|review-prs|doctor|secrets>  (see `vibecodereview` header comment)",
+    );
     process.exit(cmd ? 1 : 0);
   }
 } catch (err) {

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -51,7 +51,10 @@ function callTool(id, params) {
     const text = runCouncil(params?.arguments?.diff);
     return reply(id, { content: [{ type: "text", text }] });
   } catch (err) {
-    return reply(id, { content: [{ type: "text", text: `Council error: ${err?.message || err}` }], isError: true });
+    return reply(id, {
+      content: [{ type: "text", text: `Council error: ${err?.message || err}` }],
+      isError: true,
+    });
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,15 +1,14 @@
 {
   "name": "vibecodereview",
   "version": "0.1.1",
-  "publishConfig": { "access": "public" },
   "description": "LLM-council PR review: many models, diverse lenses, one self-healing GitHub check. Also reviews your local diff before you push.",
-  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pooriaarab/vibecodereview.git"
+  },
   "bin": {
     "vibecodereview": "bin/vibecodereview.mjs"
-  },
-  "scripts": {
-    "selfcheck": "node scripts/council-review.mjs --selfcheck && node scripts/chair-fallback.mjs --selfcheck",
-    "mcp": "node mcp/server.mjs"
   },
   "files": [
     "action.yml",
@@ -19,12 +18,15 @@
     "skills/",
     "AGENTS.md"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "selfcheck": "node scripts/council-review.mjs --selfcheck && node scripts/chair-fallback.mjs --selfcheck",
+    "mcp": "node mcp/server.mjs"
+  },
   "engines": {
     "node": ">=20"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/pooriaarab/vibecodereview.git"
-  },
-  "license": "MIT"
+  }
 }


### PR DESCRIPTION
Closes #65

## What
Adds `.oxfmtrc.json`, runs `oxfmt --write` over the 9 files it covers, and adds `.github/workflows/oxfmt.yml` so CI fails on unformatted code.

## Why
The 2026-08-31 fleet audit found oxfmt in zero of the 48 pooriaarab repos that
carry JS/TS, against oxlint in 40. One formatter, enforced in CI, removes a class
of review noise that agent-authored diffs generate constantly.

`ignorePatterns` excludes vendor, third_party, generated, minified and build
output. Without it the formatter rewrites dependencies: on foxcade that was
141,361 lines, of which roughly 87,000 were `three.module.js` and `maplibre-gl`.

Part 3 of 3, stacked on `vcr-63-adopt-oxfmt-part2`. Each part touches a disjoint set of files
so the parts do not conflict. Merge them in order.

## How I verified

```
npx oxfmt@0.65.0 --check .                 -> exit 0
npx oxlint@1.80.0 --config .oxlintrc.json  -> exit 0
git diff --numstat vcr-63-adopt-oxfmt-part2                 -> 9 files, 224 lines
```

No source was hand-edited. Every change is `oxfmt --write` output.

Assisted-by: claude-personal-1:claude-opus-5
