### PR TITLE
[VCR-83] Prove a review was posted before going green

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -894,10 +894,25 @@ runs:
         [ "$claimed" = none ] && [ "$Q" = "success" ] && claimed="fourth"
         [ "$claimed" = none ] && [ "$F" = "success" ] && claimed="fallback"
 
-        posted=$(gh api "repos/$VCR_REPO/pulls/$VCR_PR/reviews" --paginate \
-          --jq "[.[] | select(.submitted_at >= \"$STARTED_AT\")] | length" 2>/dev/null || echo 0)
+        # `--jq` runs once per page under `--paginate`, so on a PR with more
+        # than one page of reviews this printed one number per page and
+        # `-gt` blew up on the multi-line result. Piping the raw pages into
+        # `jq -s` (the pattern already used above for the budget comment
+        # lookup) slurps every page into one array before counting.
+        #
+        # Login is checked too: without it, any human or unrelated bot review
+        # (e.g. coderabbitai[bot], which reviews this very PR) posted after
+        # STARTED_AT satisfies the gate even when every chair failed to post.
+        # "claude[bot]" covers the four Claude Code Action chairs; the
+        # OpenRouter fallback posts through `gh pr review` with
+        # `inputs.github_token`, documented above as the caller's
+        # `github.token`, which GitHub always attributes to
+        # "github-actions[bot]".
+        posted=$(gh api "repos/$VCR_REPO/pulls/$VCR_PR/reviews" --paginate 2>/dev/null \
+          | jq -s "[.[][] | select(.submitted_at >= \"$STARTED_AT\" and (.user.login == \"claude[bot]\" or .user.login == \"github-actions[bot]\"))] | length" 2>/dev/null)
+        posted="${posted:-0}"
 
-        if [ "${posted:-0}" -gt 0 ]; then
+        if [ "$posted" -gt 0 ]; then
           echo "chair: $claimed posted $posted review(s) this run"
           exit 0
         fi

--- a/action.yml
+++ b/action.yml
@@ -94,6 +94,13 @@ runs:
     # A full-history clone is usually waste here: the diff comes from the API,
     # and the delta needs only the previous reviewed head plus the commits the
     # fix-cycle guard counts. A missing previous head fails open to the API diff.
+    # Recorded before anything reviews, so the result gate can tell a review
+    # posted by THIS run from one left by an earlier cycle. Without it a stale
+    # review from yesterday would satisfy today's gate.
+    - name: Mark the start of this run
+      id: gate_start
+      shell: bash
+      run: echo "at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
     - name: Checkout PR branch
       uses: actions/checkout@v4
       with:
@@ -843,24 +850,63 @@ runs:
           gh api "repos/$VCR_REPO/issues/$VCR_PR/comments" -X POST -F body=@budget-comment.md --silent
         fi
 
+    # The gate asks whether a review was POSTED, not whether a step exited 0.
+    #
+    # A step can succeed and review nothing. claude-code-action refuses to run
+    # when the pull request edits its own workflow file -- a correct control, a
+    # pull request must not edit the reviewer that judges it -- and a skipped
+    # action still exits 0. So the outcome read `success`, this gate printed
+    # "backup token succeeded", the check went green, and no review existed.
+    # Eight pull requests in the fleet carried that green check on one day.
+    #
+    # Green is the dangerous direction: a red check gets investigated and a
+    # green one gets merged. So the only evidence accepted here is a review on
+    # the pull request, newer than this run's start.
     - name: Chair result gate
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        VCR_PR: ${{ github.event.pull_request.number }}
+        VCR_REPO: ${{ github.repository }}
+        P: ${{ steps.chair_primary.outcome }}
+        B: ${{ steps.chair_backup.outcome }}
+        T: ${{ steps.chair_third.outcome }}
+        Q: ${{ steps.chair_fourth.outcome }}
+        F: ${{ steps.chair_fallback.outcome }}
+        OVER_BUDGET: ${{ steps.budget.outputs.over }}
+        TOKEN_1: ${{ steps.chair_probe.outputs.token_1 }}
+        TOKEN_2: ${{ steps.chair_probe.outputs.token_2 }}
+        TOKEN_3: ${{ steps.chair_probe.outputs.token_3 }}
+        TOKEN_4: ${{ steps.chair_probe.outputs.token_4 }}
+        STARTED_AT: ${{ steps.gate_start.outputs.at }}
       run: |
