### PR TITLE
[VCR-122] Skip the council on a trivial delta

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "vibecodereview": "bin/vibecodereview.mjs"
   },
   "scripts": {
-    "test": "node scripts/review-delta.test.mjs && node scripts/council-cache.test.mjs && node scripts/vibetrace-emit.test.mjs && node scripts/lint-workflow.test.mjs && node scripts/release.test.mjs && npm run selfcheck",
+    "test": "node scripts/review-delta.test.mjs && node scripts/council-cache.test.mjs && node scripts/vibetrace-emit.test.mjs && node scripts/lint-workflow.test.mjs && node scripts/release.test.mjs && node scripts/behavioral-surface.test.mjs && npm run selfcheck",
     "selfcheck": "node scripts/council-review.mjs --selfcheck && node scripts/chair-fallback.mjs --selfcheck",
     "mcp": "node mcp/server.mjs"
   },

--- a/scripts/behavioral-surface.mjs
+++ b/scripts/behavioral-surface.mjs
@@ -1,0 +1,80 @@
+// Classify a git diff by whether any changed path has behavioral surface.
+// Used by the council engine to skip model calls on docs-only / lockfile pushes.
+
+import { diffPaths } from "./review-delta.mjs";
+
+const EDITOR_NOISE = new Set([
+  ".gitignore", ".gitattributes", ".editorconfig", ".prettierignore",
+  ".npmignore", ".dockerignore", ".cursorignore",
+]);
+
+const LOCKFILES = new Set([
+  "package-lock.json", "npm-shrinkwrap.json", "yarn.lock", "pnpm-lock.yaml",
+  "bun.lock", "bun.lockb", "Cargo.lock", "poetry.lock", "Gemfile.lock",
+  "composer.lock", "go.sum", "Pipfile.lock", "uv.lock", "flake.lock",
+]);
+
+const INERT_EXTENSIONS = new Set([
+  ".md", ".mdx", ".txt", ".rst",
+  ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".ico",
+  ".mp4", ".mov", ".woff", ".woff2", ".ttf", ".otf",
+]);
+
+const AGENT_INSTRUCTION_NAMES = new Set([
+  "AGENTS.md", "CLAUDE.md", "GEMINI.md", ".cursorrules", ".windsurfrules", "SKILL.md",
+]);
+
+const BEHAVIORAL_DIRS = new Set([
+  ".claude", ".agents", ".cursor", ".github",
+  "skills", "commands", "prompts", "rules", "hooks",
+]);
+
+function basename(path) {
+  const i = path.lastIndexOf("/");
+  return i === -1 ? path : path.slice(i + 1);
+}
+
+function extensionOf(path) {
+  const i = path.lastIndexOf(".");
+  return i === -1 ? "" : path.slice(i).toLowerCase();
+}
+
+function isAgentInstructionPath(path) {
+  if (AGENT_INSTRUCTION_NAMES.has(basename(path))) return true;
+  return path.split("/").some((seg) => BEHAVIORAL_DIRS.has(seg));
+}
+
+function isInertPath(path) {
+  if (isAgentInstructionPath(path)) return false;
+  const base = basename(path);
+  if (EDITOR_NOISE.has(base)) return true;
+  if (base === "LICENSE" || base === "NOTICE") return true;
+  // Exact name only. A `startsWith` here made `CHANGELOG_GENERATOR.py` inert,
+  // which skips review on a source file — the one direction this gate must
+  // never fail in. A real changelog with an extension is already covered by
+  // INERT_EXTENSIONS below.
+  if (base === "CHANGELOG") return true;
+  if (LOCKFILES.has(base)) return true;
+  return INERT_EXTENSIONS.has(extensionOf(path));
+}
+
+/** @returns {{ trivial: boolean, paths: string[], reason: string }} */
+export function behavioralSurface(diff) {
+  const paths = diffPaths(diff);
+  if (paths.length === 0) {
+    return { trivial: false, paths, reason: "no parseable paths in diff" };
+  }
+  const behavioral = paths.filter((p) => !isInertPath(p));
+  if (behavioral.length > 0) {
+    return {
+      trivial: false,
+      paths,
+      reason: `changed paths include behavioral surface (${behavioral.join(", ")})`,
+    };
+  }
+  return {
+    trivial: true,
+    paths,
+    reason: "every changed path is inert (docs, lockfiles, assets, or editor noise)",
+  };
+}

