### PR TITLE
[VCR-70] Adopt oxfmt as the formatter (part 2 of 3)

### DIFF
--- a/bin/merge-rollout.mjs
+++ b/bin/merge-rollout.mjs
@@ -10,9 +10,13 @@ import { execFileSync } from "node:child_process";
 
 const gh = (a) => execFileSync("gh", a, { encoding: "utf8" }).trim();
 const lenient = process.argv.includes("--lenient");
-const repos = (process.argv.slice(2).filter((a) => a !== "--lenient").length
-  ? process.argv.slice(2).filter((a) => a !== "--lenient")
-  : (process.env.REPOS || "").split(",")).map((s) => s.trim()).filter(Boolean);
+const repos = (
+  process.argv.slice(2).filter((a) => a !== "--lenient").length
+    ? process.argv.slice(2).filter((a) => a !== "--lenient")
+    : (process.env.REPOS || "").split(",")
+)
+  .map((s) => s.trim())
+  .filter(Boolean);
 
 // The rolled-out workflow job is named `review` (older) or `vibecodereview`.
 const isVibe = (c) => {
@@ -26,19 +30,50 @@ const WAIT = ["PENDING", "QUEUED", "IN_PROGRESS", ""];
 const out = { merged: [], pending: [], vibe_failed: [], other_red: [], nopr: [], error: [] };
 for (const repo of repos) {
   try {
-    const num = gh(["pr", "list", "--repo", repo, "--head", "add-vibecodereview", "--state", "open",
-      "--json", "number", "--jq", ".[0].number // empty"]);
-    if (!num) { out.nopr.push(repo); continue; }
-    const checks = JSON.parse(gh(["pr", "view", num, "--repo", repo, "--json", "statusCheckRollup"])).statusCheckRollup || [];
+    const num = gh([
+      "pr",
+      "list",
+      "--repo",
+      repo,
+      "--head",
+      "add-vibecodereview",
+      "--state",
+      "open",
+      "--json",
+      "number",
+      "--jq",
+      ".[0].number // empty",
+    ]);
+    if (!num) {
+      out.nopr.push(repo);
+      continue;
+    }
+    const checks =
+      JSON.parse(gh(["pr", "view", num, "--repo", repo, "--json", "statusCheckRollup"]))
+        .statusCheckRollup || [];
     const vibe = checks.filter(isVibe).map(state);
     const others = checks.filter((c) => !isVibe(c)).map(state);
-    if (vibe.some((s) => WAIT.includes(s)) || (!vibe.length && checks.some((c) => WAIT.includes(state(c))))) { out.pending.push(`${repo}#${num}`); continue; }
-    if (vibe.some((s) => FAIL.includes(s))) { out.vibe_failed.push(`${repo}#${num}`); continue; }
-    if (!lenient && others.some((s) => FAIL.includes(s))) { out.other_red.push(`${repo}#${num}`); continue; }
+    if (
+      vibe.some((s) => WAIT.includes(s)) ||
+      (!vibe.length && checks.some((c) => WAIT.includes(state(c))))
+    ) {
+      out.pending.push(`${repo}#${num}`);
+      continue;
+    }
+    if (vibe.some((s) => FAIL.includes(s))) {
+      out.vibe_failed.push(`${repo}#${num}`);
+      continue;
+    }
+    if (!lenient && others.some((s) => FAIL.includes(s))) {
+      out.other_red.push(`${repo}#${num}`);
+      continue;
+    }
     gh(["pr", "merge", num, "--repo", repo, "--squash", "--admin", "--delete-branch"]);
     out.merged.push(`${repo}#${num}`);
     console.log(`merged ${repo}#${num}`);
-  } catch (e) { out.error.push(`${repo}: ${String(e.message).split("\n")[0].slice(0, 100)}`); }
+  } catch (e) {
+    out.error.push(`${repo}: ${String(e.message).split("\n")[0].slice(0, 100)}`);
+  }
 }
 console.log("\n=== summary ===");
 for (const k of Object.keys(out)) console.log(`${k} (${out[k].length}): ${out[k].join(", ")}`);

--- a/bin/rebrand-rollout.mjs
+++ b/bin/rebrand-rollout.mjs
@@ -6,38 +6,128 @@
 import { execFileSync } from "node:child_process";
 
 const gh = (a) => execFileSync("gh", a, { encoding: "utf8" }).trim();
-const ghTry = (a) => { try { return { ok: true, out: gh(a) }; } catch (e) { return { ok: false, err: String(e.stderr || e.message).split("\n").filter(Boolean).pop() || "" }; } };
+const ghTry = (a) => {
+  try {
+    return { ok: true, out: gh(a) };
+  } catch (e) {
+    return {
+      ok: false,
+      err:
+        String(e.stderr || e.message)
+          .split("\n")
+          .filter(Boolean)
+          .pop() || "",
+    };
+  }
+};
 const dry = process.argv.includes("--dry-run");