-        P="${{ steps.chair_primary.outcome }}"
-        B="${{ steps.chair_backup.outcome }}"
-        T="${{ steps.chair_third.outcome }}"
-        Q="${{ steps.chair_fourth.outcome }}"
-        F="${{ steps.chair_fallback.outcome }}"
-        if [ "${{ steps.budget.outputs.over }}" = "true" ]; then
+        set -uo pipefail
+        if [ "$OVER_BUDGET" = "true" ]; then
           echo "chair: skipped, the pull request is over budget"; exit 0
         fi
-        if [ "$P" = "success" ]; then echo "chair: primary token succeeded"; exit 0; fi
-        if [ "$B" = "success" ]; then echo "chair: primary did not review ($P); backup token succeeded"; exit 0; fi
-        if [ "$T" = "success" ]; then echo "chair: primary and backup failed; third token succeeded"; exit 0; fi
-        if [ "$Q" = "success" ]; then echo "chair: first three tokens failed; fourth token succeeded"; exit 0; fi
-        if [ "$F" = "success" ]; then echo "chair: all Claude tokens failed; OpenRouter fallback posted the review"; exit 0; fi
-        echo "chair review failed (primary=$P, backup=${B:-skipped}, third=${T:-skipped}, fourth=${Q:-skipped}, fallback=${F:-skipped})"
-        echo "probe: token_1=${{ steps.chair_probe.outputs.token_1 }} token_2=${{ steps.chair_probe.outputs.token_2 }} token_3=${{ steps.chair_probe.outputs.token_3 }} token_4=${{ steps.chair_probe.outputs.token_4 }}"
+
+        # Which step claims to have reviewed. Kept for the message only; the
+        # claim is not what decides the outcome.
+        claimed="none"
+        [ "$P" = "success" ] && claimed="primary"
+        [ "$claimed" = none ] && [ "$B" = "success" ] && claimed="backup"
+        [ "$claimed" = none ] && [ "$T" = "success" ] && claimed="third"
+        [ "$claimed" = none ] && [ "$Q" = "success" ] && claimed="fourth"
+        [ "$claimed" = none ] && [ "$F" = "success" ] && claimed="fallback"
+
+        posted=$(gh api "repos/$VCR_REPO/pulls/$VCR_PR/reviews" --paginate \
+          --jq "[.[] | select(.submitted_at >= \"$STARTED_AT\")] | length" 2>/dev/null || echo 0)
+
+        if [ "${posted:-0}" -gt 0 ]; then
+          echo "chair: $claimed posted $posted review(s) this run"
+          exit 0
+        fi
+
+        echo "chair posted no review this run (claimed=$claimed; primary=$P, backup=${B:-skipped}, third=${T:-skipped}, fourth=${Q:-skipped}, fallback=${F:-skipped})"
+        echo "probe: token_1=$TOKEN_1 token_2=$TOKEN_2 token_3=$TOKEN_3 token_4=$TOKEN_4"
+        echo "A step that exits 0 without posting is the failure this gate exists to catch."
+        echo "Most often: the pull request edits .github/workflows/vibecodereview.yml, and"
+        echo "claude-code-action refuses to run when the workflow differs from the default branch."
         exit 1
 
     # Persist the review boundary and the findings that still need a chair's

--- a/action.yml
+++ b/action.yml
@@ -903,14 +903,26 @@ runs:
         # Login is checked too: without it, any human or unrelated bot review
         # (e.g. coderabbitai[bot], which reviews this very PR) posted after
         # STARTED_AT satisfies the gate even when every chair failed to post.
