### PR TITLE
[VCR-107] Emit review.council traces to vibetrace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -661,6 +661,7 @@ runs:
         GITHUB_REPOSITORY: ${{ github.repository }}
         VCR_PR: ${{ github.event.pull_request.number }}
         GITHUB_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        VCR_PR_BODY: ${{ github.event.pull_request.body }}
         VCR_MEMBER_DIFF_NOTE: ${{ env.VCR_MEMBER_DIFF_NOTE }}
       run: |
         MODE=full
@@ -675,8 +676,11 @@ runs:
           MEMBERS=$(grep -cE '^## .+ — .+ lens' council-findings.md 2>/dev/null)
           MEMBERS=${MEMBERS:-0}
         fi
+        # Anchored to the exact header the engine emits for a cached member
+        # (`## Name — lens lens (cached)`); a bare substring search would also
+        # match a finding that happens to quote that text from the diff.
         CACHE_HIT=0
-        if [ -f council-findings.md ] && grep -q '(cached)' council-findings.md 2>/dev/null; then
+        if [ -f council-findings.md ] && grep -qE '^## .+ lens \(cached\)$' council-findings.md 2>/dev/null; then
           CACHE_HIT=1
         fi
         # `job` is a workflow-job context; composite action steps don't receive

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,10 @@ inputs:
     description: "Optional JSON object mapping each lens to a regex or array of regexes for paths it should skip. Empty by default: no path-based lens skipping. Keep filters per-lens; security has no built-in executable-file allowlist."
     required: false
     default: ""
+  vibetrace_ingest_url:
+    description: "Optional POST endpoint for vibetrace review.council records. When unset, the emit step writes JSONL under RUNNER_TEMP and never fails the review."
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -347,6 +351,7 @@ runs:
         fi
         printf '%s\n' "$REVIEW_HEAD_SHA" > "$RUNNER_TEMP/vcr-review-head-sha"
         printf 'VCR_REVIEW_HEAD_SHA=%s\n' "$REVIEW_HEAD_SHA" >> "$GITHUB_ENV"
+        printf 'VCR_MEMBER_DIFF_NOTE=%s\n' "$MEMBER_DIFF_NOTE" >> "$GITHUB_ENV"
         export COUNCIL_MEMBER_DIFF_FILE="$PWD/pr-delta.diff"
         export VCR_REVIEW_HEAD_SHA="$REVIEW_HEAD_SHA"
         export VCR_MEMBER_DIFF_NOTE="$MEMBER_DIFF_NOTE"
@@ -644,6 +649,38 @@ runs:
         fi
         cat council.log || true
         echo "----- council-findings.md -----"; cat council-findings.md || true
+
+    # Observability only. Silent-fail inside the script. Never gates the review.
+    - name: Emit vibetrace review.council
+      if: always() && steps.budget.outputs.over != 'true'
+      continue-on-error: true
+      shell: bash
+      env:
+        VIBETRACE_INGEST_URL: ${{ inputs.vibetrace_ingest_url }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        VCR_PR: ${{ github.event.pull_request.number }}
+        GITHUB_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        VCR_MEMBER_DIFF_NOTE: ${{ env.VCR_MEMBER_DIFF_NOTE }}
+      run: |
+        MODE=full
+        case "${VCR_MEMBER_DIFF_NOTE:-}" in
+          delta*) MODE=delta ;;
+        esac
+        MEMBERS=0
+        if [ -f council-findings.md ]; then
+          MEMBERS=$(grep -cE '^## .+ — .+ lens' council-findings.md 2>/dev/null || echo 0)
+        fi
+        CACHE_HIT=0
+        if [ -f council-findings.md ] && grep -q '(cached)' council-findings.md 2>/dev/null; then
+          CACHE_HIT=1
+        fi
+        CANCELLED=0
+        if [ "${{ job.status }}" = "cancelled" ]; then
+          CANCELLED=1
+        fi
+        node "${{ github.action_path }}/scripts/vibetrace-emit.mjs" review.council \
+          --mode "$MODE" --cache-hit "$CACHE_HIT" --members "$MEMBERS" --cancelled "$CANCELLED"
+
     # Failover chain: each attempt runs the SAME prompt (built once above) with
     # a different subscription. Every attempt costs ~10s of setup even when the
     # token is dead, so order them best-credit-first.

--- a/action.yml
+++ b/action.yml
@@ -633,6 +633,7 @@ runs:
         done
 
     - name: Council fan-out (await)
