### PR TITLE
[VCR-106] Sync package version when cutting a release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,9 +1,11 @@
 name: npm publish
 on:
+  # The vX major tag is pushed as +refs/tags/vX, which deliberately does not match v*.*.*, so a major-pointer move is not a publish event.
   release:
     types: [published]
-  push:
-    tags: ["v*.*.*"]
+concurrency:
+  group: npm-publish-${{ github.ref_name }}
+  cancel-in-progress: false
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,6 +16,12 @@ jobs:
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
+      - name: Set package version from tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          node -e "const fs=require('fs'); const f='package.json'; const p=JSON.parse(fs.readFileSync(f,'utf8')); p.version='${VERSION}'; fs.writeFileSync(f, JSON.stringify(p, null, 2) + '\n');"
       - name: Selfcheck
         run: npm run selfcheck
       - name: Publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,13 @@ Two tags per release, never one.
 | `vX` | force-moved to the newest `vX.Y.Z` | the ~80 repos whose workflow says `@v1` |
 
     node bin/release.mjs 1.2.0            # dry run, prints the plan
-    node bin/release.mjs 1.2.0 --apply    # create v1.2.0, move v1 to it
+    node bin/release.mjs 1.2.0 --apply    # bump package.json, commit, create v1.2.0, move v1
     gh release create v1.2.0 --notes "..."
+
+`--apply` writes the version into `package.json` on `main` and commits it before
+cutting either tag, so the tag's tree and `npm publish` always agree on the
+version. It checks out `main` fresh from the remote first; it refuses to run if a
+local `main` has diverged from the remote instead of resetting it.
 
 The immutable tag is the point. Without it there is no way to say which version
 a repo is on, and no way back except a SHA dug out of `git log`. This repo ran

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,13 +61,14 @@ Two tags per release, never one.
 | `vX` | force-moved to the newest `vX.Y.Z` | the ~80 repos whose workflow says `@v1` |
 
     node bin/release.mjs 1.2.0            # dry run, prints the plan
-    node bin/release.mjs 1.2.0 --apply    # bump package.json, commit, create v1.2.0, move v1
+    node bin/release.mjs 1.2.0 --apply    # create v1.2.0, move v1
     gh release create v1.2.0 --notes "..."
 
-`--apply` writes the version into `package.json` on `main` and commits it before
-cutting either tag, so the tag's tree and `npm publish` always agree on the
-version. It checks out `main` fresh from the remote first; it refuses to run if a
-local `main` has diverged from the remote instead of resetting it.
+`--apply` resolves `main` from the remote, refuses a dirty working tree, and
+creates the two tags from that sha. It never checks out the branch or pushes to
+it. The committed `package.json` is not modified; `.github/workflows/npm-publish.yml`
+writes the version from the triggering tag at publish time, so `npm` and the git
+tag agree while git stays the source of truth.
 
 The immutable tag is the point. Without it there is no way to say which version
 a repo is on, and no way back except a SHA dug out of `git log`. This repo ran