-        # "claude[bot]" covers the four Claude Code Action chairs; the
-        # OpenRouter fallback posts through `gh pr review` with
-        # `inputs.github_token`, documented above as the caller's
-        # `github.token`, which GitHub always attributes to
-        # "github-actions[bot]".
+        # "claude[bot]" covers the four Claude Code Action chairs (confirmed
+        # by scripts/budget-guard.sh, which already counts reviews under that
+        # login for the same fleet). The OpenRouter fallback posts through
+        # `gh pr review` with `inputs.github_token`; on the default wiring
+        # (`github_token: ${{ github.token }}`) GitHub attributes that to
+        # "github-actions[bot]", but a consumer repo may instead pass a
+        # `vibecodereview[bot]`-backed app token, the same login
+        # council-cache.mjs and the review-state lookup above already treat
+        # as an automation actor -- so it is accepted here too.
         posted=$(gh api "repos/$VCR_REPO/pulls/$VCR_PR/reviews" --paginate 2>/dev/null \
-          | jq -s "[.[][] | select(.submitted_at >= \"$STARTED_AT\" and (.user.login == \"claude[bot]\" or .user.login == \"github-actions[bot]\"))] | length" 2>/dev/null)
+          | jq -s "[.[][] | select(.submitted_at >= \"$STARTED_AT\" and (.user.login == \"claude[bot]\" or .user.login == \"github-actions[bot]\" or .user.login == \"vibecodereview[bot]\"))] | length" 2>/dev/null)
         posted="${posted:-0}"
+
+        # The primary subscription failing is easy to miss: the gate can
+        # still go green off a later token, and the only trace was a probe
+        # line nobody reads unless the gate also fails. Warn every run, not
+        # only on failure.
+        if [ "$TOKEN_1" = "dead" ] && { [ "$TOKEN_2" = "live" ] || [ "$TOKEN_3" = "live" ] || [ "$TOKEN_4" = "live" ]; }; then
+          echo "::warning::primary Claude subscription token is dead (probe: token_1=$TOKEN_1 token_2=$TOKEN_2 token_3=$TOKEN_3 token_4=$TOKEN_4); this run is on a backup token"
+        fi
 
         if [ "$posted" -gt 0 ]; then
           echo "chair: $claimed posted $posted review(s) this run"

--- a/scripts/chair-gate.test.sh
+++ b/scripts/chair-gate.test.sh
@@ -61,8 +61,34 @@ check() {
   fi
 }
 
+# Asserts on the gate's output rather than its exit code, for behavior (like
+# the dead-primary-token warning) that must not flip the pass/fail verdict.
+check_output() {
+  local mode="$1" needle="$2" name="$3" out
+  out=$(bash "$WORK/gate.sh" 2>&1)
+  case "$mode" in
+    contains)
+      if printf '%s' "$out" | grep -qF "$needle"; then
+        printf 'ok    %s\n' "$name"
+      else
+        printf 'FAIL  %s (output did not contain %q)\n' "$name" "$needle"
+        fails=$((fails + 1))
+      fi
+      ;;
+    lacks)
+      if printf '%s' "$out" | grep -qF "$needle"; then
+        printf 'FAIL  %s (output unexpectedly contained %q)\n' "$name" "$needle"
+        fails=$((fails + 1))
+      else
+        printf 'ok    %s\n' "$name"
+      fi
+      ;;
+  esac
+}
+
 claude_review() { printf '{"submitted_at":"%s","user":{"login":"claude[bot]"}}' "${1:-2026-01-01T13:00:00Z}"; }
 fallback_review() { printf '{"submitted_at":"%s","user":{"login":"github-actions[bot]"}}' "${1:-2026-01-01T13:00:00Z}"; }
+vibecodereview_review() { printf '{"submitted_at":"%s","user":{"login":"vibecodereview[bot]"}}' "${1:-2026-01-01T13:00:00Z}"; }
 unrelated_review() { printf '{"submitted_at":"%s","user":{"login":"coderabbitai[bot]"}}' "${1:-2026-01-01T13:00:00Z}"; }
 
 # The shipped bug. A step succeeded, nothing was posted, the check went green.