+      id: council_await
       shell: bash
       continue-on-error: true
       run: |
@@ -668,14 +669,21 @@ runs:
         esac
         MEMBERS=0
         if [ -f council-findings.md ]; then
-          MEMBERS=$(grep -cE '^## .+ — .+ lens' council-findings.md 2>/dev/null || echo 0)
+          # grep -c exits 1 (but still prints "0") on zero matches, so a plain
+          # `|| echo 0` fallback ran BOTH commands and doubled the output into
+          # "0\n0" -- a multi-line value that the emitter then rejected outright.
+          MEMBERS=$(grep -cE '^## .+ — .+ lens' council-findings.md 2>/dev/null)
+          MEMBERS=${MEMBERS:-0}
         fi
         CACHE_HIT=0
         if [ -f council-findings.md ] && grep -q '(cached)' council-findings.md 2>/dev/null; then
           CACHE_HIT=1
         fi
+        # `job` is a workflow-job context; composite action steps don't receive
+        # it, so `job.status` is always empty here. Read the fan-out step's own
+        # outcome instead, the same way the chair steps are checked below.
         CANCELLED=0
-        if [ "${{ job.status }}" = "cancelled" ]; then
+        if [ "${{ steps.council_await.outcome }}" = "cancelled" ]; then
           CANCELLED=1
         fi
         node "${{ github.action_path }}/scripts/vibetrace-emit.mjs" review.council \

--- a/action.yml
+++ b/action.yml
@@ -670,10 +670,12 @@ runs:
         esac
         MEMBERS=0
         if [ -f council-findings.md ]; then
-          # grep -c exits 1 (but still prints "0") on zero matches, so a plain
-          # `|| echo 0` fallback ran BOTH commands and doubled the output into
-          # "0\n0" -- a multi-line value that the emitter then rejected outright.
-          MEMBERS=$(grep -cE '^## .+ — .+ lens' council-findings.md 2>/dev/null)
+          # grep -c exits 1 (but still prints "0") on zero matches. GitHub's
+          # bash shell runs with `set -eo pipefail`, and a failing command
+          # substitution in an assignment aborts the step right there -- even
+          # inside this `if` body -- which would skip the emit below entirely.
+          # `|| true` keeps the "0" stdout but neutralizes the exit status.
+          MEMBERS=$(grep -cE '^## .+ — .+ lens' council-findings.md 2>/dev/null || true)
           MEMBERS=${MEMBERS:-0}
         fi
         # Anchored to the exact header the engine emits for a cached member

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "vibecodereview": "bin/vibecodereview.mjs"
   },
   "scripts": {
-    "test": "node scripts/review-delta.test.mjs && node scripts/council-cache.test.mjs && npm run selfcheck",
+    "test": "node scripts/review-delta.test.mjs && node scripts/council-cache.test.mjs && node scripts/vibetrace-emit.test.mjs && npm run selfcheck",
     "selfcheck": "node scripts/council-review.mjs --selfcheck && node scripts/chair-fallback.mjs --selfcheck",
     "mcp": "node mcp/server.mjs"
   },

