### PR TITLE
[VCR-112] Wire council emit to ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Or wire the action directly:
     gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
     moonshot_api_key: ${{ secrets.MOONSHOT_API_KEY }}
     openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+    vibetrace_ingest_url: ${{ secrets.VIBETRACE_INGEST_URL }}
+    vibetrace_ingest_token: ${{ secrets.VIBETRACE_INGEST_TOKEN }}
 ```
 
 Swap models without code: `council_models` input, or the `*_MODEL` env
@@ -297,3 +299,4 @@ Exposes one tool, `council_review(diff)`. Provider keys come from the server env
 - Subscriptions (codex-personal, gemini-personal, muse) don't reach a CI runner —
   CI uses each provider's **API key**. Only Claude's OAuth token ports to CI.
 - Rotate any key you paste into a chat or terminal history.
+- **Vibetrace Ingestion**: Supply the optional `VIBETRACE_INGEST_URL` and `VIBETRACE_INGEST_TOKEN` as repository secrets to forward completed council run trace metrics and records to a centralized telemetry ingest server. When unset, telemetry traces are stored under `RUNNER_TEMP` as JSONL files.

--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,10 @@ inputs:
     description: "Optional POST endpoint for vibetrace review.council records. When unset, the emit step writes JSONL under RUNNER_TEMP and never fails the review."
     required: false
     default: ""
+  vibetrace_ingest_token:
+    description: "Optional Bearer token for authorization at the vibetrace_ingest_url. When unset, POST requests are sent without an Authorization header."
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -662,6 +666,7 @@ runs:
       shell: bash
       env:
         VIBETRACE_INGEST_URL: ${{ inputs.vibetrace_ingest_url }}
+        VIBETRACE_INGEST_TOKEN: ${{ inputs.vibetrace_ingest_token }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         VCR_PR: ${{ github.event.pull_request.number }}
         GITHUB_HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/bin/rollout.mjs
+++ b/bin/rollout.mjs
@@ -42,6 +42,8 @@ const SECRET_NAMES = [
   'GEMINI_API_KEY',
   'MOONSHOT_API_KEY',
   'OPENROUTER_API_KEY',
+  'VIBETRACE_INGEST_URL',
+  'VIBETRACE_INGEST_TOKEN',
 ];
 
 const WORKFLOW_PATH = '.github/workflows/vibecodereview.yml';
@@ -92,6 +94,8 @@ const WORKFLOW_YAML =
     '          gemini_api_key: ${{ secrets.GEMINI_API_KEY }}',
     '          moonshot_api_key: ${{ secrets.MOONSHOT_API_KEY }}',
     '          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}',
+    '          vibetrace_ingest_url: ${{ secrets.VIBETRACE_INGEST_URL }}',
+    '          vibetrace_ingest_token: ${{ secrets.VIBETRACE_INGEST_TOKEN }}',
   ].join('\n') + '\n';
 
 function stderrOf(err) {

--- a/scripts/vibetrace-emit.mjs
+++ b/scripts/vibetrace-emit.mjs
@@ -6,7 +6,7 @@
 //   node vibetrace-emit.mjs review.council \
 //     --mode delta|full --cache-hit 0|1 --members N --cancelled 0|1
 //
-// Env (all optional): VIBETRACE_INGEST_URL, VIBETRACE_FILE,
+// Env (all optional): VIBETRACE_INGEST_URL, VIBETRACE_INGEST_TOKEN, VIBETRACE_FILE,
 // GITHUB_REPOSITORY, VCR_PR / GITHUB_PR_NUMBER, GITHUB_HEAD_REF,
 // VCR_ISSUE / OFFROUTER_ISSUE, VCR_PR_BODY
 
@@ -88,13 +88,18 @@ function buildCouncilRecord() {
 
 async function emit(record) {
   const ingest = process.env.VIBETRACE_INGEST_URL?.trim();
+  const token = process.env.VIBETRACE_INGEST_TOKEN?.trim();
   const body = JSON.stringify(record);
   if (ingest) {
     // Bounded so a dead/hanging endpoint can never hold the job open despite
     // the "never blocks the review" contract this script promises.
+    const headers = { "content-type": "application/json" };
+    if (token) {
+      headers["authorization"] = `Bearer ${token}`;
+    }
     const res = await fetch(ingest, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers,
       body,
       signal: AbortSignal.timeout(5000),
     });

--- a/scripts/vibetrace-emit.test.mjs
+++ b/scripts/vibetrace-emit.test.mjs
@@ -115,8 +115,10 @@ if (cancelledRun.status !== 0) {
 
 await new Promise((resolve, reject) => {
   const received = [];
+  const reqHeaders = [];
   const server = http.createServer((req, res) => {
     let body = "";
+    reqHeaders.push(req.headers);
     req.on("data", (chunk) => (body += chunk));
     req.on("end", () => {
       received.push(body);
@@ -130,7 +132,6 @@ await new Promise((resolve, reject) => {
       ["review.council", "--mode", "full", "--cache-hit", "0", "--members", "2", "--cancelled", "0"],
       { VIBETRACE_INGEST_URL: `http://127.0.0.1:${port}/ingest` },
     ).then((ingestRun) => {
-      server.close();
       if (ingestRun.status !== 0) {
         console.error("FAIL ingest exit", ingestRun.status, ingestRun.stderr);
         failed++;
@@ -142,14 +143,48 @@ await new Promise((resolve, reject) => {
         if (rec.type !== "review.council" || rec.memberCount !== 2) {
           console.error("FAIL ingest record shape", rec);
           failed++;
+        } else if (reqHeaders[0].authorization !== undefined) {
+          console.error("FAIL ingest sent authorization header when token unset", reqHeaders[0]);
+          failed++;
         } else if (!/-> ingest$/.test(ingestRun.stdout.trim())) {
           console.error("FAIL ingest destination log", ingestRun.stdout);
           failed++;
         } else {
-          console.log("ok - posts review.council to VIBETRACE_INGEST_URL");
+          console.log("ok - posts review.council to VIBETRACE_INGEST_URL (no token)");
         }
       }
-      resolve();
+
+      runAsync(
+        ["review.council", "--mode", "full", "--cache-hit", "0", "--members", "2", "--cancelled", "0"],
+        {
+          VIBETRACE_INGEST_URL: `http://127.0.0.1:${port}/ingest`,
+          VIBETRACE_INGEST_TOKEN: "secret-token-123",
+        },
+      ).then((ingestRun2) => {
+        server.close();
+        if (ingestRun2.status !== 0) {
+          console.error("FAIL ingest with token exit", ingestRun2.status, ingestRun2.stderr);
+          failed++;
+        } else if (received.length !== 2) {
+          console.error("FAIL ingest with token did not receive a POST", ingestRun2.stdout, ingestRun2.stderr);
+          failed++;
+        } else {
+          const rec = JSON.parse(received[1]);
+          if (rec.type !== "review.council" || rec.memberCount !== 2) {
+            console.error("FAIL ingest record shape (with token)", rec);
+            failed++;
+          } else if (reqHeaders[1].authorization !== "Bearer secret-token-123") {
+            console.error("FAIL ingest with token: bad or missing authorization header", reqHeaders[1]);
+            failed++;
+          } else if (!/-> ingest$/.test(ingestRun2.stdout.trim())) {
+            console.error("FAIL ingest with token destination log", ingestRun2.stdout);
+            failed++;
+          } else {
+            console.log("ok - posts review.council with Authorization Bearer token header");
+          }
+        }
+        resolve();
+      });
     });
   });
   server.on("error", reject);


### PR DESCRIPTION
Closes #112

## What

Adds optional `vibetrace_ingest_token` next to the existing ingest URL, sends `Authorization: Bearer` from the emit script when set, and teaches `bin/rollout.mjs` / README to set both secrets on new installs.

## Why

Council emit already writes `review.council` records. Without a tokened URL they stay in `RUNNER_TEMP` and the fleet never sees them.

## How I verified

node --test scripts/vibetrace-emit.test.mjs -> vibetrace-emit tests passed

Proof: n/a — CLI/unit check with no user-visible surface.

Assisted-by: gemini:gemini-3.8-flash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional token-based authentication for forwarding telemetry traces to a centralized ingest server.
  - Generated workflows can now configure the telemetry ingest URL and token.
  - When configured, ingest requests include secure Bearer authentication.
  - When no ingest destination is configured, traces continue to be stored locally as JSONL files.

- **Documentation**
  - Documented the new telemetry ingest URL and token inputs, including local storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->