--- a/scripts/behavioral-surface.test.mjs
+++ b/scripts/behavioral-surface.test.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { behavioralSurface } from "./behavioral-surface.mjs";
+
+function diffFor(path) {
+  return `diff --git a/${path} b/${path}\n--- a/${path}\n+++ b/${path}\n+change\n`;
+}
+
+function joinDiffs(...paths) {
+  return paths.map(diffFor).join("");
+}
+
+// Docs-only diff is trivial.
+assert.equal(behavioralSurface(diffFor("README.md")).trivial, true);
+// Lockfile-only diff is trivial.
+assert.equal(behavioralSurface(diffFor("package-lock.json")).trivial, true);
+// Source change is not trivial.
+assert.equal(behavioralSurface(diffFor("src/app.ts")).trivial, false);
+// Mixed docs + source is not trivial.
+assert.equal(behavioralSurface(joinDiffs("docs/guide.md", "src/app.ts")).trivial, false);
+// Workflow changes are behavioral.
+assert.equal(behavioralSurface(diffFor(".github/workflows/ci.yml")).trivial, false);
+// Agent-instruction markdown is behavioral.
+assert.equal(behavioralSurface(diffFor("AGENTS.md")).trivial, false);
+assert.equal(behavioralSurface(diffFor(".claude/rules/foo.md")).trivial, false);
+assert.equal(behavioralSurface(diffFor("skills/x/SKILL.md")).trivial, false);
+// Plain docs under docs/ stay inert.
+assert.equal(behavioralSurface(diffFor("docs/guide.md")).trivial, true);
+// Empty / unparseable diff fails open.
+assert.equal(behavioralSurface("").trivial, false);
+assert.equal(behavioralSurface("not a git diff").trivial, false);
+// A real changelog is inert, but a source file that merely STARTS with the
+// word is not. Getting this wrong skips review on code, which is the only
+// direction this gate must never fail in.
+assert.equal(behavioralSurface(diffFor("CHANGELOG")).trivial, true);
+assert.equal(behavioralSurface(diffFor("CHANGELOG.md")).trivial, true);
+assert.equal(behavioralSurface(diffFor("CHANGELOG_GENERATOR.py")).trivial, false);
+assert.equal(behavioralSurface(diffFor("tools/CHANGELOGGER.ts")).trivial, false);
+// Config is behavioral; named lockfiles are inert.
+assert.equal(behavioralSurface(diffFor("config.json")).trivial, false);
+assert.equal(behavioralSurface(diffFor("package-lock.json")).trivial, true);
+
+console.log("behavioral surface tests passed");

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -49,6 +49,7 @@ import {
   callModelWithFallback,
 } from "./council-members.mjs";
 import { cacheKey, loadCouncilResults, saveCouncilResult } from "./council-cache.mjs";