-const repos = (process.argv.slice(2).filter((a) => a !== "--dry-run").length
-  ? process.argv.slice(2).filter((a) => a !== "--dry-run")
-  : (process.env.REPOS || "").split(",")).map((s) => s.trim()).filter(Boolean);
+const repos = (
+  process.argv.slice(2).filter((a) => a !== "--dry-run").length
+    ? process.argv.slice(2).filter((a) => a !== "--dry-run")
+    : (process.env.REPOS || "").split(",")
+)
+  .map((s) => s.trim())
+  .filter(Boolean);
 const PATH = ".github/workflows/vibecodereview.yml";
 const out = { rebranded: [], via_pr: [], already: [], nofile: [], error: [] };
 
 for (const repo of repos) {
   try {
     const meta = ghTry(["api", `repos/${repo}/contents/${PATH}`]);
-    if (!meta.ok) { out.nofile.push(repo); continue; }
+    if (!meta.ok) {
+      out.nofile.push(repo);
+      continue;
+    }
     const { content, sha } = JSON.parse(meta.out);
     const yaml = Buffer.from(content, "base64").toString("utf8");
-    if (/^\s{2}vibecodereview:\s*$/m.test(yaml)) { out.already.push(repo); continue; }
-    if (!/^\s{2}review:\s*$/m.test(yaml)) { out.already.push(repo); continue; }
+    if (/^\s{2}vibecodereview:\s*$/m.test(yaml)) {
+      out.already.push(repo);
+      continue;
+    }
+    if (!/^\s{2}review:\s*$/m.test(yaml)) {
+      out.already.push(repo);
+      continue;
+    }
     const updated = yaml.replace(/^(\s{2})review:(\s*)$/m, "$1vibecodereview:$2");
     const b64 = Buffer.from(updated).toString("base64");
-    if (dry) { console.log(`[dry] would rebrand ${repo}`); out.rebranded.push(repo); continue; }
-    const def = gh(["repo", "view", repo, "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name"]);
-    const direct = ghTry(["api", "-X", "PUT", `repos/${repo}/contents/${PATH}`,
-      "-f", "message=Brand PR-review check as vibecodereview", "-f", `content=${b64}`, "-f", `sha=${sha}`, "-f", `branch=${def}`]);
-    if (direct.ok) { out.rebranded.push(repo); console.log(`rebranded ${repo}`); continue; }
+    if (dry) {
+      console.log(`[dry] would rebrand ${repo}`);
+      out.rebranded.push(repo);
+      continue;
+    }
+    const def = gh([
+      "repo",
+      "view",
+      repo,
+      "--json",
+      "defaultBranchRef",
+      "--jq",
+      ".defaultBranchRef.name",
+    ]);
+    const direct = ghTry([
+      "api",
+      "-X",
+      "PUT",
+      `repos/${repo}/contents/${PATH}`,
+      "-f",
+      "message=Brand PR-review check as vibecodereview",
+      "-f",
+      `content=${b64}`,
+      "-f",
+      `sha=${sha}`,
+      "-f",
+      `branch=${def}`,
+    ]);
+    if (direct.ok) {
+      out.rebranded.push(repo);
+      console.log(`rebranded ${repo}`);
+      continue;
+    }
     // protected default branch -> PR
     const headSha = gh(["api", `repos/${repo}/git/ref/heads/${def}`, "--jq", ".object.sha"]);
-    ghTry(["api", "-X", "POST", `repos/${repo}/git/refs`, "-f", "ref=refs/heads/rebrand-vibecodereview", "-f", `sha=${headSha}`]);
-    gh(["api", "-X", "PUT", `repos/${repo}/contents/${PATH}`, "-f", "message=Brand PR-review check as vibecodereview",
-      "-f", `content=${b64}`, "-f", `sha=${sha}`, "-f", "branch=rebrand-vibecodereview"]);
-    gh(["pr", "create", "--repo", repo, "--base", def, "--head", "rebrand-vibecodereview",
-      "--title", "Brand PR-review check as vibecodereview", "--body", "Renames the workflow job review -> vibecodereview."]);
-    out.via_pr.push(repo); console.log(`PR opened for ${repo} (protected branch)`);
-  } catch (e) { out.error.push(`${repo}: ${String(e.message).split("\n")[0].slice(0, 100)}`); }
+    ghTry([
+      "api",
+      "-X",
+      "POST",
+      `repos/${repo}/git/refs`,
+      "-f",
+      "ref=refs/heads/rebrand-vibecodereview",
+      "-f",
+      `sha=${headSha}`,
+    ]);
+    gh([
+      "api",
+      "-X",
+      "PUT",
+      `repos/${repo}/contents/${PATH}`,
+      "-f",
+      "message=Brand PR-review check as vibecodereview",
+      "-f",
+      `content=${b64}`,
+      "-f",
+      `sha=${sha}`,
+      "-f",
+      "branch=rebrand-vibecodereview",
+    ]);
+    gh([
+      "pr",
+      "create",
+      "--repo",
+      repo,
+      "--base",
+      def,
+      "--head",
+      "rebrand-vibecodereview",
+      "--title",
+      "Brand PR-review check as vibecodereview",
+      "--body",
+      "Renames the workflow job review -> vibecodereview.",
+    ]);
+    out.via_pr.push(repo);
+    console.log(`PR opened for ${repo} (protected branch)`);
+  } catch (e) {
+    out.error.push(`${repo}: ${String(e.message).split("\n")[0].slice(0, 100)}`);
+  }
 }
 console.log("\n=== summary ===");
 for (const k of Object.keys(out)) console.log(`${k} (${out[k].length}): ${out[k].join(", ")}`);