@@ -81,6 +107,12 @@ OVER_BUDGET=false P=failure B=failure T=failure Q=success F=skipped REVIEWS_JSON
   check 0 'the fourth token posting passes'
 OVER_BUDGET=false P=failure B=failure T=failure Q=failure F=success REVIEWS_JSON="[$(fallback_review)]" \
   check 0 'the OpenRouter fallback posting under github-actions[bot] passes'
+
+# A consumer repo may wire a `vibecodereview[bot]`-backed app token into
+# github_token instead of the default github.token, so the fallback's review
+# shows up under that login there rather than github-actions[bot].
+OVER_BUDGET=false P=failure B=failure T=failure Q=failure F=success REVIEWS_JSON="[$(vibecodereview_review)]" \
+  check 0 'the OpenRouter fallback posting under vibecodereview[bot] passes'
 
 OVER_BUDGET=false P=failure B=failure T=failure Q=failure F=failure REVIEWS_JSON='[]' \
   check 1 'every chair failing fails the gate'
@@ -109,6 +141,19 @@ OVER_BUDGET=false P=failure B=failure T=failure Q=failure F=success \
 # without a review. Failing here would hide a real failure behind a cost stop.
 OVER_BUDGET=true P=skipped B=skipped T=skipped Q=skipped F=skipped REVIEWS_JSON='[]' \
   check 0 'an over-budget run passes without a review'
+
+# The primary subscription failing over to a backup token is easy to miss --
+# the gate still goes green -- so it must warn on both the success and
+# failure path, not only inside the failure message.
+OVER_BUDGET=false P=failure B=success T=skipped Q=skipped F=skipped TOKEN_1=dead TOKEN_2=live \
+  REVIEWS_JSON="[$(claude_review)]" \
+  check_output contains '::warning::' 'a dead primary token warns even when the gate passes'
+OVER_BUDGET=false P=failure B=failure T=failure Q=failure F=failure TOKEN_1=dead TOKEN_2=live \
+  REVIEWS_JSON='[]' \
+  check_output contains '::warning::' 'a dead primary token warns when the gate also fails'
+OVER_BUDGET=false P=success B=skipped T=skipped Q=skipped F=skipped TOKEN_1=live TOKEN_2=live \
+  REVIEWS_JSON="[$(claude_review)]" \
+  check_output lacks '::warning::' 'a live primary token warns of nothing'
 
 [ "$fails" = 0 ] || { printf '\n%s failing\n' "$fails" >&2; exit 1; }
 printf '\nall passing\n'

--- a/scripts/chair-gate.test.sh
+++ b/scripts/chair-gate.test.sh
@@ -23,17 +23,30 @@ gate = next(s for s in steps if s.get("name") == "Chair result gate")
 open(sys.argv[2], "w").write(gate["run"])
 PY
 
-# Stand in for the reviews query. REVIEWS_POSTED is what the real API would
-# return for reviews submitted since this run started.
+# Stand in for the reviews query. REVIEWS_JSON is a JSON array of review
+# objects, each shaped like the real API (`submitted_at`, `user.login`); the
+# stub hands them back one per page, exactly like real `--paginate` output,
+# so the gate's own `jq -s` pipeline does the flattening, time filter, and
+# login filter for real instead of a preset count standing in for the result.
+# It also checks the invocation shape, so dropping `--paginate` or pointing
+# at the wrong endpoint fails loudly instead of the stub answering anyway.
 mkdir -p "$WORK/bin"
 cat > "$WORK/bin/gh" <<'GH'
 #!/usr/bin/env bash
-echo "${REVIEWS_POSTED:-0}"
+case "$*" in
+  *"/reviews"*"--paginate"*) ;;
+  *) echo "unexpected gh invocation: $*" >&2; exit 1 ;;
+esac
+python3 -c '
+import json, os
+for r in json.loads(os.environ.get("REVIEWS_JSON", "[]")):
+    print(json.dumps([r]))
+'
 GH
 chmod +x "$WORK/bin/gh"
 export PATH="$WORK/bin:$PATH"
 
