### PR TITLE
[VCR-116] Dogfood vibetrace ingest

### DIFF
--- a/.github/workflows/vibecodereview.yml
+++ b/.github/workflows/vibecodereview.yml
@@ -36,3 +36,5 @@ jobs:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           moonshot_api_key: ${{ secrets.MOONSHOT_API_KEY }}
           openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          vibetrace_ingest_url: ${{ secrets.VIBETRACE_INGEST_URL }}
+          vibetrace_ingest_token: ${{ secrets.VIBETRACE_INGEST_TOKEN }}


### PR DESCRIPTION
Closes #116

## What
Adds the two `vibetrace_ingest_url` / `vibetrace_ingest_token` `with:` lines to the `uses: ./` step of this repo's self-review workflow, wired to the already-set `VIBETRACE_INGEST_URL` / `VIBETRACE_INGEST_TOKEN` secrets.

## Why
This repo consumes the action via `uses: ./` instead of `@v1`, so the fleet-wide vibetrace rollout (#111-era config) never reached it — the council traces emitted since #112 have had nowhere to go. Also advances pooriaarab/vibetrace#12 by wiring this repo first.

## How I verified
```
grep -c vibetrace_ingest .github/workflows/vibecodereview.yml -> 2
git diff --stat -> 1 file changed, 2 insertions(+)
```
The action already declares both inputs (`action.yml` lines 86/90) and forwards them as env to the emit step (lines 668-669); no action.yml changes. Next PR into this repo should produce a first self-hosted ingest.

Assisted-by: pi:glm-5.3-flash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review processing to use the configured Vibetrace ingestion endpoint and authentication token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->