### PR TITLE
[VCR-54] Teach the chair the PR standard it kept breaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ shows leaves that evidence good. `scripts/proof-gate.test.sh` pins both paths th
 `require_proof` flag travels — the council scope lens and the chair's own bullet —
 because the first version gated only one of them.
 
+The chair also reads the PR against the fleet standard when the repo carries
+`.github/pr-standards.json`: branch and title shape, exactly one `Closes #N`, a
+`## How I verified` that names a command and its result, and the hard caps of 500 counted
+lines and 40 counted files. Being over a cap is reported, never "fixed" — the chair names
+the split it would make and leaves the work alone, because deleting code to fit a cap is
+worse than a large PR.
+
+**The chair never signs its commits with a model name.** Its fix commits carry no
+`Co-Authored-By:` trailer, because the same standard rejects model attribution in commit
+messages: a repo enforcing `pr-standards` would fail its own review bot, and the PR could
+not merge until a human squashed the bot's commit away. That happened twice in
+[pooriaarab/scripts](https://github.com/pooriaarab/scripts) before this was fixed.
+Attribution belongs in the PR body as `Assisted-by:`, written by the author.
+
 ## Use it in a repo
 
 ```bash

--- a/action.yml
+++ b/action.yml
@@ -325,6 +325,22 @@ runs:
            issues, fix them (Edit/Write), then:
            `git add -A && git commit -m "fix: <what>" && git push origin __BRANCH__`
            Do NOT push style-only or speculative changes.
+           NEVER add a `Co-Authored-By:` trailer, or any trailer naming a model or an agent.
+           The fleet PR standard rejects model attribution in commit messages, so a repo that
+           enforces `pr-standards` fails its own review bot and the PR cannot merge until a
+           human squashes your commit away. Attribution belongs in the PR body as
+           `Assisted-by:`, which the author writes, not you.
+        5b. PR-STANDARD LENS. If the repo has `.github/pr-standards.json`, this PR is subject
+           to the fleet standard: a `<prefix>-<issue>-<slug>` branch, a `[PREFIX-<issue>]
+           <imperative subject>` title, a body with exactly one `Closes #<issue>` plus
+           `## What`, `## Why`, and a `## How I verified` that names a real command and its
+           result, ending in `Assisted-by:`. Hard caps: 500 counted lines and 40 counted
+           files (lockfiles, build output, snapshots, generated code and migrations do not
+           count). Report violations as Major findings.
+           Over a cap is NOT something you fix. Do not delete work to fit, and do not push a
+           fix that would carry the PR over: your own commits count. Say it is over, name the
+           concrete split — which files or which concern belongs in a follow-up PR, and in
+           what order they should land — and leave the work in place for the author.
         6. Assign severity yourself (council members do not rate it): Critical (security, crash,
            data loss), Major (real bug / convention violation), Minor (rest). Post Major+ inline,
            roll Minor into the summary, cap ~8 inline comments. Submit ONE review with


### PR DESCRIPTION
Closes #54

## What

The chair prompt now forbids model trailers on its fix commits, and reads the PR against the fleet PR standard as an explicit lens.

## Why

The review bot was failing the standard it works alongside. Its auto-fix commits carried `Co-Authored-By: Claude Sonnet 5`, which `pr-standards` rejects:

```
FAIL  AI attribution in 6292a63
      got:      Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
      expected: no model or agent named in a commit trailer
```

So on any repo enforcing the standard, a PR the chair touched could not merge until a human squashed the bot's commit away — throwing out its authorship along with the trailer. That happened twice in `pooriaarab/scripts` (#119, #124), and both times the fixes themselves were good.

The second half is the lens. The chair already reads `AGENTS.md`, `CLAUDE.md` and `.claude/rules/`; the standard those repos are actually gated on was not among them. It now checks branch and title shape, exactly one `Closes #N`, a `## How I verified` that names a command and its result, and the hard caps.

**Being over a cap is reported, never fixed.** The prompt is explicit that the chair must not delete work to fit, and must not push a fix that carries the PR over — its own commits count against the cap. Instead it names the concrete split: which files or which concern belongs in a follow-up, and in what order they should land. A cap exists to force decomposition before the code is written; a bot shrinking a diff to satisfy it would defeat the point and lose work.

## How I verified

```
python3 -c "import yaml; yaml.safe_load(open('action.yml'))"  -> yaml ok, prompt heredoc intact
git diff --stat                                               -> action.yml +17, README.md +14, no other files
```

The prompt change is inside the quoted `VCR_PROMPT_EOF` heredoc, so the added text stays literal — verified by parsing the file after the edit, since a stray backtick or `$` there would break the build step rather than the review.

This cannot be verified end to end without a live run: the chair only pushes a fix commit when it finds a confirmed defect on a real PR. The next PR it fixes anywhere in the fleet is the test, and the signal is a fix commit whose message ends at its own body.

Assisted-by: claude-personal:claude-opus-5