-export VCR_PR=1 VCR_REPO=owner/repo STARTED_AT=2026-01-01T00:00:00Z
+export VCR_PR=1 VCR_REPO=owner/repo STARTED_AT=2026-01-01T12:00:00Z
 export TOKEN_1=live TOKEN_2=live TOKEN_3=live TOKEN_4=live
 
 fails=0
@@ -48,29 +61,53 @@ check() {
   fi
 }
 
+claude_review() { printf '{"submitted_at":"%s","user":{"login":"claude[bot]"}}' "${1:-2026-01-01T13:00:00Z}"; }
+fallback_review() { printf '{"submitted_at":"%s","user":{"login":"github-actions[bot]"}}' "${1:-2026-01-01T13:00:00Z}"; }
+unrelated_review() { printf '{"submitted_at":"%s","user":{"login":"coderabbitai[bot]"}}' "${1:-2026-01-01T13:00:00Z}"; }
+
 # The shipped bug. A step succeeded, nothing was posted, the check went green.
-OVER_BUDGET=false P=success B=skipped T=skipped Q=skipped F=skipped REVIEWS_POSTED=0 \
+OVER_BUDGET=false P=success B=skipped T=skipped Q=skipped F=skipped REVIEWS_JSON='[]' \
   check 1 'a step that exits 0 without posting fails the gate'
 
-OVER_BUDGET=false P=success B=skipped T=skipped Q=skipped F=skipped REVIEWS_POSTED=1 \
+OVER_BUDGET=false P=success B=skipped T=skipped Q=skipped F=skipped REVIEWS_JSON="[$(claude_review)]" \
   check 0 'a posted review passes'
 
 # Failover still works: any chair may fail as long as something posted.
-OVER_BUDGET=false P=failure B=success T=skipped Q=skipped F=skipped REVIEWS_POSTED=1 \
+OVER_BUDGET=false P=failure B=success T=skipped Q=skipped F=skipped REVIEWS_JSON="[$(claude_review)]" \
   check 0 'the backup token posting passes'
-OVER_BUDGET=false P=failure B=failure T=success Q=skipped F=skipped REVIEWS_POSTED=1 \
+OVER_BUDGET=false P=failure B=failure T=success Q=skipped F=skipped REVIEWS_JSON="[$(claude_review)]" \
   check 0 'the third token posting passes'
-OVER_BUDGET=false P=failure B=failure T=failure Q=success F=skipped REVIEWS_POSTED=1 \
+OVER_BUDGET=false P=failure B=failure T=failure Q=success F=skipped REVIEWS_JSON="[$(claude_review)]" \
   check 0 'the fourth token posting passes'
-OVER_BUDGET=false P=failure B=failure T=failure Q=failure F=success REVIEWS_POSTED=1 \
-  check 0 'the OpenRouter fallback posting passes'
+OVER_BUDGET=false P=failure B=failure T=failure Q=failure F=success REVIEWS_JSON="[$(fallback_review)]" \
+  check 0 'the OpenRouter fallback posting under github-actions[bot] passes'
 
-OVER_BUDGET=false P=failure B=failure T=failure Q=failure F=failure REVIEWS_POSTED=0 \
+OVER_BUDGET=false P=failure B=failure T=failure Q=failure F=failure REVIEWS_JSON='[]' \
   check 1 'every chair failing fails the gate'
