### PR TITLE
[VCR-89] Fix budget guard fallback

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -207,7 +207,10 @@ runs:
         # branch like "x&branch=some-empty-branch" would otherwise split the
         # query string and silently read as under budget. -f switches gh api to
         # POST unless --method GET is given, and this endpoint is GET-only.
-        RUNS=$(gh api "repos/$VCR_REPO/actions/runs" --method GET -f branch="$VCR_BRANCH" -f per_page=100 2>/dev/null || echo '{"workflow_runs":[]}')
+        RUNS_FILE="$RUNNER_TEMP/vcr-runs.json"
+        bash "${{ github.action_path }}/scripts/fetch-runs-json.sh" \
+          "$RUNS_FILE" "$VCR_REPO" "$VCR_BRANCH"
+        RUNS=$(cat "$RUNS_FILE")
         printf '%s' "$RUNS" | python3 -c '
         import json, os, sys
         # github.workflow is the display name in the workflow file, which is not

--- a/scripts/budget-guard.test.sh
+++ b/scripts/budget-guard.test.sh
@@ -61,6 +61,35 @@ check false 'a different workflow path does not count'  "$(guard "$(many 6 .gith
 # "out of budget" would stop every review in the fleet on one bad request.
 check false 'an empty run list is not over budget'      "$(guard '{"workflow_runs":[]}' 6 60)"
 
+# The fetcher must replace output from a failed or malformed API response.
+# Appending fallback JSON creates two documents and crashes the guard.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/gh" <<'SH'
+#!/usr/bin/env bash
+case "$GH_CASE" in
+  failed) printf '%s' '{"workflow_runs":[{"path":"partial"}]}' ; exit 1 ;;
+  malformed) printf '%s' '{broken' ; exit 0 ;;
+  valid) printf '%s' '{"workflow_runs":[{"path":"kept"}]}' ; exit 0 ;;
+esac
+SH
+chmod +x "$WORK/bin/gh"
+fetch() {
+  GH_CASE="$1" PATH="$WORK/bin:$PATH" \
+    bash "$HERE/fetch-runs-json.sh" "$WORK/fetched.json" o/r feature
+  cat "$WORK/fetched.json"
+}
+check_fetch() {
+  local want="$1" name="$2" got="$3"
+  if [ "$got" = "$want" ]; then printf 'ok    %s\n' "$name"
+  else printf 'FAIL  %s\n' "$name"; fails=$((fails + 1)); fi
+}
+check_fetch '{"workflow_runs":[]}' \
+  'a failed request replaces its response body' "$(fetch failed)"
+check_fetch '{"workflow_runs":[]}' \
+  'a malformed successful response fails open' "$(fetch malformed)"
+check_fetch '{"workflow_runs":[{"path":"kept"}]}' \
+  'a valid response stays unchanged' "$(fetch valid)"
+
 # A run still in progress has not cost a full run yet, and counting it would
 # stop the very review that is running.
 check false 'an in-progress run does not count'         "$(guard '{"workflow_runs":[{"path":".github/workflows/vibecodereview.yml","status":"in_progress","head_branch":"feature"},{"path":".github/workflows/vibecodereview.yml","status":"in_progress","head_branch":"feature"},{"path":".github/workflows/vibecodereview.yml","status":"in_progress","head_branch":"feature"},{"path":".github/workflows/vibecodereview.yml","status":"in_progress","head_branch":"feature"},{"path":".github/workflows/vibecodereview.yml","status":"in_progress","head_branch":"feature"},{"path":".github/workflows/vibecodereview.yml","status":"in_progress","head_branch":"feature"}]}' 6 60)"

--- a/scripts/budget-guard.test.sh
+++ b/scripts/budget-guard.test.sh
@@ -69,6 +69,7 @@ cat > "$WORK/bin/gh" <<'SH'
 case "$GH_CASE" in
   failed) printf '%s' '{"workflow_runs":[{"path":"partial"}]}' ; exit 1 ;;
   malformed) printf '%s' '{broken' ; exit 0 ;;
+  null_entry) printf '%s' '{"workflow_runs":[null]}' ; exit 0 ;;
   valid) printf '%s' '{"workflow_runs":[{"path":"kept"}]}' ; exit 0 ;;
 esac
 SH
@@ -87,6 +88,8 @@ check_fetch '{"workflow_runs":[]}' \
   'a failed request replaces its response body' "$(fetch failed)"
 check_fetch '{"workflow_runs":[]}' \
   'a malformed successful response fails open' "$(fetch malformed)"
+check_fetch '{"workflow_runs":[]}' \
+  'a run entry that is not an object fails open' "$(fetch null_entry)"
 check_fetch '{"workflow_runs":[{"path":"kept"}]}' \
   'a valid response stays unchanged' "$(fetch valid)"
 

--- a/scripts/fetch-runs-json.sh
+++ b/scripts/fetch-runs-json.sh
@@ -18,7 +18,8 @@ import json, sys
 
 with open(sys.argv[1]) as source:
     data = json.load(source)
-if not isinstance(data, dict) or not isinstance(data.get("workflow_runs"), list):
+runs = data.get("workflow_runs") if isinstance(data, dict) else None
+if not isinstance(runs, list) or not all(isinstance(r, dict) for r in runs):
     raise SystemExit(1)
 PY
 then

--- a/scripts/fetch-runs-json.sh
+++ b/scripts/fetch-runs-json.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Fetch one valid Actions runs document. API errors and malformed responses
+# fail open to an empty list, so the review still runs.
+set -uo pipefail
+
+OUT="$1"
+REPO="$2"
+BRANCH="$3"
+
+if ! gh api "repos/$REPO/actions/runs" --method GET \
+  -f branch="$BRANCH" -f per_page=100 > "$OUT" 2>/dev/null; then
+  printf '%s' '{"workflow_runs":[]}' > "$OUT"
+  exit 0
+fi
+
+if ! python3 - "$OUT" 2>/dev/null <<'PY'
+import json, sys
+
+with open(sys.argv[1]) as source:
+    data = json.load(source)
+if not isinstance(data, dict) or not isinstance(data.get("workflow_runs"), list):
+    raise SystemExit(1)
+PY
+then
+  printf '%s' '{"workflow_runs":[]}' > "$OUT"
+fi


### PR DESCRIPTION
Closes #89

## What

- Fetch Actions run data into a dedicated file.
- Replace failed or malformed responses with one valid empty list.
- Test failed, malformed, and valid responses.

## Why

The old shell fallback appended JSON after some failed API responses. The budget guard then crashed before review started.

## How I verified

`bash scripts/budget-guard.test.sh` -> all passing
`bash scripts/vcr-hooks.test.sh` -> all passing
`bash scripts/proof-gate.test.sh` -> all passing
`node scripts/council-review.mjs --selfcheck` -> passed
`node scripts/chair-fallback.mjs --selfcheck` -> passed
`git diff --cached --check` -> passed before commit

Proof: n/a — this changes a non-visual workflow guard.

Assisted-by: codex:gpt-5.6-sol
