### PR TITLE
[VCR-120] Wire VibeTrace inputs

### DIFF
--- a/.github/workflows/vibecodereview.yml
+++ b/.github/workflows/vibecodereview.yml
@@ -36,5 +36,5 @@ jobs:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           moonshot_api_key: ${{ secrets.MOONSHOT_API_KEY }}
           openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
-          vibetrace_ingest_url: ${{ secrets.VIBETRACE_INGEST_URL }}
+          vibetrace_ingest_url: ${{ vars.VIBETRACE_INGEST_URL }}
           vibetrace_ingest_token: ${{ secrets.VIBETRACE_INGEST_TOKEN }}


### PR DESCRIPTION
Closes #120

## What
Pass the VibeTrace ingest URL from `vars.VIBETRACE_INGEST_URL` and the ingest token from `secrets.VIBETRACE_INGEST_TOKEN` to the existing `pooriaarab/vibecodereview@v1` step.

## Why
Enable the pilot repository to emit council traces to the live VibeTrace ingest endpoint without exposing credentials.

## How I verified
1. **Workflow inputs** — PR #121 changes the workflow block to use the required sources:

   ```diff
   -          vibetrace_ingest_url: ${{ secrets.VIBETRACE_INGEST_URL }}
   +          vibetrace_ingest_url: ${{ vars.VIBETRACE_INGEST_URL }}
              vibetrace_ingest_token: ${{ secrets.VIBETRACE_INGEST_TOKEN }}
   ```

2. **Stored council record** — the real council run for [PR #121](https://github.com/pooriaarab/vibecodereview/pull/121) completed successfully at [run 33721924655](https://github.com/pooriaarab/vibecodereview/actions/runs/33721924655). The resulting R2 object is `traces/2026/09/03/pooriaarab/vibecodereview/153e7df2-e931-4284-8dfb-4c8b1b3fa993.jsonl` and contains:

   ```json
   "attribution": {
     "repo": "pooriaarab/vibecodereview",
     "issue": 120,
     "pr": 121
   }
   ```

   The emit step logged the accepted write: `vibetrace-emit: wrote review.council -> ingest`.

3. **No credential in logs** — the [run log](https://github.com/pooriaarab/vibecodereview/actions/runs/33721924655) contains `VIBETRACE_INGEST_TOKEN: ***` and no raw credential. The URL is visible as configuration, but the token is masked.

4. **Failing endpoint remains non-blocking** — the action source emits this line for a non-2xx response:

   ```js
   console.error(`vibetrace-emit: ingest HTTP ${res.status}`);
   ```

   Source: [`scripts/vibetrace-emit.mjs`](https://github.com/pooriaarab/vibecodereview/blob/900d70dbf40a30e66133d91777f3920b3b81d48e/scripts/vibetrace-emit.mjs#L108-L112).

5. **Only the VibeTrace wiring changed** — `git diff origin/main...HEAD -- .github/workflows/vibecodereview.yml` -> 1 file changed, 1 insertion(+), 1 deletion(-), showing only the URL-source replacement above; the token line and every other input, trigger, concurrency setting, and budget are unchanged. `git diff --check` -> passed.

`gh pr checks 121 --repo pooriaarab/vibecodereview` -> captured output:

```text
CodeRabbit	pass	0	Review rate limited
PR standards	pass	10s	https://github.com/pooriaarab/vibecodereview/actions/runs/33722340514/job/100543899179
lint	pass	9s	https://github.com/pooriaarab/vibecodereview/actions/runs/33721924764/job/100542666956
review	pass	49s	https://github.com/pooriaarab/vibecodereview/actions/runs/33721924655/job/100542666605
```

Assisted-by: pi:openai/gpt-5.6-luna