+
+# A review that predates this run does not count -- it is evidence of a past
+# cycle, not this one.
+OVER_BUDGET=false P=failure B=failure T=skipped Q=skipped F=skipped \
+  REVIEWS_JSON="[$(claude_review 2026-01-01T11:00:00Z)]" \
+  check 1 'a review submitted before this run started does not count'
+
+# The bug this file exists to catch: every chair failed, but an unrelated
+# bot (coderabbitai reviews this very repo's PRs) commented on the pull
+# request while the run was in flight. Counting it would report success for
+# a run that posted nothing.
+OVER_BUDGET=false P=failure B=failure T=failure Q=failure F=failure REVIEWS_JSON="[$(unrelated_review)]" \
+  check 1 'an unrelated bot review after this run started does not count'
+
+# Real pagination: three reviews returned as three separate pages, only the
+# last one qualifying. If `--jq` ran per page instead of over the slurped
+# whole, `-gt` would choke on a multi-line count.
+OVER_BUDGET=false P=failure B=failure T=failure Q=failure F=success \
+  REVIEWS_JSON="[$(unrelated_review 2026-01-01T10:00:00Z), $(claude_review 2026-01-01T11:30:00Z), $(fallback_review)]" \
+  check 0 'a qualifying review counts even split across multiple pages'
 
 # Over budget is a routing decision, not a verdict on the code, so it passes
 # without a review. Failing here would hide a real failure behind a cost stop.
-OVER_BUDGET=true P=skipped B=skipped T=skipped Q=skipped F=skipped REVIEWS_POSTED=0 \
+OVER_BUDGET=true P=skipped B=skipped T=skipped Q=skipped F=skipped REVIEWS_JSON='[]' \
   check 0 'an over-budget run passes without a review'
 
 [ "$fails" = 0 ] || { printf '\n%s failing\n' "$fails" >&2; exit 1; }

--- a/scripts/chair-gate.test.sh
+++ b/scripts/chair-gate.test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Drive the chair result gate that action.yml embeds.
+#
+# The gate decides whether a pull request's review check goes green, and green
+# is the dangerous direction: a red check gets investigated, a green one gets
+# merged. The case that matters is the one that shipped — a chair step exits 0
+# having reviewed nothing, because claude-code-action refuses to run when the
+# pull request edits its own workflow file. A skipped action still exits 0, so
+# an outcome-only gate called that success. Eight pull requests in the fleet
+# carried that green check on one day.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Extract the step from action.yml rather than copying it, so the test cannot
+# drift from what the action runs.
+python3 - "$(dirname "$HERE")/action.yml" "$WORK/gate.sh" <<'PY'
+import sys, yaml
+steps = yaml.safe_load(open(sys.argv[1]))["runs"]["steps"]
+gate = next(s for s in steps if s.get("name") == "Chair result gate")
+open(sys.argv[2], "w").write(gate["run"])
+PY
+
+# Stand in for the reviews query. REVIEWS_POSTED is what the real API would
+# return for reviews submitted since this run started.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/gh" <<'GH'
+#!/usr/bin/env bash
+echo "${REVIEWS_POSTED:-0}"
+GH
+chmod +x "$WORK/bin/gh"
+export PATH="$WORK/bin:$PATH"
+
+export VCR_PR=1 VCR_REPO=owner/repo STARTED_AT=2026-01-01T00:00:00Z
+export TOKEN_1=live TOKEN_2=live TOKEN_3=live TOKEN_4=live
+
+fails=0
+check() {
+  local want="$1" name="$2" got out
+  out=$(bash "$WORK/gate.sh" 2>&1); got=$?
+  if [ "$got" = "$want" ]; then
+    printf 'ok    %s\n' "$name"
+  else
+    printf 'FAIL  %s (want exit %s, got %s)\n      %s\n' "$name" "$want" "$got" "$(printf '%s' "$out" | head -1)"
+    fails=$((fails + 1))
+  fi
+}
+
+# The shipped bug. A step succeeded, nothing was posted, the check went green.
+OVER_BUDGET=false P=success B=skipped T=skipped Q=skipped F=skipped REVIEWS_POSTED=0 \
+  check 1 'a step that exits 0 without posting fails the gate'
+
+OVER_BUDGET=false P=success B=skipped T=skipped Q=skipped F=skipped REVIEWS_POSTED=1 \
+  check 0 'a posted review passes'
+
+# Failover still works: any chair may fail as long as something posted.
+OVER_BUDGET=false P=failure B=success T=skipped Q=skipped F=skipped REVIEWS_POSTED=1 \
+  check 0 'the backup token posting passes'
+OVER_BUDGET=false P=failure B=failure T=success Q=skipped F=skipped REVIEWS_POSTED=1 \
+  check 0 'the third token posting passes'
+OVER_BUDGET=false P=failure B=failure T=failure Q=success F=skipped REVIEWS_POSTED=1 \
+  check 0 'the fourth token posting passes'
+OVER_BUDGET=false P=failure B=failure T=failure Q=failure F=success REVIEWS_POSTED=1 \
+  check 0 'the OpenRouter fallback posting passes'
+
+OVER_BUDGET=false P=failure B=failure T=failure Q=failure F=failure REVIEWS_POSTED=0 \
+  check 1 'every chair failing fails the gate'
+
+# Over budget is a routing decision, not a verdict on the code, so it passes
+# without a review. Failing here would hide a real failure behind a cost stop.
+OVER_BUDGET=true P=skipped B=skipped T=skipped Q=skipped F=skipped REVIEWS_POSTED=0 \
+  check 0 'an over-budget run passes without a review'
+
+[ "$fails" = 0 ] || { printf '\n%s failing\n' "$fails" >&2; exit 1; }
+printf '\nall passing\n'