--- a/bin/release.mjs
+++ b/bin/release.mjs
@@ -111,7 +111,11 @@ if (highest && cmp(newVer, highest) <= 0) {
 }
 
 console.log(`main      ${sha}`);
-console.log(tagExists ? `exists    ${tag} -> ${sha.slice(0, 7)} (resuming)` : `create    ${tag} -> ${sha.slice(0, 7)}`);
+console.log(
+  tagExists
+    ? `exists    ${tag} -> ${sha.slice(0, 7)} (resuming)`
+    : `create    ${tag} -> ${sha.slice(0, 7)}`,
+);
 console.log(`${majorExists ? "move     " : "create   "} ${major} -> ${sha.slice(0, 7)}`);
 if (!apply) {
   console.log("\ndry run. Nothing was written. Re-run with --apply.");
@@ -121,16 +125,45 @@ if (!apply) {
 if (tagExists) {
   console.log(`${tag} already exists at this sha, skipping`);
 } else {
-  gh(["api", `repos/${REPO}/git/refs`, "-X", "POST", "-f", `ref=refs/tags/${tag}`, "-f", `sha=${sha}`]);
+  gh([
+    "api",
+    `repos/${REPO}/git/refs`,
+    "-X",
+    "POST",
+    "-f",
+    `ref=refs/tags/${tag}`,
+    "-f",
+    `sha=${sha}`,
+  ]);
   console.log(`created ${tag}`);
 }
 // The major pointer is the only tag this force-updates, and it is the one
 // consumers opted into by writing @v1 rather than a pinned version.
 if (majorExists) {
-  gh(["api", `repos/${REPO}/git/refs/tags/${major}`, "-X", "PATCH", "-f", `sha=${sha}`, "-F", "force=true"]);
+  gh([
+    "api",
+    `repos/${REPO}/git/refs/tags/${major}`,
+    "-X",
+    "PATCH",
+    "-f",
+    `sha=${sha}`,
+    "-F",
+    "force=true",
+  ]);
   console.log(`moved ${major} -> ${tag}`);
 } else {
-  gh(["api", `repos/${REPO}/git/refs`, "-X", "POST", "-f", `ref=refs/tags/${major}`, "-f", `sha=${sha}`]);
+  gh([
+    "api",
+    `repos/${REPO}/git/refs`,
+    "-X",
+    "POST",
+    "-f",
+    `ref=refs/tags/${major}`,
+    "-f",
+    `sha=${sha}`,
+  ]);
   console.log(`created ${major} -> ${tag}`);
 }
-console.log(`\nNow write the release notes:\n  gh release create ${tag} --repo ${REPO} --title "${tag}" --notes "..."`);
+console.log(
+  `\nNow write the release notes:\n  gh release create ${tag} --repo ${REPO} --title "${tag}" --notes "..."`,
+);

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -108,14 +108,17 @@ async function askChair(diff, council, diffTruncated) {
           {
             role: "user",
             content:
-              (diffTruncated ? "NOTE: this diff was truncated for length. Judge only what you can see.\n\n" : "") +
+              (diffTruncated
+                ? "NOTE: this diff was truncated for length. Judge only what you can see.\n\n"
+                : "") +
               (context ? `PR title, body and linked issues:\n\n${context}\n\n---\n\n` : "") +
               `PR diff:\n\n${diff}\n\n---\n\nCouncil findings:\n\n${council}`,
           },
         ],
       }),
     });
