### PR TITLE
[VCR-77] Ship the VISION.md exception in the template

### DIFF
--- a/bin/rollout.mjs
+++ b/bin/rollout.mjs
@@ -58,7 +58,12 @@ const WORKFLOW_YAML =
     'on:',
     '  pull_request:',
     '    types: [opened, synchronize, review_requested]',
-    '    paths-ignore: ["**.md", "docs/**"]',
+    // VISION.md is what the council reads to judge whether every OTHER pull
+    // request belongs in the repo, so the markdown skip made it the one file
+    // the council never saw — and the one file it could never approve. A later
+    // negative pattern re-includes a path an earlier one ignored, so a README
+    // typo still costs nothing.
+    '    paths-ignore: ["**.md", "docs/**", "!VISION.md"]',
     'concurrency:',
     '  group: vibecodereview-${{ github.event.pull_request.number }}',
     '  cancel-in-progress: true',


### PR DESCRIPTION
Closes #77

## What

`bin/rollout.mjs` now writes `paths-ignore: ["**.md", "docs/**", "!VISION.md"]` into the workflow it installs.

## Why

The markdown skip is right — a README typo does not need a five-model council. It covered `VISION.md` too, and that one file is different: it is what the council reads to judge whether every *other* pull request belongs in the repo. A wrong one does not cost one bad merge, it bends every review after it.

It was also the one file the council could never approve, which makes "merge once the council approves and CI is green" unreachable for exactly the document that governs the rest.

Nine repos now carry the exception by hand. Without this the next install puts it back.

## How I verified

The emitted workflow parses, and the negation lands last, which is what makes it win:

```
$ node -e "…extract WORKFLOW_YAML from bin/rollout.mjs, write it out…"
name: vibecodereview
on:
  pull_request:
    types: [opened, synchronize, review_requested]
    paths-ignore: ["**.md", "docs/**", "!VISION.md"]

$ python3 -c "import yaml; d = yaml.safe_load(open('/tmp/emitted.yml')); print('emitted yaml parses; filter =', d[True]['pull_request']['paths-ignore'])"
emitted yaml parses; filter = ['**.md', 'docs/**', '!VISION.md']   ->  ok
```

```
$ node scripts/council-review.mjs --selfcheck
selfcheck ok
```

The real check is the nine vision pull requests that got this line by hand today: each changes `VISION.md`, and until the line was added no council ran on any of them. If the council does not review those, the filter needs the positive `paths` form instead and this is wrong.

Proof: n/a — a CI trigger inside a rollout template, with no visible surface.

Assisted-by: claude-personal-1:claude-opus-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated automated workflow triggering to skip most Markdown and documentation changes while continuing to review `VISION.md`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->