### PR DESCRIPTION
Closes #83

## What

The chair result gate now requires a review to have been **posted** before it goes green. A step's exit code decides nothing.

## Why

A step can exit 0 having reviewed nothing.

`claude-code-action` refuses to run when a pull request edits its own workflow file — a correct control, since a pull request must not edit the reviewer that judges it. A skipped action still exits 0. So `steps.chair_backup.outcome` read `success`, this gate printed `chair: primary did not review (skipped); backup token succeeded`, the check went green, and no review existed.

Eight pull requests across the fleet carried that green check on one day. That is worse than a red one: red gets investigated, green gets merged.

The gate now accepts one kind of evidence — a review on the pull request submitted after this run started. The step's claim is kept for the message and decides nothing. An over-budget run still passes without a review, because that stop is a routing decision rather than a verdict on the code, and failing there would hide a real failure behind a cost cap.

The same log surfaced a second thing worth acting on separately: `probe: token_1=dead`. The primary subscription token is not working, so every review in the fleet is currently running on the backup.

## How I verified

`scripts/chair-gate.test.sh` extracts the step from `action.yml` rather than copying it, so the test cannot drift from what the action runs, and stubs the reviews query.

```
$ ./scripts/chair-gate.test.sh
ok    a step that exits 0 without posting fails the gate
ok    a posted review passes
ok    the backup token posting passes
ok    the OpenRouter fallback posting passes
ok    every chair failing fails the gate
ok    an over-budget run passes without a review

all passing
```

Checked by reverting, not by watching the suite stay green — putting the outcome-only logic back makes the shipped case pass again, which is exactly the bug:

```
--- outcome-only gate restored:
FAIL  a step that exits 0 without posting fails the gate (want exit 1, got 0)
1 failing
--- fix back:
all passing
```

The other three suites still pass:

```
$ ./scripts/budget-guard.test.sh   ->  all passing
$ ./scripts/proof-gate.test.sh     ->  all passing
$ ./scripts/vcr-hooks.test.sh      ->  all passing
$ node scripts/council-review.mjs --selfcheck   ->  selfcheck ok
```

Those four suites run nowhere in CI, which is its own gap — filed as #84.

Proof: n/a — a CI gate whose only output is the exit codes above.

Assisted-by: claude-personal-1:claude-opus-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for chair failover and incremental review updates.
  - Added optional filing of unfixed findings, lens path filtering, and Vibetrace ingestion.
  - Review budgets now default to three automated reviews and validate the configured ceiling.
  - Successful runs retain review state and clear temporary cache comments.
  - Added support for a fourth backup review token and warnings when the primary token is unavailable.

- **Bug Fixes**
  - Improved validation to accept only qualifying reviews from the current run.
  - Prevents stale, unrelated, missing, or over-budget reviews from being treated as successful.

- **Tests**
  - Added coverage for validation, pagination, failover, failures, and budget limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->