### PR TITLE
[VCR-74] Add canonical design context

### DIFF
--- a/.agents/brand.md
+++ b/.agents/brand.md
@@ -1,0 +1,45 @@
+# vibecodereview brand
+
+## Identity
+
+vibecodereview is a council PR-review tool in the Vibe Suite.
+
+One engine serves a GitHub composite Action, CLI, and MCP server. The engine produces Markdown findings for the chair.
+
+## Audience and promise
+
+vibecodereview serves maintainers who want several model perspectives on a pull request.
+
+Council members review through distinct lenses. The chair verifies their claims, can fix confirmed issues, and posts one review.
+
+## Voice
+
+Use direct, evidence-first language. Treat every model finding as an unverified claim until code confirms it.
+
+State skipped providers, truncation, and budget stops clearly. Do not turn degraded coverage into a successful-review claim.
+
+## Message hierarchy
+
+Lead with the review outcome and actionable findings. Follow with evidence, affected paths, and provider limitations.
+
+Keep configuration and cost controls visible when they affect review coverage or workflow runs.
+
+## Claims
+
+Support reliability, coverage, and compatibility claims with code and checks.
+
+Distinguish council output from the chair's verified review. Do not claim that every configured provider ran.
+
+The tool sends diffs to configured model providers. Follow the repository's personal and private code restriction.
+
+## Naming
+
+Write the product name as `vibecodereview` in lowercase.
+
+Write `Vibe Suite`, `GitHub Action`, `Claude Code`, `MCP`, and provider names in their official forms.
+
+## Assets and ownership
+
+The tracked logo is `assets/logo.jpg`. Two launch trailers are tracked in `assets/`.
+
+The README links to a shared getvibe.dev trailer page. This repository does not establish deployment ownership for that route.

--- a/.agents/design.md
+++ b/.agents/design.md
@@ -1,0 +1,78 @@
+# vibecodereview design context
+
+## Overview
+
+vibecodereview has a `developer-ui` surface: Action metadata, CLI output, MCP JSON-RPC, logs, and generated Markdown findings.
+
+The main sources are `action.yml`, `bin/vibecodereview.mjs`, `mcp/server.mjs`, and `scripts/council-review.mjs`.
+
+Keep the engine as the output source of truth. Surfaces must not fork provider or lens behavior.
+
+## Colors
+
+The CLI and MCP server define no ANSI colors. Status and errors use visible text.
+
+GitHub Action metadata sets the Marketplace icon to `eye` and its color to `purple` in `action.yml`.
+
+Treat that metadata as platform branding, not a product palette. Do not derive colors from the logo alone.
+
+## Typography
+
+Host terminals and Markdown renderers control fonts. The repository defines no font family, weight, or scale.
+
+Use plain text for CLI output. Preserve literal provider keys, commands, paths, and configuration names.
+
+Generated findings use Markdown headings, blockquotes, italics, and inline code from `scripts/council-review.mjs`.
+
+## Layout
+
+CLI command output follows the order in `bin/vibecodereview.mjs`.
+
+`doctor` prints `Chair:`, then two-space-indented status rows. It follows with `Council members:` and their status rows.
+
+`review-prs` separates pull requests with `=== owner/repo#number ===`. It ends with reviewed and error counts.
+
+The MCP server sends one JSON-RPC object per line on standard output. Parse errors go to standard error.
+
+Findings start with one H1 and an explanatory paragraph. Notices use blockquotes. Each member gets one H2 with its lens.
+
+The terminal controls wrapping. JSON-RPC framing must remain one object per line.
+
+## Elevation & Depth
+
+Not applicable. The developer surfaces define no overlays, shadows, or stacking.
+
+Headings, blank lines, blockquotes, and indentation express hierarchy.
+
+## Shapes
+
+CLI status uses words such as `set`, `MISSING`, `not set`, `SKIP/ERR`, and `ok`.
+
+Multi-repository output uses `===` separators. Findings use judge, warning, and information symbols with text labels.
+
+The current surfaces define no controls, radii, spinners, or custom borders.
+
+## Components
+
+The CLI exposes `init`, `review`, `review-prs`, `doctor`, and `secrets`.
+
+`init` reports the written workflow and next step. `secrets` prints commands without reading secret values.
+
+`review` prints generated findings. `review-prs` can also post them through the GitHub CLI.
+
+The MCP server exposes `council_review`. Successful and failed tool calls return text content inside JSON-RPC responses.
+
+The council report lists each model and lens. Missing keys, failures, and truncation appear as explicit notes.
+
+The GitHub Action combines the council findings with a chair review. Fix pushes depend on its configured inputs and limits.
+
+The owned surfaces define no animation. Text labels keep status understandable without color or motion.
+
+## Do's and Don'ts
+
+- Do keep provider and lens logic in the engine. Do not copy it into a surface.
+- Do disclose skipped members and truncated input. Do not imply full council coverage when members did not run.
+- Do keep MCP standard output valid JSON-RPC. Do not write decorative logs there.
+- Do preserve text status and error labels. Do not make meaning depend on color or symbols.
+- Do treat findings as claims for verification. Do not present raw council output as confirmed defects.
+- Do add delivery routes only after ownership is proven. Do not infer ownership from the shared catalog link.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@ surfaces: a GitHub composite Action (`action.yml`), a CLI (`bin/vibecodereview.m
 and an MCP server (`mcp/server.mjs`). Keep the engine the single source of truth —
 never fork its provider/lens logic into the surfaces.
 
+Read `.agents/brand.md` and `.agents/design.md` before public copy or interface work.
+
 ## Layout
 
 - `scripts/council-review.mjs` — fans a diff out to council models (OpenAI-compatible


### PR DESCRIPTION
Closes #74

## What

- Add canonical brand and developer-interface context.
- Preserve the existing agent guide and require both context files.
- Document current Action, CLI, MCP, and findings conventions.

## Why

Future interface work needs one verified source without invented tokens or route ownership.

## How I verified

npm run selfcheck -> passed
bun x oxlint@^1 --config .oxlintrc.json -> passed with six existing warnings
bash scripts/budget-guard.test.sh -> all passing
bash scripts/proof-gate.test.sh -> all passing
git diff --check -> passed
change size -> 125 counted lines

Assisted-by: pi:google/gemini-3.5-flash