### PR TITLE
[VCR-93] File an issue for an unfixed finding

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,10 @@ inputs:
     description: "If true, the chair may commit and push fixes to the PR branch."
     required: false
     default: "true"
+  file_unfixed_findings:
+    description: "If true, a council finding the pull request did not fix is filed as a GitHub issue carrying the triage label. Filed, not scheduled: triage decides whether it is worth doing. Off by default, because a queue of agent-written issues nobody agreed to is worse than none."
+    required: false
+    default: "false"
   require_proof:
     description: "If true, the chair checks that the PR body's evidence matches the diff — a UI change needs before/after screenshots, a command needs its result. Set false in a repo where no change is ever visible. See pr-standards.md in pooriaarab/scripts."
     required: false
@@ -880,3 +884,19 @@ runs:
         else
           gh api "repos/$VCR_REPO/issues/$VCR_PR/comments" -X POST -F body=@review-state.md --silent
         fi
+    - name: File unfixed findings
+      # Runs after the chair, so the findings it reads are the ones that
+      # survived to the final diff. Never fails the review: a finding that could
+      # not be filed is worse read in the review than not reviewed at all.
+      if: ${{ inputs.file_unfixed_findings == 'true' }}
+      shell: bash
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        [ -f council-findings.md ] || { echo "no findings file"; exit 0; }
+        node "${{ github.action_path }}/scripts/file-findings.mjs" \
+          --findings council-findings.md \
+          --repo "${{ github.repository }}" \
+          --pr "${{ github.event.pull_request.number }}" \
+          --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/scripts/file-findings.mjs
+++ b/scripts/file-findings.mjs
@@ -1,0 +1,221 @@
+// File a council finding that the pull request did not fix as a GitHub issue.
+//
+// A review produces findings with evidence at the one moment that evidence is
+// cheap to collect. Anything the author does not fix leaves no trace once the
+// pull request merges, so the same defect is found again by the next review, or
+// shipped.
+//
+// Filed, not scheduled. Triage decides whether it is worth doing. Auto-filing
+// without auto-ranking keeps the finding and defers the cost of acting on it,
+// which is the only part that was ever expensive. Auto-ranking would produce a
+// queue of agent-written work nobody agreed to.
+//
+// Runs after the council's last pass on a pull request, so the findings it sees
+// are the ones that survived to the final diff.
+
+import { execFileSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+
+// A finding line, as the council prompt asks for it:
+//   - `path:line` — the defect and its trigger -> the fix
+// The dash may be an em dash or a hyphen, and the arrow may be -> or a real
+// arrow, because five different models write this line five different ways.
+const FINDING_RE = /^\s*[-*]\s+`([^`]+)`\s*[—–-]\s*(.+)$/;
+
+// The marker that makes filing idempotent. It carries a fingerprint of the
+// finding, so a rerun of the same review recognises its own earlier issue
+// rather than filing a duplicate.
+const MARKER = 'vibecodereview-finding';
+
+export function fingerprint(location, text) {
+  // Normalise before hashing: the same defect described with different
+  // whitespace or casing by a rerun is the same defect.
+  const normal = `${location}|${text}`.toLowerCase().replace(/\s+/g, ' ').trim();
+  return crypto.createHash('sha256').update(normal).digest('hex').slice(0, 16);
+}
+
+export function parseFindings(markdown) {
+  const findings = [];
+  let lens = null;
+  let fenced = false;
+  for (const line of String(markdown || '').split('\n')) {
+    if (/^\s*(```|~~~)/.test(line)) { fenced = !fenced; continue; }
+    if (fenced) continue;
+    const heading = /^##\s+(.+?)\s*$/.exec(line);
+    if (heading) { lens = heading[1].trim(); continue; }
+    // Findings only appear under a model heading. A bullet in the preamble is
+    // instructions to the reader, not a defect.
+    if (!lens) continue;
+    const match = FINDING_RE.exec(line);
+    if (!match) continue;
+    const location = match[1].trim();
+    const text = match[2].trim();
+    // The council is asked to name a concrete trigger. A line without one is
+    // not a finding, and `path:line` is the shape that carries it.
+    if (!/:\d+/.test(location) && !location.includes('/')) continue;
+    findings.push({ location, text, lens, id: fingerprint(location, text) });
+  }
+  return findings;
+}
+
+// The council says this in so many words when it has nothing.
+export function isEmptyReview(markdown) {
+  return /(^|\n)\s*_?No findings\.?_?\s*(\n|$)/i.test(String(markdown || ''))
+    || parseFindings(markdown).length === 0;
+}
+
+function gh(args, { allowFail = false } = {}) {
+  try {
+    return execFileSync('gh', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (error) {
+    if (allowFail) return '';
+    throw new Error(`gh ${args.slice(0, 2).join(' ')} failed: ${String(error.stderr || error.message).trim().split('\n')[0]}`);
+  }
+}
+
+export function alreadyFiled(repo, id) {
+  // Search the marker rather than the title. A title can be edited by hand; the
+  // marker is what makes a rerun recognise its own earlier issue.
+  const out = gh(['search', 'issues', '--repo', repo, '--match', 'body',
+    `${MARKER}:${id}`, '--json', 'number', '--limit', '1'], { allowFail: true });
+  try {
+    return (JSON.parse(out || '[]')[0] || {}).number || null;
+  } catch {
+    return null;
+  }
+}
+
+// The standard wants an imperative subject of 10 to 50 characters. A finding's
+// first clause is usually longer than that and cutting it at a fixed width
+// leaves a title severed mid-phrase, so drop whole words until it fits and fall
+// back to the file name when the clause carries nothing usable.
+export function buildTitle(finding, path) {
+  const clause = finding.text.split(/->|—|\.\s|;/)[0].trim().replace(/[.,:;]$/, '');
+  const file = String(path || '').split('/').pop() || 'the reported defect';
+  let subject = clause.charAt(0).toLowerCase() + clause.slice(1);
+  while (subject.length > 46 && subject.includes(' ')) {
+    subject = subject.slice(0, subject.lastIndexOf(' '));
+  }
+  subject = subject.replace(/[\s,]+$/, '');
+  if (subject.length < 6) subject = `the defect in ${file}`;
+  return `Fix ${subject}`;
+}
+
+// Written to the issue standard so `issue-standards check` passes on what this
+// files. A finding is a defect, so it is filed as a bug: the trigger the
+// council was required to name is the reproduction.
+export function buildIssue(finding, { repo, prNumber, runUrl }) {
+  const [path] = finding.location.split(':');
+  const title = buildTitle(finding, path);
+  const body = [
+    `## Impact`,
+    finding.text,
+    '',
+    `## Reproduction`,
+    `Found by the ${finding.lens} during review of #${prNumber}, at \`${finding.location}\`.`,
+    '',
+    'The council is required to name a concrete failure trigger, and the sentence above is it. Verify it against the code before acting: a finding is co-reviewer input, not a verdict.',
+    '',
+    `## Last known good`,
+    `The defect was introduced or touched by #${prNumber}. Anything before it did not carry this code.`,
+    '',
+    `## Acceptance criteria`,
+    `- [ ] The behaviour described above no longer happens.`,
+    `- [ ] A test covers the trigger, and fails without the fix.`,
+    '',
+    `## How to verify`,
+    `Reproduce the trigger against \`${path}\`, then confirm the test fails before the fix and passes after.`,
+    '',
+    '---',
+    '',
+    `> Filed automatically from a review that #${prNumber} did not fix. Not triaged, and not agreed: read it before acting.`,
+    runUrl ? `> Review run: ${runUrl}` : '',
+    `> \`${MARKER}:${finding.id}\``,
+  ].filter((line) => line !== '').join('\n');
+  return { title, body };
+}
+
+// Every filed issue lands in triage. Nothing here decides priority.
+const LABELS = ['bug', 'triage'];
+
+export function fileFindings(markdown, { repo, prNumber, runUrl, dryRun = false } = {}) {
+  const findings = parseFindings(markdown);
+  const filed = [];
+  const skipped = [];
+  for (const finding of findings) {
+    const existing = alreadyFiled(repo, finding.id);
+    if (existing) {
+      skipped.push({ ...finding, reason: `already filed as #${existing}` });
+      continue;
+    }
+    const { title, body } = buildIssue(finding, { repo, prNumber, runUrl });
+    if (dryRun) {
+      filed.push({ ...finding, title, dryRun: true });
+      continue;
+    }
+    const out = gh(['issue', 'create', '--repo', repo, '--title', title,
+      '--body', body, '--label', LABELS.join(',')], { allowFail: true });
+    const url = out.trim().split('\n').pop();
+    if (!url.startsWith('http')) {
+      // Filing is best effort. A review that fails because an issue could not
+      // be filed is worse than a finding that has to be read in the review.
+      skipped.push({ ...finding, reason: 'could not file' });
+      continue;
+    }
+    filed.push({ ...finding, title, url });
+  }
+  return { findings, filed, skipped };
+}
+
+function usage() {
+  return `Usage:
+  file-findings.mjs --findings F --repo owner/name --pr N [--run-url U] [--dry-run]`;
+}
+
+export async function main(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--dry-run') { options.dryRun = true; continue; }
+    if (['--findings', '--repo', '--pr', '--run-url'].includes(arg)) {
+      options[arg.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    process.stderr.write(`${usage()}\n`);
+    return 2;
+  }
+  if (!options.findings || !options.repo || !options.pr) {
+    process.stderr.write(`${usage()}\n`);
+    return 2;
+  }
+  if (!fs.existsSync(options.findings)) {
+    process.stdout.write('No findings file. Nothing to file.\n');
+    return 0;
+  }
+  const markdown = fs.readFileSync(options.findings, 'utf8');
+  if (isEmptyReview(markdown)) {
+    process.stdout.write('No findings. Nothing to file.\n');
+    return 0;
+  }
+  const result = fileFindings(markdown, {
+    repo: options.repo,
+    prNumber: options.pr,
+    runUrl: options.runUrl,
+    dryRun: options.dryRun,
+  });
+  for (const item of result.filed) {
+    process.stdout.write(`${item.dryRun ? 'would file' : 'filed'}  ${item.location}  ${item.url || ''}\n`);
+  }
+  for (const item of result.skipped) {
+    process.stdout.write(`skipped   ${item.location}  ${item.reason}\n`);
+  }
+  process.stdout.write(`${result.filed.length} filed, ${result.skipped.length} skipped, ${result.findings.length} findings seen\n`);
+  return 0;
+}
+
+const invokedDirectly = process.argv[1] && process.argv[1].endsWith('file-findings.mjs');
+if (invokedDirectly) {
+  main(process.argv.slice(2)).then((status) => { process.exitCode = status; });
+}

--- a/scripts/file-findings.test.mjs
+++ b/scripts/file-findings.test.mjs
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildTitle,
+  buildIssue,
+  fingerprint,
+  isEmptyReview,
+  parseFindings,
+} from './file-findings.mjs';
+
+const REVIEW = `# 🧑‍⚖️ LLM Council findings
+
+Independent per-lens reviews from council models. Treat as co-reviewer input:
+de-dupe, verify each claim against the code, discard false positives.
+
+- This bullet is instructions to the reader, not a finding.
+
+## GPT-5.6 — correctness lens
+
+- \`src/billing/credit-guard.ts:39\` — prepareCreditCharge runs unconditionally, so an orchestrator-forwarded request is charged twice -> skip when the signed header is present.
+- \`src/middleware.ts:104\` — a forged x-ai-credit header is not stripped when the signature is absent rather than invalid -> treat absent as invalid.
+
+## Kimi K3 — security lens
+
+- \`src/auth/session.ts:163\` — apiKeyTeamId is read from the body before membership is confirmed -> resolve it from the key.
+
+## Gemini — performance lens
+
+_provider HTTP 503_
+`;
+
+test('findings are parsed with their location and lens', () => {
+  const findings = parseFindings(REVIEW);
+  assert.equal(findings.length, 3);
+  assert.equal(findings[0].location, 'src/billing/credit-guard.ts:39');
+  assert.match(findings[0].lens, /correctness/);
+  assert.match(findings[2].lens, /security/);
+});
+
+test('a bullet outside a model section is not a finding', () => {
+  // The preamble tells the reader how to treat the review. Filing it as a
+  // defect would be filing the instructions.
+  const findings = parseFindings(REVIEW);
+  assert.ok(!findings.some((f) => f.text.includes('instructions to the reader')));
+});
+
+test('a lens that errored contributes nothing', () => {
+  const findings = parseFindings(REVIEW);
+  assert.ok(!findings.some((f) => f.lens.includes('performance')));
+});
+
+test('a fenced block is not scanned for findings', () => {
+  // A review quoting a diff would otherwise have its own example lines filed.
+  const withFence = `## Model — lens\n\n\`\`\`\n- \`src/x.ts:1\` — an example inside a fence -> nothing.\n\`\`\`\n`;
+  assert.equal(parseFindings(withFence).length, 0);
+});
+
+test('an em dash and a plain hyphen are both accepted', () => {
+  // Five models write this line five ways, and the separator is the part they
+  // disagree on most.
+  const emDash = '## M — lens\n\n- `a/b.ts:1` — the defect -> the fix.\n';
+  const hyphen = '## M — lens\n\n- `a/b.ts:1` - the defect -> the fix.\n';
+  assert.equal(parseFindings(emDash).length, 1);
+  assert.equal(parseFindings(hyphen).length, 1);
+});
+
+test('a line with no file location is not a finding', () => {
+  const vague = '## M — lens\n\n- `looks risky` — something feels off -> think about it.\n';
+  assert.equal(parseFindings(vague).length, 0);
+});
+
+test('an empty review files nothing', () => {
+  assert.ok(isEmptyReview('# 🧑‍⚖️ LLM Council findings\n\n## M — lens\n\nNo findings.\n'));
+  assert.ok(isEmptyReview('# 🧑‍⚖️ LLM Council findings\n\n_Council skipped: empty diff._\n'));
+  assert.ok(!isEmptyReview(REVIEW));
+});
+
+test('the fingerprint is stable across whitespace and casing', () => {
+  const a = fingerprint('src/x.ts:1', 'The  defect   here');
+  const b = fingerprint('src/x.ts:1', 'the defect here');
+  assert.equal(a, b);
+  assert.notEqual(a, fingerprint('src/x.ts:2', 'the defect here'));
+});
+
+test('the filed issue carries every heading the bug form requires', () => {
+  const [finding] = parseFindings(REVIEW);
+  const { title, body } = buildIssue(finding, { repo: 'pooriaarab/x', prNumber: 42, runUrl: 'https://example/run' });
+
+  for (const heading of ['## Impact', '## Reproduction', '## Last known good', '## Acceptance criteria', '## How to verify']) {
+    assert.ok(body.includes(heading), `missing ${heading}`);
+  }
+  // The standard wants criteria as checkboxes, each one testable.
+  assert.match(body, /- \[ \] /);
+  // No parent or blocker written in prose: those are native links.
+  assert.ok(!/^\s*(Parent|Blocked by)\s*:/m.test(body));
+  // Imperative subject, no trailing period.
+  assert.match(title, /^Fix /);
+  assert.ok(!title.endsWith('.'));
+});
+
+test('the marker makes a rerun recognise its own earlier issue', () => {
+  const [finding] = parseFindings(REVIEW);
+  const { body } = buildIssue(finding, { repo: 'pooriaarab/x', prNumber: 42 });
+  assert.ok(body.includes(`vibecodereview-finding:${finding.id}`));
+  // Rerunning the same review produces the same id, which is what dedupe needs.
+  assert.equal(parseFindings(REVIEW)[0].id, finding.id);
+});
+
+test('the issue says it is untriaged, because nothing here agreed to the work', () => {
+  const [finding] = parseFindings(REVIEW);
+  const { body } = buildIssue(finding, { repo: 'pooriaarab/x', prNumber: 42 });
+  assert.match(body, /Not triaged/i);
+  assert.match(body, /read it before acting/i);
+});
+
+test('the title is imperative and inside the standard length', () => {
+  // 10 to 50 characters, imperative, no trailing period. A finding's first
+  // clause is usually longer, and cutting at a fixed width severs it mid-word.
+  const cases = parseFindings(REVIEW);
+  for (const finding of cases) {
+    const { title } = buildIssue(finding, { repo: 'pooriaarab/x', prNumber: 42 });
+    assert.ok(title.length >= 10 && title.length <= 50, `${title.length}: ${title}`);
+    assert.match(title, /^Fix /);
+    assert.ok(!title.endsWith('.'));
+    assert.ok(!title.endsWith(','));
+    // Not severed mid-word: the last token must appear whole in the source.
+    const last = title.split(' ').pop();
+    assert.ok(finding.text.toLowerCase().includes(last.toLowerCase()) || title.includes('the defect in'), title);
+  }
+});
+
+test('a finding with no usable clause still gets a title', () => {
+  const [finding] = parseFindings('## M — lens\n\n- `src/deep/thing.ts:9` — x -> y.\n');
+  const { title } = buildIssue(finding, { repo: 'pooriaarab/x', prNumber: 1 });
+  assert.ok(title.length >= 10, title);
+  assert.match(title, /thing\.ts/);
+});


### PR DESCRIPTION
Closes #93

## What

A council finding the pull request did not fix becomes a GitHub issue carrying the `triage` label. Opt-in per repo through a new `file_unfixed_findings` input, off by default.

## Why

A review produces findings with evidence at the one moment that evidence is cheap to collect. Anything the author does not fix leaves no trace once the pull request merges, so the same defect gets found again by the next review, or shipped.

**Filed, not scheduled.** Triage decides whether it is worth doing. Auto-filing without auto-ranking keeps the finding and defers the cost of acting on it, which is the only part that was ever expensive. Auto-ranking would produce a queue of agent-written work nobody agreed to, which is worse than losing the finding.

**Off by default.** A repo opts in. The same reasoning as `can_push_fixes`.

The step runs after the chair, so the findings it reads are the ones that survived to the final diff, and it is `continue-on-error` because a finding that could not be filed is better read in the review than a review that failed over filing.

## How I verified

```
node scripts/file-findings.test.mjs
  -> tests 13, pass 13, fail 0
```

The filed issue has to satisfy the issue standard, so that was checked against the real checker rather than asserted:

```
node scripts/file-findings.mjs  (build one issue body from a finding)
issue-standards precheck --body-file filed-body.md --kind bug
  -> PASS  ## Impact
     PASS  ## Reproduction
     PASS  ## Last known good
     PASS  ## Acceptance criteria
     PASS  ## How to verify
     OK, exit 0
```

End to end, against a findings file in the council's real output shape:

```
node scripts/file-findings.mjs --findings findings.md --repo pooriaarab/content-rabbit --pr 42 --dry-run
  -> would file  src/billing/credit-guard.ts:39
     1 filed, 0 skipped, 1 findings seen

node scripts/file-findings.mjs --findings empty.md --repo pooriaarab/content-rabbit --pr 42
  -> No findings. Nothing to file.  exit 0
```

The action file still parses and the step is wired last:

```
python3 -c "import yaml; d=yaml.safe_load(open('action.yml')); ..."
  -> yaml valid; inputs include file_unfixed_findings: True
     steps: 18 | last step: File unfixed findings
```

Size:

```
git diff --stat
  -> 3 files changed, 380 insertions(+)
```

## The parsing cases that earn their tests

Five models write the finding line five ways, and most of the risk is in reading it wrong rather than filing it wrong:

- A bullet in the preamble is instructions to the reader, not a defect. Filing it would file the instructions.
- A lens that errored contributes nothing.
- A fenced block is not scanned, so a review quoting a diff does not file its own example lines.
- An em dash and a plain hyphen are both accepted as the separator.
- A line naming no file location is dropped, because the council is required to name a concrete trigger and a line without one is not a finding.

Dedupe is a fingerprint of the location plus the normalised text, written into the body as a marker. A rerun recognises its own earlier issue instead of filing a duplicate, and the fingerprint is stable across whitespace and casing.

## Known limit

"Did not fix" is inferred from the findings surviving the council's last pass, not from tracking each finding through the fix cycles. A finding the chair fixed in an earlier cycle is gone from the final file and so is never filed, which is the behaviour wanted. A finding the author fixed in a way the council still flags would be filed, and triage is where that gets closed. Tightening this needs per-finding state across cycles, which is a bigger change than this one.

Assisted-by: claude-personal-1:claude-opus-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional settings for carrying forward unresolved findings and filtering reviews by file path.
  * Council reviews now support incremental diffs and retain findings across review runs, with safeguards for unavailable or rewritten history.
  * Added an optional, non-failing workflow step to file unresolved findings as GitHub issues.
  * Issues include pull request and workflow details, while duplicate findings are detected to prevent repeat filing.
* **Tests**
  * Added coverage for finding detection, filtering, formatting, empty reviews, and duplicate handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->