--- a/bin/release.mjs
+++ b/bin/release.mjs
@@ -49,7 +49,9 @@ if (git(["status", "--short"])) {
 
 // Resolve everything against the remote tracking ref. The transport moved from
 // `gh api` to local `git` so this works offline and from a throwaway clone.
-git(["fetch", REMOTE, "--tags"]);
+// --force refreshes a local vX tag that a prior run already force-moved on the
+// remote; without it, `git fetch --tags` would exit with "would clobber".
+git(["fetch", REMOTE, "--tags", "--force"]);
 
 const mainSha = git(["rev-parse", `${REMOTE}/${BRANCH}`]);
 

--- a/bin/release.mjs
+++ b/bin/release.mjs
@@ -106,12 +106,26 @@ if (!apply) {
 
 if (tagExists) {
   console.log(`${tag} already exists at this sha, skipping`);
+  // tagExists only proves a local ref at the right sha -- a prior --apply may have
+  // created the tag locally and then failed to push it (network blip). Pushing it
+  // again is a safe no-op once the remote already has it at this sha.
+  git(["push", REMOTE, tag]);
   // The immutable tag is already correct; make sure the moving major pointer is too.
   git(["tag", "-f", major, mainSha]);
   git(["push", REMOTE, `+refs/tags/${major}`]);
 } else {
   // Check out a clean, up-to-date main. This is the release branch; any uncommitted
   // local changes would be ambiguous with the version bump we are about to make.
+  // Refuse rather than resetting a local branch of the same name that has diverged
+  // (e.g. unpushed local commits) -- `checkout -B` would otherwise silently rewind it.
+  const localBranchSha = git(["rev-parse", "-q", "--verify", BRANCH], { ok: true });
+  if (localBranchSha && localBranchSha !== mainSha) {
+    console.error(
+      `error: local ${BRANCH} (${localBranchSha.slice(0, 7)}) differs from ${REMOTE}/${BRANCH} ` +
+        `(${mainSha.slice(0, 7)}); refusing to reset it`,
+    );
+    process.exit(1);
+  }
   git(["checkout", "-B", BRANCH, `${REMOTE}/${BRANCH}`]);
   if (git(["status", "--short"])) {
     console.error("error: the working tree has uncommitted changes");
@@ -119,13 +133,18 @@ if (tagExists) {
   }
 
   const pkgText = readFileSync(PKG, "utf8");
-  const updated = pkgText.replace(/("version"\s*:\s*")[^"]*(")/, `$1${version}$2`);
-  if (updated === pkgText) {
+  const versionFieldRe = /("version"\s*:\s*")[^"]*(")/;
+  const match = pkgText.match(versionFieldRe);
+  if (!match) {
     console.error("error: could not find a version field to update in package.json");
     process.exit(1);
   }
-  if (updated !== pkgText) {
-    writeFileSync(PKG, updated);
+  // A prior --apply may have pushed this same version bump to main and then failed
+  // before the tag push (see the tagExists branch above for the tag-only half of
+  // this). Comparing the matched value (not just replacing) tells "already at the
+  // target version" apart from "no version field found" so resuming doesn't error.
+  if (match[0] !== `${match[1]}${version}${match[2]}`) {
+    writeFileSync(PKG, pkgText.replace(versionFieldRe, `$1${version}$2`));
     git(["add", PKG]);
     git(["commit", "-m", `Release ${version}`]);
   }

--- a/bin/release.mjs
+++ b/bin/release.mjs
@@ -1,18 +1,19 @@
 #!/usr/bin/env node
-// Cut a release: update package.json, commit it, then cut an immutable vX.Y.Z
-// tag and force-move the vX pointer.
+// Cut a release: create an immutable vX.Y.Z tag and force-move the vX pointer.
+// Does not commit package.json. The npm manifest version is written at publish
+// time by .github/workflows/npm-publish.yml, derived from the tag that triggers
+// the run. Git stays the source of truth; npm is a downstream artifact.
 //
 // Two tags, not one. The immutable tag is what makes "which version are we on"
 // and "put it back" answerable; the moving major tag is what the ~80 consuming
 // repos follow to get fixes without editing 80 workflows. Skipping the
-// immutable one leaves no rollback target except a SHA dug out of git log,
+// immutable one leaves no rollback target except a SHA dug out of `git log`,
 // which is where this repo was until v1.0.0 was cut retroactively.
 //
 // Usage:
 //   node bin/release.mjs 1.2.0            # dry run, prints the plan
-//   node bin/release.mjs 1.2.0 --apply
+//   node bin/release.mjs 1.2.0 --apply    # create v1.2.0, move v1 to it
 import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
 
 const version = process.argv[2];
 const apply = process.argv.includes("--apply");
@@ -27,7 +28,6 @@ const major = `v${majorNum}`;
 const tag = `v${version}`;
 const REMOTE = process.env.RELEASE_REMOTE || "origin";
 const BRANCH = process.env.RELEASE_BRANCH || "main";
-const PKG = "package.json";
 const REPO = "pooriaarab/vibecodereview";
 
 const git = (args, opts = {}) => {
@@ -40,21 +40,30 @@ const git = (args, opts = {}) => {
   }
 };
 
-// Read the remote so the plan and the guard checks are against the same tree
-// the tags will eventually point to. In dry-run mode this fetches refs only;
-// it does not touch the working tree.
+// Never run while the working tree is dirty. The script does not move the
+// caller's HEAD, but it still should not run from an ambiguous checkout.
+if (git(["status", "--short"])) {
+  console.error("error: the working tree has uncommitted changes");
+  process.exit(1);
+}
+
+// Resolve everything against the remote tracking ref. The transport moved from
+// `gh api` to local `git` so this works offline and from a throwaway clone.
 git(["fetch", REMOTE, "--tags"]);
 
 const mainSha = git(["rev-parse", `${REMOTE}/${BRANCH}`]);
 
 const beforeVersion = (() => {
   try {
-    return JSON.parse(git(["show", `${REMOTE}/${BRANCH}:${PKG}`])).version;
+    const remotePkg = git(["show", `${REMOTE}/${BRANCH}:package.json`], { ok: true });
+    return remotePkg ? JSON.parse(remotePkg).version : null;
   } catch {
-    return JSON.parse(readFileSync(PKG, "utf8")).version;
+    return null;
   }
 })();
 
+// Resolve through to the commit (^{}) so an annotated tag compares against the
+// commit sha, not the tag object sha.
 const tagSha = (name) => git(["rev-parse", "-q", "--verify", `refs/tags/${name}^{}`], { ok: true }) || null;
 
 const existingTagSha = tagSha(tag);
@@ -95,7 +104,13 @@ if (highest && cmp(newVer, highest) <= 0) {
 }
 
 console.log(`main      ${mainSha.slice(0, 7)}`);
-console.log(`package.json  ${beforeVersion === version ? `${version} (already)` : `${beforeVersion} -> ${version}`}`);
+if (beforeVersion === version) {
+  console.log(`package.json  ${version} (already)`);
+} else if (beforeVersion) {
+  console.log(`package.json  ${beforeVersion} (npm workflow will set to ${version})`);
+} else {
+  console.log(`package.json  (npm workflow will set to ${version})`);
+}
 console.log(tagExists ? `exists    ${tag} -> ${mainSha.slice(0, 7)} (resuming)` : `create    ${tag} -> ${mainSha.slice(0, 7)}`);
 console.log(`${majorExists ? "move     " : "create   "} ${major} -> ${mainSha.slice(0, 7)}`);
 
@@ -106,35 +121,15 @@ if (!apply) {
 
 if (tagExists) {
   console.log(`${tag} already exists at this sha, skipping`);
-  // The immutable tag is already correct; make sure the moving major pointer is too.
+  // A prior run may have created the local tag but failed to push it. Make sure
+  // the remote has it before we update the major pointer.
+  git(["push", REMOTE, tag]);
   git(["tag", "-f", major, mainSha]);
   git(["push", REMOTE, `+refs/tags/${major}`]);
 } else {
-  // Check out a clean, up-to-date main. This is the release branch; any uncommitted
-  // local changes would be ambiguous with the version bump we are about to make.
-  git(["checkout", "-B", BRANCH, `${REMOTE}/${BRANCH}`]);
-  if (git(["status", "--short"])) {
-    console.error("error: the working tree has uncommitted changes");
-    process.exit(1);
-  }
-
-  const pkgText = readFileSync(PKG, "utf8");
-  const updated = pkgText.replace(/("version"\s*:\s*")[^"]*(")/, `$1${version}$2`);
-  if (updated === pkgText) {
-    console.error("error: could not find a version field to update in package.json");
-    process.exit(1);
-  }
-  if (updated !== pkgText) {
-    writeFileSync(PKG, updated);
-    git(["add", PKG]);
-    git(["commit", "-m", `Release ${version}`]);
-  }
-  const releaseSha = git(["rev-parse", "HEAD"]);
-
-  git(["push", REMOTE, BRANCH]);
-  git(["tag", tag, releaseSha]);
+  git(["tag", tag, mainSha]);
   git(["push", REMOTE, tag]);
-  git(["tag", "-f", major, releaseSha]);
+  git(["tag", "-f", major, mainSha]);
   git(["push", REMOTE, `+refs/tags/${major}`]);
 }
 

--- a/bin/release.mjs
+++ b/bin/release.mjs
@@ -40,10 +40,25 @@ const git = (args, opts = {}) => {
   }
 };
 
+// git merge-base --is-ancestor communicates through exit code, not stdout, so
+// it needs its own success/failure check rather than the ok:true "" fallback above.
+const isAncestor = (ancestor, descendant) => {
+  try {
+    execFileSync("git", ["merge-base", "--is-ancestor", ancestor, descendant], { stdio: ["pipe", "pipe", "pipe"] });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 // Read the remote so the plan and the guard checks are against the same tree
 // the tags will eventually point to. In dry-run mode this fetches refs only;
-// it does not touch the working tree.
-git(["fetch", REMOTE, "--tags"]);
+// it does not touch the working tree. --force refreshes a local vX that a
+// prior release already moved on the remote -- without it, a plain
+// `--tags` fetch exits non-zero ("would clobber existing tag") and the
+// script dies before the plan is even printed, on every checkout that has
+// ever fetched a moving tag this repo later force-moved again.
+git(["fetch", REMOTE, "--tags", "--force"]);
 
 const mainSha = git(["rev-parse", `${REMOTE}/${BRANCH}`]);
 
@@ -118,8 +133,11 @@ if (tagExists) {
   // local changes would be ambiguous with the version bump we are about to make.
   // Refuse rather than resetting a local branch of the same name that has diverged
   // (e.g. unpushed local commits) -- `checkout -B` would otherwise silently rewind it.
+  // A local branch that is merely BEHIND the remote (the common case after someone
+  // else has merged to main) is not divergence -- `checkout -B` only fast-forwards
+  // it there, so only refuse when local is not an ancestor of the remote.
   const localBranchSha = git(["rev-parse", "-q", "--verify", BRANCH], { ok: true });
-  if (localBranchSha && localBranchSha !== mainSha) {
+  if (localBranchSha && localBranchSha !== mainSha && !isAncestor(localBranchSha, mainSha)) {
     console.error(
       `error: local ${BRANCH} (${localBranchSha.slice(0, 7)}) differs from ${REMOTE}/${BRANCH} ` +
         `(${mainSha.slice(0, 7)}); refusing to reset it`,
@@ -159,5 +177,5 @@ if (tagExists) {
 
 // Pull the new tags back into the local checkout so verification commands like
 // `git show vX.Y.Z:package.json` and `git merge-base` work immediately.
-git(["fetch", REMOTE, "--tags"]);
+git(["fetch", REMOTE, "--tags", "--force"]);
 console.log(`\nNow write the release notes:\n  gh release create ${tag} --repo ${REPO} --title "${tag}" --notes "..."`);

--- a/bin/release.mjs
+++ b/bin/release.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
-// Cut a release: an immutable vX.Y.Z tag, then move the vX pointer to it.
+// Cut a release: update package.json, commit it, then cut an immutable vX.Y.Z
+// tag and force-move the vX pointer.
 //
 // Two tags, not one. The immutable tag is what makes "which version are we on"
-// and "put it back" answerable; the moving major tag is what the 80 consuming
+// and "put it back" answerable; the moving major tag is what the ~80 consuming
 // repos follow to get fixes without editing 80 workflows. Skipping the
 // immutable one leaves no rollback target except a SHA dug out of git log,
 // which is where this repo was until v1.0.0 was cut retroactively.
@@ -11,8 +12,8 @@
 //   node bin/release.mjs 1.2.0            # dry run, prints the plan
 //   node bin/release.mjs 1.2.0 --apply
 import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
 
-const REPO = "pooriaarab/vibecodereview";
 const version = process.argv[2];
 const apply = process.argv.includes("--apply");
 
@@ -20,82 +21,65 @@ if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version || "")) {
   console.error("usage: release.mjs <major.minor.patch> [--apply]");
   process.exit(2);
 }
-const major = `v${version.split(".")[0]}`;
+
+const majorNum = version.split(".")[0];
+const major = `v${majorNum}`;
 const tag = `v${version}`;
+const REMOTE = process.env.RELEASE_REMOTE || "origin";
+const BRANCH = process.env.RELEASE_BRANCH || "main";
+const PKG = "package.json";
+const REPO = "pooriaarab/vibecodereview";
 
-const gh = (args, input) =>
-  execFileSync("gh", args, { encoding: "utf8", input, stdio: ["pipe", "pipe", "inherit"] }).trim();
-
-// Like `gh`, but captures stderr instead of inheriting it, so a 404 (ref
-// missing) can be told apart from an auth/network/rate-limit/5xx failure.
-// Returns the ref's sha, or null if the ref does not exist.
-const refSha = (ref) => {
+const git = (args, opts = {}) => {
   try {
-    const out = execFileSync("gh", ["api", `repos/${REPO}/git/refs/${ref}`], {
-      encoding: "utf8",
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    const obj = JSON.parse(out).object;
-    // An annotated tag's ref points at the TAG object, not at the commit. Every
-    // tag here is lightweight today, so this never mattered; one `git tag -a`
-    // or a differently-cut release would make the sha comparison below compare
-    // a tag object against a commit, never match, and refuse to resume a
-    // version that is in fact correct. Resolve through to the commit.
-    if (obj.type === "tag") {
-      const tagObj = execFileSync("gh", ["api", `repos/${REPO}/git/tags/${obj.sha}`], {
-        encoding: "utf8",
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-      return JSON.parse(tagObj).object.sha;
-    }
-    return obj.sha;
-  } catch (e) {
-    if (typeof e.stderr === "string" && /HTTP 404/.test(e.stderr)) return null;
-    console.error(e.stderr || e.message);
+    return execFileSync("git", args, { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"], ...opts }).trim();
+  } catch (err) {
+    if (opts.ok) return "";
+    console.error(String(err.stderr || err.message).trim());
     process.exit(1);
   }
 };
 
-const sha = JSON.parse(gh(["api", `repos/${REPO}/git/refs/heads/main`])).object.sha;
+// Read the remote so the plan and the guard checks are against the same tree
+// the tags will eventually point to. In dry-run mode this fetches refs only;
+// it does not touch the working tree.
+git(["fetch", REMOTE, "--tags"]);
 
-// An immutable tag that already points at this same main sha means a
-// previous --apply created it but failed before (or during) the vX step —
-// resume from there instead of refusing. Only a tag pointing somewhere else
-// is the immutability violation this guards against.
-const existingTagSha = refSha(`tags/${tag}`);
-if (existingTagSha && existingTagSha !== sha) {
+const mainSha = git(["rev-parse", `${REMOTE}/${BRANCH}`]);
+
+const beforeVersion = (() => {
+  try {
+    return JSON.parse(git(["show", `${REMOTE}/${BRANCH}:${PKG}`])).version;
+  } catch {
+    return JSON.parse(readFileSync(PKG, "utf8")).version;
+  }
+})();
+
+const tagSha = (name) => git(["rev-parse", "-q", "--verify", `refs/tags/${name}^{}`], { ok: true }) || null;
+
+const existingTagSha = tagSha(tag);
+if (existingTagSha && existingTagSha !== mainSha) {
   console.error(
-    `${tag} already exists at ${existingTagSha.slice(0, 7)}, not main (${sha.slice(0, 7)}). ` +
+    `${tag} already exists at ${existingTagSha.slice(0, 7)}, not main (${mainSha.slice(0, 7)}). ` +
       `Immutable tags are never moved. Pick the next version.`,
   );
   process.exit(1);
 }
 const tagExists = existingTagSha !== null;
+const majorExists = tagSha(major) !== null;
 
 // A brand-new major (e.g. the first 2.0.0) has no vX ref to move yet, so it
-// must be created (POST) rather than moved (PATCH), or the release half-completes:
-// vX.Y.Z gets tagged and the major pointer is never created.
-const majorExists = refSha(`tags/${major}`) !== null;
-
+// must be created rather than moved, or the release half-completes.
 // vX is documented as always pointing at the newest vX.Y.Z of that major line.
-// Releasing an older/out-of-order version (a typo, an old branch cut by mistake,
-// or resuming a stale partial-apply after a newer version has since shipped from
-// a later main) would force-move vX backward — a regression shipped to every
-// consuming repo pinned to @vX. Refuse unless this version is at least as new as
-// every other vX.*.* tag that exists. This runs even when resuming (tagExists):
-// this tag already pointing at the current sha says nothing about whether a
-// higher sibling was tagged in the meantime, so it is excluded from the
-// comparison rather than used to skip it. --paginate/--slurp because a major
-// line can outgrow the API's single-page default and silently hide the highest
-// version otherwise.
-const majorNum = major.slice(1);
-const siblingRefs = JSON.parse(
-  gh(["api", "--paginate", "--slurp", `repos/${REPO}/git/matching-refs/tags/${major}.`]) || "[]",
-).flat();
+// Releasing an older/out-of-order version would force-move vX backward — a
+// regression shipped to every consuming repo pinned to @vX. Refuse unless this
+// version is at least as new as every other vX.*.* tag that exists.
 const verRe = new RegExp(`^v${majorNum}\\.(\\d+)\\.(\\d+)$`);
-const existingVersions = siblingRefs
-  .map((r) => r.ref.split("/").pop())
-  .filter((name) => name !== tag)
+const existingTags = git(["for-each-ref", "--format=%(refname:short)", `refs/tags/${major}.*`], { ok: true })
+  .split("\n")
+  .filter(Boolean)
+  .filter((name) => name !== tag);
+const existingVersions = existingTags
   .map((name) => name.match(verRe))
   .filter(Boolean)
   .map((m) => [Number(majorNum), Number(m[1]), Number(m[2])]);
@@ -110,9 +94,11 @@ if (highest && cmp(newVer, highest) <= 0) {
   process.exit(1);
 }
 
-console.log(`main      ${sha}`);
-console.log(tagExists ? `exists    ${tag} -> ${sha.slice(0, 7)} (resuming)` : `create    ${tag} -> ${sha.slice(0, 7)}`);
-console.log(`${majorExists ? "move     " : "create   "} ${major} -> ${sha.slice(0, 7)}`);
+console.log(`main      ${mainSha.slice(0, 7)}`);
+console.log(`package.json  ${beforeVersion === version ? `${version} (already)` : `${beforeVersion} -> ${version}`}`);
+console.log(tagExists ? `exists    ${tag} -> ${mainSha.slice(0, 7)} (resuming)` : `create    ${tag} -> ${mainSha.slice(0, 7)}`);
+console.log(`${majorExists ? "move     " : "create   "} ${major} -> ${mainSha.slice(0, 7)}`);
+
 if (!apply) {
   console.log("\ndry run. Nothing was written. Re-run with --apply.");
   process.exit(0);
@@ -120,17 +106,39 @@ if (!apply) {
 
 if (tagExists) {
   console.log(`${tag} already exists at this sha, skipping`);
+  // The immutable tag is already correct; make sure the moving major pointer is too.
+  git(["tag", "-f", major, mainSha]);
+  git(["push", REMOTE, `+refs/tags/${major}`]);
 } else {
-  gh(["api", `repos/${REPO}/git/refs`, "-X", "POST", "-f", `ref=refs/tags/${tag}`, "-f", `sha=${sha}`]);
-  console.log(`created ${tag}`);
+  // Check out a clean, up-to-date main. This is the release branch; any uncommitted
+  // local changes would be ambiguous with the version bump we are about to make.
+  git(["checkout", "-B", BRANCH, `${REMOTE}/${BRANCH}`]);
+  if (git(["status", "--short"])) {
+    console.error("error: the working tree has uncommitted changes");
+    process.exit(1);
+  }
+
+  const pkgText = readFileSync(PKG, "utf8");
+  const updated = pkgText.replace(/("version"\s*:\s*")[^"]*(")/, `$1${version}$2`);
+  if (updated === pkgText) {
+    console.error("error: could not find a version field to update in package.json");
+    process.exit(1);
+  }
+  if (updated !== pkgText) {
+    writeFileSync(PKG, updated);
+    git(["add", PKG]);
+    git(["commit", "-m", `Release ${version}`]);
+  }
+  const releaseSha = git(["rev-parse", "HEAD"]);
+
+  git(["push", REMOTE, BRANCH]);
+  git(["tag", tag, releaseSha]);
+  git(["push", REMOTE, tag]);
+  git(["tag", "-f", major, releaseSha]);
+  git(["push", REMOTE, `+refs/tags/${major}`]);
 }
-// The major pointer is the only tag this force-updates, and it is the one
-// consumers opted into by writing @v1 rather than a pinned version.
-if (majorExists) {
-  gh(["api", `repos/${REPO}/git/refs/tags/${major}`, "-X", "PATCH", "-f", `sha=${sha}`, "-F", "force=true"]);
-  console.log(`moved ${major} -> ${tag}`);
-} else {
-  gh(["api", `repos/${REPO}/git/refs`, "-X", "POST", "-f", `ref=refs/tags/${major}`, "-f", `sha=${sha}`]);
-  console.log(`created ${major} -> ${tag}`);
-}
+
+// Pull the new tags back into the local checkout so verification commands like
+// `git show vX.Y.Z:package.json` and `git merge-base` work immediately.
+git(["fetch", REMOTE, "--tags"]);
 console.log(`\nNow write the release notes:\n  gh release create ${tag} --repo ${REPO} --title "${tag}" --notes "..."`);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "vibecodereview": "bin/vibecodereview.mjs"
   },
   "scripts": {
-    "test": "node scripts/review-delta.test.mjs && node scripts/council-cache.test.mjs && node scripts/vibetrace-emit.test.mjs && node scripts/lint-workflow.test.mjs && npm run selfcheck",
+    "test": "node scripts/review-delta.test.mjs && node scripts/council-cache.test.mjs && node scripts/vibetrace-emit.test.mjs && node scripts/lint-workflow.test.mjs && node scripts/release.test.mjs && npm run selfcheck",
     "selfcheck": "node scripts/council-review.mjs --selfcheck && node scripts/chair-fallback.mjs --selfcheck",
     "mcp": "node mcp/server.mjs"
   },

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -35,7 +35,11 @@ mkdirSync(clone, { recursive: true });
 try {
   git(bare, ["init", "--bare"]);
 
-  git(clone, ["init"]);
+  // Pin the branch name: `git init` falls back to "master" on any system/git
+  // version where `init.defaultBranch` isn't set to "main", which would make
+  // the `push -u origin main` below fail with "src refspec main does not
+  // match any".
+  git(clone, ["init", "-b", "main"]);
   git(clone, ["remote", "add", "origin", bare]);
   git(clone, ["config", "user.email", "release-test@example.com"]);
   git(clone, ["config", "user.name", "Release Test"]);
@@ -92,6 +96,23 @@ try {
   assert.notEqual(older.status, 0, older.stderr);
   assert.ok(older.stderr.includes("not newer"), older.stderr);
   assert.equal(git(clone, ["tag", "-l", "v1.3.2"]), "");
+
+  // Criterion 6: resuming when a prior --apply pushed the branch and created
+  // the local tag but failed to push the tag itself (e.g. a network blip)
+  // must still publish the tag, not error out because package.json already
+  // matches the target version.
+  const bumped = JSON.parse(readFileSync(join(clone, "package.json"), "utf8"));
+  bumped.version = "1.4.0";
+  writeFileSync(join(clone, "package.json"), JSON.stringify(bumped, null, 2) + "\n");
+  git(clone, ["commit", "-am", "Release 1.4.0"]);
+  git(clone, ["push", "origin", "main"]);
+  git(clone, ["tag", "v1.4.0"]); // local only: simulates a tag push that previously failed
+
+  const resumed = runRelease(clone, ["1.4.0", "--apply"]);
+  assert.equal(resumed.status, 0, resumed.stderr);
+  assert.equal(git(bare, ["tag", "-l", "v1.4.0"]), "v1.4.0", "immutable tag was never pushed to the remote");
+  assert.equal(git(bare, ["tag", "-l", "v1"]), "v1");
+  assert.equal(packageVersion(clone, "v1.4.0"), "1.4.0");
 
   console.log("release tests passed");
 } finally {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -96,11 +96,32 @@ try {
   assert.equal(refSha(clone, "v1"), initialSha, "major tag moved");
   assert.equal(packageVersion(clone, "v1.3.3"), "0.1.1");
 
+  // Criterion 6: resuming when a prior --apply created the local tag but failed
+  // to push it (e.g. a network blip) must still publish the tag, not drop it.
+  git(clone, ["tag", "v1.4.0"]); // local only: simulates a tag push that previously failed
+  const resumed = runRelease(clone, ["1.4.0", "--apply"]);
+  assert.equal(resumed.status, 0, resumed.stderr);
+  assert.equal(git(bare, ["tag", "-l", "v1.4.0"]), "v1.4.0", "immutable tag was never pushed to the remote");
+  assert.equal(git(bare, ["tag", "-l", "v1"]), "v1");
+  assert.equal(refSha(clone, "v1.4.0"), initialSha, "v1.4.0 did not point at main");
+  assert.equal(refSha(clone, "v1"), initialSha, "v1 did not point at main");
+  assert.equal(packageVersion(clone, "v1.4.0"), "0.1.1");
+
   // Older versions are still refused by the ordering guard.
   const older = runRelease(clone, ["1.3.2", "--apply"]);
   assert.notEqual(older.status, 0, older.stderr);
   assert.ok(older.stderr.includes("not newer"), older.stderr);
   assert.equal(git(clone, ["tag", "-l", "v1.3.2"]), "");
+
+  // Criterion 4: the publish workflow writes the version from the tag before
+  // npm publish, so the published artifact matches the git tag even though the
+  // committed package.json does not change.
+  assert.ok(existsSync(workflowPath), "npm-publish.yml missing");
+  const workflow = readFileSync(workflowPath, "utf8");
+  assert.ok(workflow.includes("Set package version from tag"), workflow);
+  assert.ok(/github\.ref_name|GITHUB_REF_NAME/.test(workflow), workflow);
+  assert.ok(workflow.includes("package.json"), workflow);
+  assert.match(workflow, /npm publish/);
 
   // Criterion 2: running from a different branch with a dirty working tree
   // refuses before any branch movement and leaves HEAD where it was.
@@ -113,16 +134,6 @@ try {
   assert.ok(git(clone, ["status", "--short"]).includes("?? dirty.txt"), "working tree was cleaned");
   assert.equal(git(clone, ["tag", "-l", "v1.3.4"]), "", "tag was created from a dirty checkout");
   assert.equal(Number(git(clone, ["rev-list", "--count", "HEAD"])), commitCountBefore, "dirty run created a commit");
-
-  // Criterion 4: the publish workflow writes the version from the tag before
-  // npm publish, so the published artifact matches the git tag even though the
-  // committed package.json does not change.
-  assert.ok(existsSync(workflowPath), "npm-publish.yml missing");
-  const workflow = readFileSync(workflowPath, "utf8");
-  assert.ok(workflow.includes("Set package version from tag"), workflow);
-  assert.ok(/github\.ref_name|GITHUB_REF_NAME/.test(workflow), workflow);
-  assert.ok(workflow.includes("package.json"), workflow);
-  assert.match(workflow, /npm publish/);
 
   console.log("release tests passed");
 } finally {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -31,6 +31,19 @@ function refSha(cwd, ref) {
   return git(cwd, ["rev-parse", ref]);
 }
 
+function topBlock(src, header) {
+  const lines = src.split("\n");
+  const start = lines.indexOf(header);
+  assert.notEqual(start, -1, `missing ${header}`);
+  const out = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line !== "" && !line.startsWith(" ") && !line.startsWith("#")) break;
+    out.push(line);
+  }
+  return out.join("\n").trim();
+}
+
 const tmp = mkdtempSync(join(tmpdir(), "release-test-"));
 const bare = join(tmp, "origin.git");
 const clone = join(tmp, "clone");
@@ -122,6 +135,14 @@ try {
   assert.ok(/github\.ref_name|GITHUB_REF_NAME/.test(workflow), workflow);
   assert.ok(workflow.includes("package.json"), workflow);
   assert.match(workflow, /npm publish/);
+
+  // Criterion 7: the publish workflow must have exactly one trigger, and it
+  // must be release: published. Two triggers (tag push + release) would publish
+  // the same version twice and guarantee a registry E403 on every release.
+  const onBlock = topBlock(workflow, "on:");
+  const triggers = [...onBlock.matchAll(/^  ([a-z]+):/gm)].map((m) => m[1]);
+  assert.deepEqual(triggers, ["release"], "npm-publish.yml must have exactly one publish trigger");
+  assert.match(onBlock, /^  release:\n    types: \[published\]/m);
 
   // Criterion 2: running from a different branch with a dirty working tree
   // refuses before any branch movement and leaves HEAD where it was.

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const root = new URL("../", import.meta.url).pathname.replace(/\/$/, "");
+const releaseScript = join(root, "bin/release.mjs");
+
+function git(cwd, args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function runRelease(cwd, args) {
+  const res = spawnSync(process.execPath, [releaseScript, ...args], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  return { status: res.status, stdout: res.stdout, stderr: res.stderr };
+}
+
+function packageVersion(cwd, ref = "HEAD") {
+  return JSON.parse(git(cwd, ["show", `${ref}:package.json`])).version;
+}
+
+const tmp = mkdtempSync(join(tmpdir(), "release-test-"));
+const bare = join(tmp, "origin.git");
+const clone = join(tmp, "clone");
+
+mkdirSync(bare, { recursive: true });
+mkdirSync(clone, { recursive: true });
+
+try {
+  git(bare, ["init", "--bare"]);
+
+  git(clone, ["init"]);
+  git(clone, ["remote", "add", "origin", bare]);
+  git(clone, ["config", "user.email", "release-test@example.com"]);
+  git(clone, ["config", "user.name", "Release Test"]);
+
+  const initialPkg = JSON.stringify(
+    {
+      name: "vibecodereview",
+      version: "0.1.1",
+      publishConfig: { access: "public" },
+    },
+    null,
+    2,
+  );
+  writeFileSync(join(clone, "package.json"), initialPkg + "\n");
+
+  git(clone, ["add", "package.json"]);
+  git(clone, ["commit", "-m", "init"]);
+  git(clone, ["push", "-u", "origin", "main"]);
+
+  // Criterion 3: dry run prints the package.json edit and writes nothing.
+  const dry = runRelease(clone, ["1.3.3"]);
+  assert.equal(dry.status, 0, dry.stderr);
+  assert.ok(dry.stdout.includes("package.json  0.1.1 -> 1.3.3"), dry.stdout);
+  assert.ok(dry.stdout.includes("create    v1.3.3"), dry.stdout);
+  assert.ok(dry.stdout.includes("v1 ->"), dry.stdout);
+  assert.equal(git(clone, ["status", "--short"]), "");
+
+  // Criterion 1: --apply updates package.json to the requested version.
+  const first = runRelease(clone, ["1.3.3", "--apply"]);
+  assert.equal(first.status, 0, first.stderr);
+  assert.equal(packageVersion(clone, "HEAD"), "1.3.3");
+
+  // Criterion 2: the version commit is an ancestor of the immutable tag.
+  git(clone, ["fetch", "origin", "--tags"]);
+  assert.equal(packageVersion(clone, "v1.3.3"), "1.3.3");
+  const versionCommit = git(clone, ["rev-list", "-1", "v1.3.3", "--", "package.json"]);
+  git(clone, ["merge-base", "--is-ancestor", versionCommit, "v1.3.3"]);
+  assert.equal(git(clone, ["tag", "-l", "v1.3.3"]), "v1.3.3");
+  assert.equal(git(clone, ["tag", "-l", "v1"]), "v1");
+
+  const commitCountBefore = Number(git(clone, ["rev-list", "--count", "HEAD"]));
+
+  // Criterion 5: re-running the same version is refused (no new commit, no moved tag).
+  const afterFirst = runRelease(clone, ["1.3.3", "--apply"]);
+  assert.equal(afterFirst.status, 0, afterFirst.stderr);
+  assert.ok(afterFirst.stdout.includes("v1.3.3 already exists at this sha, skipping"), afterFirst.stdout);
+  const commitCountAfter = Number(git(clone, ["rev-list", "--count", "HEAD"]));
+  assert.equal(commitCountBefore, commitCountAfter, "re-run created a new commit");
+  assert.equal(packageVersion(clone, "v1.3.3"), "1.3.3");
+  assert.equal(packageVersion(clone, "v1"), "1.3.3");
+
+  // Older versions are still refused by the ordering guard.
+  const older = runRelease(clone, ["1.3.2", "--apply"]);
+  assert.notEqual(older.status, 0, older.stderr);
+  assert.ok(older.stderr.includes("not newer"), older.stderr);
+  assert.equal(git(clone, ["tag", "-l", "v1.3.2"]), "");
+
+  console.log("release tests passed");
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const root = new URL("../", import.meta.url).pathname.replace(/\/$/, "");
-const releaseScript = join(root, "bin/release.mjs");
+const root = dirname(fileURLToPath(import.meta.url)).replace(/\/$/, "");
+const releaseScript = join(root, "..", "bin", "release.mjs");
+const workflowPath = join(root, "..", ".github", "workflows", "npm-publish.yml");
 
 function git(cwd, args) {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
@@ -25,6 +27,10 @@ function packageVersion(cwd, ref = "HEAD") {
   return JSON.parse(git(cwd, ["show", `${ref}:package.json`])).version;
 }
 
+function refSha(cwd, ref) {
+  return git(cwd, ["rev-parse", ref]);
+}
+
 const tmp = mkdtempSync(join(tmpdir(), "release-test-"));
 const bare = join(tmp, "origin.git");
 const clone = join(tmp, "clone");
@@ -35,7 +41,7 @@ mkdirSync(clone, { recursive: true });
 try {
   git(bare, ["init", "--bare"]);
 
-  git(clone, ["init"]);
+  git(clone, ["init", "-b", "main"]);
   git(clone, ["remote", "add", "origin", bare]);
   git(clone, ["config", "user.email", "release-test@example.com"]);
   git(clone, ["config", "user.name", "Release Test"]);
@@ -55,43 +61,68 @@ try {
   git(clone, ["commit", "-m", "init"]);
   git(clone, ["push", "-u", "origin", "main"]);
 
-  // Criterion 3: dry run prints the package.json edit and writes nothing.
+  const initialSha = refSha(clone, "origin/main");
+
+  // Criterion 3: dry run prints the plan and writes nothing.
   const dry = runRelease(clone, ["1.3.3"]);
   assert.equal(dry.status, 0, dry.stderr);
-  assert.ok(dry.stdout.includes("package.json  0.1.1 -> 1.3.3"), dry.stdout);
+  assert.ok(dry.stdout.includes("package.json  0.1.1 (npm workflow will set to 1.3.3)"), dry.stdout);
   assert.ok(dry.stdout.includes("create    v1.3.3"), dry.stdout);
   assert.ok(dry.stdout.includes("v1 ->"), dry.stdout);
   assert.equal(git(clone, ["status", "--short"]), "");
 
-  // Criterion 1: --apply updates package.json to the requested version.
+  // Criterion 1: --apply creates the immutable and major tags at the remote
+  // main commit. Git is the source of truth for the manifest: package.json is
+  // not committed, so the tag's tree still carries the original version. npm
+  // gets the correct version at publish time from .github/workflows/npm-publish.yml.
   const first = runRelease(clone, ["1.3.3", "--apply"]);
   assert.equal(first.status, 0, first.stderr);
-  assert.equal(packageVersion(clone, "HEAD"), "1.3.3");
-
-  // Criterion 2: the version commit is an ancestor of the immutable tag.
-  git(clone, ["fetch", "origin", "--tags"]);
-  assert.equal(packageVersion(clone, "v1.3.3"), "1.3.3");
-  const versionCommit = git(clone, ["rev-list", "-1", "v1.3.3", "--", "package.json"]);
-  git(clone, ["merge-base", "--is-ancestor", versionCommit, "v1.3.3"]);
-  assert.equal(git(clone, ["tag", "-l", "v1.3.3"]), "v1.3.3");
-  assert.equal(git(clone, ["tag", "-l", "v1"]), "v1");
+  assert.equal(refSha(clone, "v1.3.3"), initialSha, "v1.3.3 did not point at main");
+  assert.equal(refSha(clone, "v1"), initialSha, "v1 did not point at main");
+  assert.equal(refSha(clone, "HEAD"), initialSha, "HEAD moved");
+  assert.equal(packageVersion(clone, "v1.3.3"), "0.1.1", "tag manifest was modified");
+  assert.equal(packageVersion(clone, "HEAD"), "0.1.1", "working tree was modified");
 
   const commitCountBefore = Number(git(clone, ["rev-list", "--count", "HEAD"]));
 
-  // Criterion 5: re-running the same version is refused (no new commit, no moved tag).
+  // Criterion 5: re-running the same version is refused (no new commit, the
+  // immutable tag is not re-pointed, the major tag stays on the same sha).
   const afterFirst = runRelease(clone, ["1.3.3", "--apply"]);
   assert.equal(afterFirst.status, 0, afterFirst.stderr);
   assert.ok(afterFirst.stdout.includes("v1.3.3 already exists at this sha, skipping"), afterFirst.stdout);
   const commitCountAfter = Number(git(clone, ["rev-list", "--count", "HEAD"]));
   assert.equal(commitCountBefore, commitCountAfter, "re-run created a new commit");
-  assert.equal(packageVersion(clone, "v1.3.3"), "1.3.3");
-  assert.equal(packageVersion(clone, "v1"), "1.3.3");
+  assert.equal(refSha(clone, "v1.3.3"), initialSha, "immutable tag moved");
+  assert.equal(refSha(clone, "v1"), initialSha, "major tag moved");
+  assert.equal(packageVersion(clone, "v1.3.3"), "0.1.1");
 
   // Older versions are still refused by the ordering guard.
   const older = runRelease(clone, ["1.3.2", "--apply"]);
   assert.notEqual(older.status, 0, older.stderr);
   assert.ok(older.stderr.includes("not newer"), older.stderr);
   assert.equal(git(clone, ["tag", "-l", "v1.3.2"]), "");
+
+  // Criterion 2: running from a different branch with a dirty working tree
+  // refuses before any branch movement and leaves HEAD where it was.
+  git(clone, ["checkout", "-b", "other-branch"]);
+  writeFileSync(join(clone, "dirty.txt"), "dirty");
+  const dirty = runRelease(clone, ["1.3.4", "--apply"]);
+  assert.notEqual(dirty.status, 0, dirty.stderr);
+  assert.ok(dirty.stderr.includes("uncommitted changes"), dirty.stderr);
+  assert.equal(git(clone, ["branch", "--show-current"]), "other-branch", "HEAD moved");
+  assert.ok(git(clone, ["status", "--short"]).includes("?? dirty.txt"), "working tree was cleaned");
+  assert.equal(git(clone, ["tag", "-l", "v1.3.4"]), "", "tag was created from a dirty checkout");
+  assert.equal(Number(git(clone, ["rev-list", "--count", "HEAD"])), commitCountBefore, "dirty run created a commit");
+
+  // Criterion 4: the publish workflow writes the version from the tag before
+  // npm publish, so the published artifact matches the git tag even though the
+  // committed package.json does not change.
+  assert.ok(existsSync(workflowPath), "npm-publish.yml missing");
+  const workflow = readFileSync(workflowPath, "utf8");
+  assert.ok(workflow.includes("Set package version from tag"), workflow);
+  assert.ok(/github\.ref_name|GITHUB_REF_NAME/.test(workflow), workflow);
+  assert.ok(workflow.includes("package.json"), workflow);
+  assert.match(workflow, /npm publish/);
 
   console.log("release tests passed");
 } finally {


### PR DESCRIPTION
Closes #106

## What

`bin/release.mjs` cuts tags only: it resolves the default branch against the remote tracking ref, never checks out, commits, or pushes a branch, and refuses to run on a dirty working tree. `.github/workflows/npm-publish.yml` writes the version into `package.json` from the triggering tag at publish time, on a single `release: published` trigger guarded by a concurrency group.

## Why

This picks the second option from the issue: **git is the source of truth and npm may lag**. Committing the version bump to `main` on every release would normalize a direct push to the unprotected default branch, which the repo's git-safety rules list as an "Always Block" operation. Instead, `release.mjs` only cuts tags, and the publish workflow sets the npm manifest version from the tag at publish time. If a publish step fails, git is already correct; npm simply lags until the next triggered publish.

## How I verified

I ran `npm test` locally. The release suite exercises the dry run, the first `--apply`, a re-run that refuses to re-point the immutable tag, a resume from a local-only tag, the older-version ordering guard, the new dirty-tree/different-branch guard, and the content of `npm-publish.yml`.

```text
npm test
```

Output:

```text
review delta tests passed
...
release tests passed
selfcheck ok
chair-fallback selfcheck passed
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release tooling now supports configurable Git remotes and branches, with improved tag validation and version handling.
  * Release application creates or resumes version tags, updates major-version tags, and pushes changes.
  * Dry-run output now includes package version details.

* **Bug Fixes**
  * Publishing is triggered only by published releases, with more reliable concurrent run handling.

* **Tests**
  * Added end-to-end coverage for release planning, tagging, reruns, validation, and workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Assisted-by: devin:swe-1-7