--- a/scripts/vibetrace-emit.mjs
+++ b/scripts/vibetrace-emit.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// Silent-fail vibetrace emitter for council runs. Matches @vibetrace/schema
+// review.council shape. Never throws; never blocks the review check.
+//
+// Usage:
+//   node vibetrace-emit.mjs review.council \
+//     --mode delta|full --cache-hit 0|1 --members N --cancelled 0|1
+//
+// Env (all optional): VIBETRACE_INGEST_URL, VIBETRACE_FILE,
+// GITHUB_REPOSITORY, VCR_PR / GITHUB_PR_NUMBER, GITHUB_HEAD_REF,
+// VCR_ISSUE / OFFROUTER_ISSUE
+
+import fs from "node:fs";
+import path from "node:path";
+
+const SCHEMA_VERSION = "0.1.0";
+
+function arg(name, fallback = undefined) {
+  const i = process.argv.indexOf(name);
+  if (i === -1 || i + 1 >= process.argv.length) return fallback;
+  return process.argv[i + 1];
+}
+
+function parseIssueFromBranch(branch) {
+  if (!branch) return undefined;
+  const m = branch.toLowerCase().match(/^[a-z][a-z0-9]{1,3}-(\d+)-/);
+  if (!m) return undefined;
+  const n = Number(m[1]);
+  return Number.isInteger(n) && n > 0 ? n : undefined;
+}
+
+function attribution() {
+  const repo = process.env.GITHUB_REPOSITORY?.trim() || undefined;
+  const branch =
+    process.env.GITHUB_HEAD_REF?.trim() ||
+    process.env.GITHUB_REF_NAME?.trim() ||
+    undefined;
+  const explicit = Number(process.env.VCR_ISSUE || process.env.OFFROUTER_ISSUE || "");
+  const issue =
+    Number.isInteger(explicit) && explicit > 0
+      ? explicit
+      : parseIssueFromBranch(branch);
+  const pr = Number(process.env.VCR_PR || process.env.GITHUB_PR_NUMBER || "");
+  const out = {};
+  if (repo) out.repo = repo;
+  if (issue) out.issue = issue;
+  if (Number.isInteger(pr) && pr > 0) out.pr = pr;
+  if (branch) out.branch = branch;
+  out.agent = "vibecodereview";
+  out.harness = "github-actions";
+  return out;
+}
+
+function buildCouncilRecord() {
+  const mode = arg("--mode", "full");
+  if (mode !== "full" && mode !== "delta") {
+    return { ok: false, reason: "mode must be full or delta" };
+  }
+  const cacheHit = arg("--cache-hit", "0") === "1";
+  const cancelled = arg("--cancelled", "0") === "1";
+  const memberCount = Number(arg("--members", "0"));
+  if (!Number.isInteger(memberCount) || memberCount < 0) {
+    return { ok: false, reason: "members must be a non-negative integer" };
+  }
+  return {
+    ok: true,
+    record: {
+      schemaVersion: SCHEMA_VERSION,
+      ts: new Date().toISOString(),
+      type: "review.council",
+      mode,
+      cacheHit,
+      memberCount,
+      cancelled,
+      attribution: attribution(),
+    },
+  };
+}
+
+async function emit(record) {
+  const ingest = process.env.VIBETRACE_INGEST_URL?.trim();
+  const body = JSON.stringify(record);
+  if (ingest) {
+    const res = await fetch(ingest, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+    if (!res.ok) throw new Error(`ingest HTTP ${res.status}`);
+    return "ingest";
+  }
+  const file =
+    process.env.VIBETRACE_FILE?.trim() ||
+    path.join(process.env.RUNNER_TEMP || "/tmp", "vibetrace-traces.jsonl");
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.appendFileSync(file, `${body}\n`, "utf8");
+  return file;
+}
+
+async function main() {
+  try {
+    const kind = process.argv[2];
+    if (kind !== "review.council") {
+      console.error("vibetrace-emit: unsupported type; only review.council");
+      process.exit(0);
+    }
+    const built = buildCouncilRecord();
+    if (!built.ok) {
+      console.error(`vibetrace-emit: ${built.reason}`);
+      process.exit(0);
+    }
+    const where = await emit(built.record);
+    console.log(`vibetrace-emit: wrote review.council -> ${where}`);
+  } catch (err) {
+    console.error(
+      `vibetrace-emit: silent-fail: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
+
+await main();

--- a/scripts/vibetrace-emit.mjs
+++ b/scripts/vibetrace-emit.mjs
@@ -81,10 +81,13 @@ async function emit(record) {
   const ingest = process.env.VIBETRACE_INGEST_URL?.trim();
   const body = JSON.stringify(record);
   if (ingest) {
+    // Bounded so a dead/hanging endpoint can never hold the job open despite
+    // the "never blocks the review" contract this script promises.
     const res = await fetch(ingest, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body,
+      signal: AbortSignal.timeout(5000),
     });
     if (!res.ok) throw new Error(`ingest HTTP ${res.status}`);
     return "ingest";

--- a/scripts/vibetrace-emit.mjs
+++ b/scripts/vibetrace-emit.mjs
@@ -8,7 +8,7 @@
 //
 // Env (all optional): VIBETRACE_INGEST_URL, VIBETRACE_FILE,
 // GITHUB_REPOSITORY, VCR_PR / GITHUB_PR_NUMBER, GITHUB_HEAD_REF,
-// VCR_ISSUE / OFFROUTER_ISSUE
+// VCR_ISSUE / OFFROUTER_ISSUE, VCR_PR_BODY
 
 import fs from "node:fs";
 import path from "node:path";
@@ -29,6 +29,15 @@ function parseIssueFromBranch(branch) {
   return Number.isInteger(n) && n > 0 ? n : undefined;
 }
 
+// Matches GitHub's own closing-keyword syntax, e.g. "Closes #107".
+function parseIssueFromBody(body) {
+  if (!body) return undefined;
+  const m = body.match(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)/i);
+  if (!m) return undefined;
+  const n = Number(m[1]);
+  return Number.isInteger(n) && n > 0 ? n : undefined;
+}
+
 function attribution() {
   const repo = process.env.GITHUB_REPOSITORY?.trim() || undefined;
   const branch =
@@ -37,9 +46,9 @@ function attribution() {
     undefined;
   const explicit = Number(process.env.VCR_ISSUE || process.env.OFFROUTER_ISSUE || "");
   const issue =
-    Number.isInteger(explicit) && explicit > 0
-      ? explicit
-      : parseIssueFromBranch(branch);
+    (Number.isInteger(explicit) && explicit > 0 ? explicit : undefined) ??
+    parseIssueFromBranch(branch) ??
+    parseIssueFromBody(process.env.VCR_PR_BODY);
   const pr = Number(process.env.VCR_PR || process.env.GITHUB_PR_NUMBER || "");
   const out = {};
   if (repo) out.repo = repo;

--- a/scripts/vibetrace-emit.test.mjs
+++ b/scripts/vibetrace-emit.test.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const script = path.join(path.dirname(fileURLToPath(import.meta.url)), "vibetrace-emit.mjs");
+let failed = 0;
+
+function run(args, env = {}) {
+  const r = spawnSync(process.execPath, [script, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+  return r;
+}
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "vcr-emit-"));
+const file = path.join(tmp, "traces.jsonl");
+
+const ok = run(
+  ["review.council", "--mode", "delta", "--cache-hit", "1", "--members", "4", "--cancelled", "0"],
+  {
+    VIBETRACE_FILE: file,
+    GITHUB_REPOSITORY: "pooriaarab/vibecodereview",
+    VCR_PR: "107",
+    GITHUB_HEAD_REF: "vcr-107-emit-council",
+  },
+);
+if (ok.status !== 0) {
+  console.error("FAIL exit", ok.status, ok.stderr);
+  failed++;
+} else {
+  const line = fs.readFileSync(file, "utf8").trim();
+  const rec = JSON.parse(line);
+  if (rec.type !== "review.council" || rec.mode !== "delta" || rec.cacheHit !== true) {
+    console.error("FAIL record shape", rec);
+    failed++;
+  } else if (rec.attribution?.issue !== 107 || rec.attribution?.pr !== 107) {
+    console.error("FAIL attribution", rec.attribution);
+    failed++;
+  } else {
+    console.log("ok - writes review.council with attribution");
+  }
+}
+
+const bad = run(["review.council", "--mode", "nope", "--members", "1"], { VIBETRACE_FILE: file });
+if (bad.status !== 0) {
+  console.error("FAIL bad mode should exit 0", bad.status);
+  failed++;
+} else if (!/mode must be/.test(bad.stderr + bad.stdout)) {
+  console.error("FAIL bad mode message", bad.stderr, bad.stdout);
+  failed++;
+} else {
+  console.log("ok - invalid mode silent-fails with message");
+}
+
+fs.rmSync(tmp, { recursive: true, force: true });
+if (failed) process.exit(1);
+console.log("vibetrace-emit tests passed");

--- a/scripts/vibetrace-emit.test.mjs
+++ b/scripts/vibetrace-emit.test.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -14,6 +15,22 @@ function run(args, env = {}) {
     env: { ...process.env, ...env },
   });
   return r;
+}
+
+// spawnSync blocks this process's event loop, which would deadlock an
+// in-process HTTP server waiting to accept the child's request. Use async
+// spawn for any run() that talks to a server started in this test process.
+function runAsync(args, env = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [script, ...args], {
+      env: { ...process.env, ...env },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.on("close", (status) => resolve({ status, stdout, stderr }));
+  });
 }
 
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "vcr-emit-"));
@@ -55,6 +72,66 @@ if (bad.status !== 0) {
 } else {
   console.log("ok - invalid mode silent-fails with message");
 }
+
+const cancelledFile = path.join(tmp, "cancelled.jsonl");
+const cancelledRun = run(
+  ["review.council", "--mode", "full", "--cache-hit", "0", "--members", "0", "--cancelled", "1"],
+  { VIBETRACE_FILE: cancelledFile },
+);
+if (cancelledRun.status !== 0) {
+  console.error("FAIL cancelled exit", cancelledRun.status, cancelledRun.stderr);
+  failed++;
+} else {
+  const rec = JSON.parse(fs.readFileSync(cancelledFile, "utf8").trim());
+  if (rec.cancelled !== true) {
+    console.error("FAIL cancelled flag", rec);
+    failed++;
+  } else {
+    console.log("ok - records cancelled=1");
+  }
+}
+
+await new Promise((resolve, reject) => {
+  const received = [];
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
+      received.push(body);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end("{}");
+    });
+  });
+  server.listen(0, "127.0.0.1", () => {
+    const { port } = server.address();
+    runAsync(
+      ["review.council", "--mode", "full", "--cache-hit", "0", "--members", "2", "--cancelled", "0"],
+      { VIBETRACE_INGEST_URL: `http://127.0.0.1:${port}/ingest` },
+    ).then((ingestRun) => {
+      server.close();
+      if (ingestRun.status !== 0) {
+        console.error("FAIL ingest exit", ingestRun.status, ingestRun.stderr);
+        failed++;
+      } else if (received.length !== 1) {
+        console.error("FAIL ingest did not receive a POST", ingestRun.stdout, ingestRun.stderr);
+        failed++;
+      } else {
+        const rec = JSON.parse(received[0]);
+        if (rec.type !== "review.council" || rec.memberCount !== 2) {
+          console.error("FAIL ingest record shape", rec);
+          failed++;
+        } else if (!/-> ingest$/.test(ingestRun.stdout.trim())) {
+          console.error("FAIL ingest destination log", ingestRun.stdout);
+          failed++;
+        } else {
+          console.log("ok - posts review.council to VIBETRACE_INGEST_URL");
+        }
+      }
+      resolve();
+    });
+  });
+  server.on("error", reject);
+});
 
 fs.rmSync(tmp, { recursive: true, force: true });
 if (failed) process.exit(1);