+import { behavioralSurface } from "./behavioral-surface.mjs";
 
 async function main() {
   if (process.argv.includes("--selfcheck")) {
@@ -216,6 +217,14 @@ async function main() {
   if (!diff) {
     write("# 🧑‍⚖️ LLM Council findings\n\n_Council skipped: empty diff._\n");
     console.log("Empty diff — council skipped.");
+    return;
+  }
+
+  const surface = behavioralSurface(memberDiffRaw);
+  if (surface.trivial) {
+    const listed = surface.paths.map((p) => `\`${p}\``).join(", ");
+    write(`# 🧑‍⚖️ LLM Council findings\n\n_Council skipped: trivial delta with no behavioral surface — ${surface.reason}. Paths: ${listed}._\n`);
+    console.log(`Trivial delta — council skipped (${surface.paths.length} inert path(s)).`);
     return;
   }
 

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -220,10 +220,25 @@ async function main() {
     return;
   }
 
+  // Read before the trivial-delta gate below: every skip path from here on
+  // must still surface carried-forward findings, or a delta that goes trivial
+  // right after a cycle that left a real finding open silently drops it from
+  // the report instead of carrying it to the next cycle.
+  const priorFindings = process.env.VCR_PRIOR_FINDINGS_FILE && fs.existsSync(process.env.VCR_PRIOR_FINDINGS_FILE)
+    ? fs.readFileSync(process.env.VCR_PRIOR_FINDINGS_FILE, "utf8")
+    : "";
+  const baseReportOptions = {
+    reviewHeadSha: process.env.VCR_REVIEW_HEAD_SHA,
+    memberDiffNote: process.env.VCR_MEMBER_DIFF_NOTE,
+    carriedFindings: priorFindings,
+    diffTruncated,
+    contextTruncated,
+  };
+
   const surface = behavioralSurface(memberDiffRaw);
   if (surface.trivial) {
     const listed = surface.paths.map((p) => `\`${p}\``).join(", ");
-    write(`# 🧑‍⚖️ LLM Council findings\n\n_Council skipped: trivial delta with no behavioral surface — ${surface.reason}. Paths: ${listed}._\n`);
+    write(buildFindingsMarkdown([], baseReportOptions) + `\n\n_Council skipped: trivial delta with no behavioral surface — ${surface.reason}. Paths: ${listed}._\n`);
     console.log(`Trivial delta — council skipped (${surface.paths.length} inert path(s)).`);
     return;
   }
@@ -248,18 +263,7 @@ async function main() {
     mutationSkipped = "the member delta was truncated before its added test lines";
   }
   if (mutationSkipped) console.log(`Mutation lens enabled but not dispatched: ${mutationSkipped}`);
-  const priorFindings = process.env.VCR_PRIOR_FINDINGS_FILE && fs.existsSync(process.env.VCR_PRIOR_FINDINGS_FILE)
-    ? fs.readFileSync(process.env.VCR_PRIOR_FINDINGS_FILE, "utf8")
-    : "";
-  const reportOptions = {
-    reviewHeadSha: process.env.VCR_REVIEW_HEAD_SHA,
-    memberDiffNote: process.env.VCR_MEMBER_DIFF_NOTE,
-    skippedLenses,
-    carriedFindings: priorFindings,
-    diffTruncated,
-    contextTruncated,
-    mutationSkipped,
-  };
+  const reportOptions = { ...baseReportOptions, skippedLenses, mutationSkipped };
 
   if (members.length === 0) {
     write(buildFindingsMarkdown([], reportOptions) + "\n\n_Council skipped: no configured lens applies to the member delta._\n");


### PR DESCRIPTION
Closes #122

## What

Classify the member delta before the council fans out, and skip every member when
no changed path has behavioral surface. The classifier is one pure function in a
new `scripts/behavioral-surface.mjs`; the engine gains one gate beside the four
early-skip idioms it already has.

## Why

Every push paid five model calls on five providers. A docs-only, whitespace-only
or lockfile-regeneration push cost exactly as much as a change to auth. The
existing controls (`max_council_runs`, `max_branch_runs`, `max_fix_cycles`,
`MAX_DIFF_CHARS`) bound how *often* the council runs and how much it *reads*.
None of them asked whether this delta was worth a council at all.

Three decisions worth stating, because each is a place this could have gone wrong:

**The signal is kind of change, never size.** Pullfrog considered and rejected
size thresholds (`modes.ts:196`): "there is no file-count, line-count, or budget
threshold either — diff size is not a proxy for review uncertainty." A one-line
change to a config default is not trivial; a 900-line lockfile regeneration is.
There is no line count anywhere in this gate.

**Agent-instruction markdown is not inert.** In this fleet some markdown *is*
executable policy — `.claude/rules/agent-review-governance.md` says so directly:
"the text here is not documentation of the policy, it is an input to the
reviewer's behaviour." So `AGENTS.md`, `CLAUDE.md`, any `SKILL.md`, and anything
under `.claude/`, `.agents/`, `.cursor/`, `.github/`, `skills/`, `commands/`,
`prompts/`, `rules/` or `hooks/` stays behavioral. A naive "markdown is prose"
gate would have stopped reviewing exactly the files that steer the fleet.

**The skip is disclosed, and the gate fails toward reviewing.** A silent skip
reads as "the security lens passed" when it never ran, so the report names the
reason and the paths. Anything the classifier cannot parse is treated as
behavioral, so an unrecognised diff still gets a full review.

The chair still runs on a trivial delta — this saves the five member calls, not
the chair session. Gating the chair is a separate concern and a separate PR.

## How I verified

Lint ran in CI on this branch and passed, which covers the 300-line `max-lines`
cap on both the new module and the engine:
https://github.com/pooriaarab/vibecodereview/actions/runs/33927923818/job/101200367390

The unit suites have no CI job in this repo yet — that is open issue #84 — so
the runs below are local and not independently checkable. Stating that rather
than implying CI ran them.

```
$ node scripts/council-review.mjs --selfcheck
selfcheck ok

$ node --test scripts/*.test.mjs
ℹ tests 19
ℹ pass 19
ℹ fail 0
```

17 tests before this change, 19 after. Classifier probed directly, one path per line:

```
true   docs/guide.md        true   CHANGELOG.md      true   package-lock.json
false  src/a.ts             false  config.json       false  .github/workflows/ci.yml
false  AGENTS.md            false  .claude/rules/x.md   false  skills/x/SKILL.md
```

An earlier draft matched the changelog by prefix, which classified
`CHANGELOG_GENERATOR.py` and `tools/CHANGELOGGER.ts` as trivial — real source
files that would have skipped review entirely. That is the one direction this
gate must never fail in. It now matches the exact name, and both cases are
regression-tested.

Assisted-by: cursor:composer-2.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automated review checks now distinguish documentation and other non-behavioral updates from changes that may affect application behavior.
  - Review reports retain prior findings and shared metadata when changes are classified as trivial.

- **Tests**
  - Added coverage for documentation, configuration, workflow, source, mixed, empty, and invalid change sets.
  - The standard test command now includes these behavioral-change checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->