-    if (!res.ok) throw new Error(`HTTP ${res.status}: ${truncate(await res.text().catch(() => ""), 300)}`);
+    if (!res.ok)
+      throw new Error(`HTTP ${res.status}: ${truncate(await res.text().catch(() => ""), 300)}`);
     const json = await res.json();
     const text = json?.choices?.[0]?.message?.content?.trim();
     if (!text) throw new Error("empty response");
@@ -184,7 +187,8 @@ function repairJsonStrings(text) {
 function parseVerdict(text) {
   const start = text.indexOf("{");
   const end = text.lastIndexOf("}");
-  if (start === -1 || end <= start) throw new Error(`no JSON object in chair reply: ${truncate(text, 200)}`);
+  if (start === -1 || end <= start)
+    throw new Error(`no JSON object in chair reply: ${truncate(text, 200)}`);
   const candidate = text.slice(start, end + 1);
   try {
     return JSON.parse(candidate);
@@ -192,7 +196,9 @@ function parseVerdict(text) {
     try {
       return JSON.parse(repairJsonStrings(candidate));
     } catch (repairErr) {
-      throw new Error(`chair reply is not JSON even after repair: ${err.message} (repair attempt: ${repairErr.message})`);
+      throw new Error(
+        `chair reply is not JSON even after repair: ${err.message} (repair attempt: ${repairErr.message})`,
+      );
     }
   }
 }
@@ -207,7 +213,8 @@ function normalizeFindings(parsed) {
   // exactly the "never approve over a Major" guarantee this file exists to
   // keep. json_object mode guarantees valid JSON, not the instructed schema,
   // so treat a wrong shape as a hard failure rather than an empty review.
-  if (!Array.isArray(raw)) throw new Error("chair reply had a malformed `findings` field (expected an array)");
+  if (!Array.isArray(raw))
+    throw new Error("chair reply had a malformed `findings` field (expected an array)");
   const bad = raw.filter((f) => !f || typeof f !== "object");
   if (bad.length) throw new Error(`chair reply had ${bad.length} finding(s) that were not objects`);
   // Severity is matched with === below, so "major" would slip past the gate
@@ -218,7 +225,8 @@ function normalizeFindings(parsed) {
   // so trim, then refuse what we do not recognize.
   for (const f of raw) {
     const severity = SEVERITIES[String(f.severity).trim().toLowerCase()];
-    if (!severity) throw new Error(`chair reply used an unrecognized severity: ${JSON.stringify(f.severity)}`);
+    if (!severity)
+      throw new Error(`chair reply used an unrecognized severity: ${JSON.stringify(f.severity)}`);
     f.severity = severity;
   }
   return raw;
@@ -248,7 +256,10 @@ function renderBody(parsed, findings, { diffTruncated } = {}) {
     "",
   ];
   if (diffTruncated) {
-    lines.push("> ⚠️ The diff was truncated for length; this review covers the first portion only.", "");
+    lines.push(
+      "> ⚠️ The diff was truncated for length; this review covers the first portion only.",
+      "",
+    );
   }
   if (sorted.length) {
     lines.push("### Findings", "");
@@ -266,23 +277,29 @@ function renderBody(parsed, findings, { diffTruncated } = {}) {
 function selfcheck() {
   // The reply that lost a whole review on PR #27: markdown underscores escaped
   // the markdown way, which JSON does not define.
-  const escaped = parseVerdict(String.raw`{"verdict":"comment","summary":"see \_foo\_ and C:\path","findings":[]}`);
+  const escaped = parseVerdict(
+    String.raw`{"verdict":"comment","summary":"see \_foo\_ and C:\path","findings":[]}`,
+  );
   if (!escaped.summary.includes("foo")) throw new Error("selfcheck: invalid escape not repaired");
 
   // A raw newline inside a string is the other way a markdown-writing model
   // breaks its own JSON.
   const raw = parseVerdict('{"verdict":"comment","summary":"line one\nline two","findings":[]}');
-  if (!raw.summary.includes("line two")) throw new Error("selfcheck: raw control character not repaired");
+  if (!raw.summary.includes("line two"))
+    throw new Error("selfcheck: raw control character not repaired");
 
   // Well-formed JSON must survive untouched — the repair is a fallback, not a
   // rewrite. \n stays a newline; it must not become a literal backslash-n.
   const clean = parseVerdict('{"verdict":"approve","summary":"a\\nb","findings":[]}');
-  if (clean.summary !== "a\nb") throw new Error("selfcheck: valid escape was mangled: " + JSON.stringify(clean.summary));
+  if (clean.summary !== "a\nb")
+    throw new Error("selfcheck: valid escape was mangled: " + JSON.stringify(clean.summary));
 
   // A raw control character right after an invalid escape (e.g. a stray
   // backslash at the end of a copied line, immediately followed by the
   // newline that ends it) must still get escaped, not copied through raw.
-  const backslashNewline = parseVerdict('{"verdict":"comment","summary":"end \\\nnext","findings":[]}');
+  const backslashNewline = parseVerdict(
+    '{"verdict":"comment","summary":"end \\\nnext","findings":[]}',
+  );
   if (!backslashNewline.summary.includes("next")) {
     throw new Error("selfcheck: control char after invalid escape not repaired");
   }
@@ -290,16 +307,25 @@ function selfcheck() {
   // A path like `C:\users` has `\u` followed by non-hex characters — not a
   // valid unicode escape. Only the backslash should be escaped; `u` and the
   // rest of the path must survive untouched.
-  const badUnicode = parseVerdict(String.raw`{"verdict":"comment","summary":"see C:\users\config","findings":[]}`);
+  const badUnicode = parseVerdict(
+    String.raw`{"verdict":"comment","summary":"see C:\users\config","findings":[]}`,
+  );
   if (!badUnicode.summary.includes("C:\\users\\config")) {
-    throw new Error("selfcheck: invalid \\u escape not repaired: " + JSON.stringify(badUnicode.summary));
+    throw new Error(
+      "selfcheck: invalid \\u escape not repaired: " + JSON.stringify(badUnicode.summary),
+    );
   }
 
   // A value ending in a lone backslash right before the real closing quote
   // (e.g. a Windows path) must not have that quote swallowed as `\"`.
-  const trailingBackslash = parseVerdict(String.raw`{"verdict":"comment","summary":"C:\path\","findings":[]}`);
+  const trailingBackslash = parseVerdict(
+    String.raw`{"verdict":"comment","summary":"C:\path\","findings":[]}`,
+  );
   if (trailingBackslash.summary !== "C:\\path\\") {
-    throw new Error("selfcheck: trailing backslash before closing quote not repaired: " + JSON.stringify(trailingBackslash.summary));
+    throw new Error(
+      "selfcheck: trailing backslash before closing quote not repaired: " +
+        JSON.stringify(trailingBackslash.summary),
+    );
   }
 
   // A genuine `\"` mid-sentence (a quoted word) followed by a comma must NOT
@@ -309,10 +335,13 @@ function selfcheck() {
   // all), this used to truncate the string at the quoted word and fail the
   // whole reply.
   const quoteThenComma = parseVerdict(
-    String.raw`{"verdict":"comment","summary":"say \"hi\", and \_bold\_ done","findings":[]}`
+    String.raw`{"verdict":"comment","summary":"say \"hi\", and \_bold\_ done","findings":[]}`,
   );
   if (quoteThenComma.summary !== 'say "hi", and \\_bold\\_ done') {
-    throw new Error("selfcheck: quoted phrase before comma misread as closing quote: " + JSON.stringify(quoteThenComma.summary));
+    throw new Error(
+      "selfcheck: quoted phrase before comma misread as closing quote: " +
+        JSON.stringify(quoteThenComma.summary),
+    );
   }
 
   // Repair is not a licence to accept anything: a truncated object still fails.
@@ -338,10 +367,14 @@ async function main() {
   const diff = diffFile && fs.existsSync(diffFile) ? fs.readFileSync(diffFile, "utf8") : "";
   if (!diff.trim()) throw new Error("empty diff");
   const council =
-    councilFile && fs.existsSync(councilFile) ? fs.readFileSync(councilFile, "utf8") : "_No council findings._";
+    councilFile && fs.existsSync(councilFile)
+      ? fs.readFileSync(councilFile, "utf8")
+      : "_No council findings._";
 
   const diffTruncated = diff.length > MAX_DIFF_CHARS;
-  const parsed = parseVerdict(await askChair(truncate(diff, MAX_DIFF_CHARS), council, diffTruncated));
+  const parsed = parseVerdict(
+    await askChair(truncate(diff, MAX_DIFF_CHARS), council, diffTruncated),
+  );
   const findings = normalizeFindings(parsed);
   // A syntactically-valid but empty reply ({}) would otherwise post "_No
   // summary._" with no findings and still report the step as a success —
@@ -355,9 +388,13 @@ async function main() {
 
   fs.writeFileSync("chair-fallback-review.md", body);
   const post = (f) =>
-    execFileSync("gh", ["pr", "review", String(pr), "--repo", repo, f, "--body-file", "chair-fallback-review.md"], {
-      stdio: "inherit",
-    });
+    execFileSync(
+      "gh",
+      ["pr", "review", String(pr), "--repo", repo, f, "--body-file", "chair-fallback-review.md"],
+      {
+        stdio: "inherit",
+      },
+    );
   try {
     post(flag);
     console.log(`fallback chair posted ${flag} (${findings.length} findings, model ${MODEL})`);
@@ -371,9 +408,12 @@ async function main() {
     // But a downgraded --request-changes must NOT read as a pass: the verdict
     // said Critical, and a green check would silently drop the block.
     if (flag === "--request-changes") {
-      throw new Error("posted the review as a comment, but could not request changes on a Critical finding", {
-        cause: err,
-      });
+      throw new Error(
+        "posted the review as a comment, but could not request changes on a Critical finding",
+        {
+          cause: err,
+        },
+      );
     }
     console.log(`fallback chair posted --comment (${findings.length} findings, model ${MODEL})`);
   }

--- a/scripts/council-config.mjs
+++ b/scripts/council-config.mjs
@@ -9,7 +9,10 @@ export const PROVIDERS = {
     keyEnv: "GEMINI_API_KEY",
   },
   moonshot: { url: "https://api.moonshot.ai/v1/chat/completions", keyEnv: "MOONSHOT_API_KEY" },
-  openrouter: { url: "https://openrouter.ai/api/v1/chat/completions", keyEnv: "OPENROUTER_API_KEY" },
+  openrouter: {
+    url: "https://openrouter.ai/api/v1/chat/completions",
+    keyEnv: "OPENROUTER_API_KEY",
+  },
   // Generic OpenAI-compatible endpoint (OpenRouter, self-hosted proxy, local
   // OffRouter). URL comes from env at call time; unset means the member skips.
   custom: { url: process.env.CUSTOM_BASE_URL, keyEnv: "CUSTOM_API_KEY" },
@@ -71,22 +74,48 @@ export const CREDENTIAL_FAILURE_STATUSES = [401, 402, 403, 429];
 export function openRouterFallbackFor(model) {
   if (model.provider === "openrouter") return null;
   if (!process.env.OPENROUTER_API_KEY?.trim()) return null;
-  const mapped = OPENROUTER_EQUIVALENT[model.model] || (model.model.includes("/") ? model.model : null);
+  const mapped =
+    OPENROUTER_EQUIVALENT[model.model] || (model.model.includes("/") ? model.model : null);
   if (!mapped) return null;
   return { ...model, provider: "openrouter", model: mapped };
 }
 
 export const DEFAULT_MODELS = [
-  { provider: "openai", model: process.env.OPENAI_MODEL || "gpt-5.6", name: "GPT-5.6 (Codex)", lens: "correctness" },
-  { provider: "gemini", model: process.env.GEMINI_MODEL || "gemini-3.1-pro-preview", name: "Gemini 3 Pro", lens: "performance" },
-  { provider: "moonshot", model: process.env.MOONSHOT_MODEL || "kimi-k3", name: "Kimi K3", lens: "security" },
-  { provider: "openrouter", model: process.env.OPENROUTER_MODEL || "x-ai/grok-4.5", name: "Grok 4.5", lens: "maintainability" },
+  {
+    provider: "openai",
+    model: process.env.OPENAI_MODEL || "gpt-5.6",
+    name: "GPT-5.6 (Codex)",
+    lens: "correctness",
+  },
+  {
+    provider: "gemini",
+    model: process.env.GEMINI_MODEL || "gemini-3.1-pro-preview",
+    name: "Gemini 3 Pro",
+    lens: "performance",
+  },
+  {
+    provider: "moonshot",
+    model: process.env.MOONSHOT_MODEL || "kimi-k3",
+    name: "Kimi K3",
+    lens: "security",
+  },
+  {
+    provider: "openrouter",
+    model: process.env.OPENROUTER_MODEL || "x-ai/grok-4.5",
+    name: "Grok 4.5",
+    lens: "maintainability",
+  },
   // Scope rides OpenRouter, not the native OpenAI key that `correctness`
   // already uses. Two lenses behind one key means one `insufficient_quota`
   // takes out both, and on 2026-08-27 that key was 429-ing on 47 of the 48
   // repos running this action. Its own SCOPE_MODEL override keeps a change
   // here from silently re-pointing the correctness member too.
-  { provider: "openrouter", model: process.env.SCOPE_MODEL || "openai/gpt-5.6", name: "GPT-5.6 (scope)", lens: "scope" },
+  {
+    provider: "openrouter",
+    model: process.env.SCOPE_MODEL || "openai/gpt-5.6",
+    name: "GPT-5.6 (scope)",
+    lens: "scope",
+  },
 ];
 
 // Test files whose ADDED lines make a mutation review worth paying for. The
@@ -148,7 +177,12 @@ export function diffAddsTestLines(diff) {
 // give quota isolation -- mutation shares OPENROUTER_API_KEY with the scope and
 // maintainability members, so an exhausted key still takes out all three.
 export function mutationMember() {
-  if (String(process.env.MUTATION_LENS || "").trim().toLowerCase() !== "true") return null;
+  if (
+    String(process.env.MUTATION_LENS || "")
+      .trim()
+      .toLowerCase() !== "true"
+  )
+    return null;
   return {
     provider: "openrouter",
     model: process.env.MUTATION_MODEL || "anthropic/claude-sonnet-5",
@@ -174,7 +208,8 @@ export function withMutationMember(models, diff) {
   const base = models.filter((m) => m.lens !== "mutation");
   const mutation = mutationMember();
   if (!mutation) return { members: base, mutationSkipped: null };
-  if (!diffAddsTestLines(diff)) return { members: base, mutationSkipped: "the diff adds no test lines" };
+  if (!diffAddsTestLines(diff))
+    return { members: base, mutationSkipped: "the diff adds no test lines" };
   return { members: [...base, mutation], mutationSkipped: null };
 }
 
@@ -186,11 +221,16 @@ export function selfcheckMutationRoster(buildFindingsMarkdown) {
   // The mutation lens must be OFF unless asked for. It is the front half of
   // something that gets expensive once it runs what it proposes, so a default
   // roster that quietly included it would be a cost nobody chose.
-  if (DEFAULT_MODELS.some((m) => m.lens === "mutation")) throw new Error("selfcheck: mutation lens is a default member");
-  const testDiff = "diff --git a/tests/t.py b/tests/t.py\n--- a/tests/t.py\n+++ b/tests/t.py\n+assert f() == 1\n";
-  const codeDiff = "diff --git a/src/a.ts b/src/a.ts\n--- a/src/a.ts\n+++ b/src/a.ts\n+const x = 1;\n";
-  if (diffAddsTestLines(codeDiff)) throw new Error("selfcheck: a code-only diff counted as adding tests");
-  if (!diffAddsTestLines(testDiff)) throw new Error("selfcheck: a test diff did not count as adding tests");
+  if (DEFAULT_MODELS.some((m) => m.lens === "mutation"))
+    throw new Error("selfcheck: mutation lens is a default member");
+  const testDiff =
+    "diff --git a/tests/t.py b/tests/t.py\n--- a/tests/t.py\n+++ b/tests/t.py\n+assert f() == 1\n";
+  const codeDiff =
+    "diff --git a/src/a.ts b/src/a.ts\n--- a/src/a.ts\n+++ b/src/a.ts\n+const x = 1;\n";
+  if (diffAddsTestLines(codeDiff))
+    throw new Error("selfcheck: a code-only diff counted as adding tests");
+  if (!diffAddsTestLines(testDiff))
+    throw new Error("selfcheck: a test diff did not count as adding tests");
   // Java/Kotlin/Scala name a test by suffix, not by directory or separator.
   if (
     !diffAddsTestLines("--- a/src/FooTest.java\n+++ b/src/FooTest.java\n+assertEquals(1, f());\n")
@@ -200,13 +240,17 @@ export function selfcheckMutationRoster(buildFindingsMarkdown) {
   // A lowercase "test" fused inside an unrelated word must NOT match -- only
   // the capitalized Test/Spec suffix does.
   if (diffAddsTestLines("--- a/src/Latest.js\n+++ b/src/Latest.js\n+const x = 1;\n")) {
-    throw new Error("selfcheck: a filename merely containing lowercase 'test' was misclassified as a test file");
+    throw new Error(
+      "selfcheck: a filename merely containing lowercase 'test' was misclassified as a test file",
+    );
   }
   // A test file that is only DELETED from adds nothing to review.
-  if (diffAddsTestLines("--- a/tests/t.py\n+++ b/tests/t.py\n-assert f() == 1\n")) throw new Error("selfcheck: a deletion counted as adding tests");
+  if (diffAddsTestLines("--- a/tests/t.py\n+++ b/tests/t.py\n-assert f() == 1\n"))
+    throw new Error("selfcheck: a deletion counted as adding tests");
   // The header itself starts with "+", so a naive scan of "+" lines would
   // report every diff as touching tests the moment one test file appears.
-  if (diffAddsTestLines("--- a/tests/t.py\n+++ b/tests/t.py\n")) throw new Error("selfcheck: the +++ header counted as an added line");
+  if (diffAddsTestLines("--- a/tests/t.py\n+++ b/tests/t.py\n"))
+    throw new Error("selfcheck: the +++ header counted as an added line");
   // ...and the flag has to reset at the next file, or one test file makes
   // every later hunk in the diff look like a test.
   if (
@@ -221,39 +265,47 @@ export function selfcheckMutationRoster(buildFindingsMarkdown) {
   // "+++ " header to its preceding "--- " line, that content line would be
   // misread as a new file header and silently swallow the real test line
   // that follows it.
-  if (
-    !diffAddsTestLines(
-      "--- a/tests/t.py\n+++ b/tests/t.py\n+++ counter;\n+assert f() == 1\n",
-    )
-  ) {
+  if (!diffAddsTestLines("--- a/tests/t.py\n+++ b/tests/t.py\n+++ counter;\n+assert f() == 1\n")) {
     throw new Error("selfcheck: an added '++ ' content line was misread as a file header");
   }
   const savedLens = process.env.MUTATION_LENS;
   try {
     delete process.env.MUTATION_LENS;
-    if (withMutationMember([], testDiff).members.length !== 0) throw new Error("selfcheck: mutation member added while disabled");
+    if (withMutationMember([], testDiff).members.length !== 0)
+      throw new Error("selfcheck: mutation member added while disabled");
     // A COUNCIL_MODELS override can name any lens string, including "mutation".
     // With the gate disabled that entry must be stripped, not dispatched as-is
     // -- otherwise a hand-written CSV row bypasses mutation_lens entirely.
     const smuggled = [{ provider: "openrouter", model: "x", name: "Smuggled", lens: "mutation" }];
     if (withMutationMember(smuggled, testDiff).members.length !== 0) {
-      throw new Error("selfcheck: a pre-existing mutation-lens member was dispatched while the gate is disabled");
+      throw new Error(
+        "selfcheck: a pre-existing mutation-lens member was dispatched while the gate is disabled",
+      );
     }
     process.env.MUTATION_LENS = "true";
     const on = withMutationMember([], testDiff);
-    if (on.members.length !== 1 || on.members[0].lens !== "mutation") throw new Error("selfcheck: mutation member not added when enabled");
+    if (on.members.length !== 1 || on.members[0].lens !== "mutation")
+      throw new Error("selfcheck: mutation member not added when enabled");
     // Even enabled, a smuggled entry must not double up with the canonical one.
     const onWithSmuggled = withMutationMember(smuggled, testDiff);
-    if (onWithSmuggled.members.length !== 1 || onWithSmuggled.members[0].name !== "Claude Sonnet 5 (mutation)") {
-      throw new Error("selfcheck: a pre-existing mutation-lens member duplicated the canonical one");
+    if (
+      onWithSmuggled.members.length !== 1 ||
+      onWithSmuggled.members[0].name !== "Claude Sonnet 5 (mutation)"
+    ) {
+      throw new Error(
+        "selfcheck: a pre-existing mutation-lens member duplicated the canonical one",
+      );
     }
     const skipped = withMutationMember([], codeDiff);
-    if (skipped.members.length !== 0) throw new Error("selfcheck: mutation member dispatched on a diff with no tests");
-    if (!skipped.mutationSkipped) throw new Error("selfcheck: skipped mutation member reported no reason");
+    if (skipped.members.length !== 0)
+      throw new Error("selfcheck: mutation member dispatched on a diff with no tests");
+    if (!skipped.mutationSkipped)
+      throw new Error("selfcheck: skipped mutation member reported no reason");
     // The reason has to reach the report. Silence reads as "found nothing",
     // which is the opposite of "never ran".
     const mdSkip = buildFindingsMarkdown([], { mutationSkipped: skipped.mutationSkipped });
-    if (!mdSkip.includes("Mutation lens enabled but not dispatched")) throw new Error("selfcheck: skip reason missing from the report");
+    if (!mdSkip.includes("Mutation lens enabled but not dispatched"))
+      throw new Error("selfcheck: skip reason missing from the report");
   } finally {
     if (savedLens === undefined) delete process.env.MUTATION_LENS;
     else process.env.MUTATION_LENS = savedLens;


### PR DESCRIPTION
Closes #70

## What
Adds `.oxfmtrc.json` and runs `oxfmt --write` over the 5 files it covers.

## Why
The 2026-08-31 fleet audit found oxfmt in zero of the 48 pooriaarab repos that
carry JS/TS, against oxlint in 40. One formatter, enforced in CI, removes a class
of review noise that agent-authored diffs generate constantly.

`ignorePatterns` excludes vendor, third_party, generated, minified and build
output. Without it the formatter rewrites dependencies: on foxcade that was
141,361 lines, of which roughly 87,000 were `three.module.js` and `maplibre-gl`.

Part 2 of 3, stacked on `vcr-68-adopt-oxfmt-part1`. Each part touches a disjoint set of files
so the parts do not conflict. Merge them in order.

## How I verified

```
npx oxfmt@0.65.0 --check .                 -> exit 0
npx oxlint@1.80.0 --config .oxlintrc.json  -> exit 0
git diff --numstat vcr-68-adopt-oxfmt-part1                 -> 5 files, 430 lines
```

No source was hand-edited. Every change is `oxfmt --write` output.

Assisted-by: claude-personal-1:claude-opus-5