--- a/scripts/vibetrace-emit.test.mjs
+++ b/scripts/vibetrace-emit.test.mjs
@@ -62,6 +62,28 @@ if (ok.status !== 0) {
   }
 }
 
+const bodyFile = path.join(tmp, "body-fallback.jsonl");
+const bodyRun = run(
+  ["review.council", "--mode", "full", "--members", "1"],
+  {
+    VIBETRACE_FILE: bodyFile,
+    GITHUB_HEAD_REF: "feature/vibetrace",
+    VCR_PR_BODY: "Some context.\n\nCloses #107\n",
+  },
+);
+if (bodyRun.status !== 0) {
+  console.error("FAIL body-fallback exit", bodyRun.status, bodyRun.stderr);
+  failed++;
+} else {
+  const rec = JSON.parse(fs.readFileSync(bodyFile, "utf8").trim());
+  if (rec.attribution?.issue !== 107) {
+    console.error("FAIL body-fallback issue", rec.attribution);
+    failed++;
+  } else {
+    console.log("ok - falls back to issue number parsed from PR body");
+  }
+}
+
 const bad = run(["review.council", "--mode", "nope", "--members", "1"], { VIBETRACE_FILE: file });
 if (bad.status !== 0) {
   console.error("FAIL bad mode should exit 0", bad.status);


### PR DESCRIPTION
Closes #107

## What

After each council await, emit a `review.council` vibetrace record (mode, cacheHit, memberCount, cancelled). Optional `vibetrace_ingest_url` input; otherwise JSONL under RUNNER_TEMP. Silent-fail; never gates the review.

## Why

CI council spend is where the measured waste was and never touches offrouter. Without this emit, vibetrace cannot answer what one PR cost in review tokens.

## How I verified

`npm test`

```
review delta tests passed
council cache tests passed
ok - writes review.council with attribution
ok - invalid mode silent-fails with message
vibetrace-emit tests passed
selfcheck ok
chair-fallback selfcheck passed
```

Assisted-by: cursor:composer

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional telemetry ingestion endpoint for sending `review.council` review data.
  - Review telemetry now records council mode, cache status, member count, repository context, and cancellation status.
  - Telemetry delivery is non-blocking and will not interrupt the review process if unavailable or unsuccessful.
- **Bug Fixes**
  - Invalid telemetry settings and unsupported configurations are handled safely without failing reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->