### PR TITLE
[VCR-127] Route each lens by the kind of file touched

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ size, line count, or file count. Each lens reviews only the kinds it can speak t
 | maintainability | source, test, CI, agent instructions |
 | performance | source, style (CSS/SCSS/Less/Sass) |
 
-A lockfile-only push keeps scope, correctness, and security; it skips performance and
-maintainability. A docs-only delta keeps scope alone. An unparseable diff fails open and
+A lockfile-only or docs-only push never reaches routing at all: the trivial-delta check
+above already skips the whole council, scope included, before any lens is dispatched.
+Routing only decides the roster once a delta has at least one non-inert path — a
+dependency-manifest-only push (`package.json`, `go.mod`, ...) keeps scope, correctness,
+and security; a test-only push keeps scope, correctness, and maintainability; a
+style-only push keeps scope and performance. An unparseable diff fails open and
 dispatches every lens. Dropped lenses are listed in the findings as "Lenses not dispatched".
 
 Set `VCR_LENS_ROUTING=off` to disable routing and dispatch the full roster.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,28 @@ verdict, self-healing fix.
 | Sonnet (mutation) | openrouter.ai | `OPENROUTER_API_KEY` | can these tests fail at all — **off by default** |
 
 A member with no key drops out. No key at all → the council step is skipped, and
-Claude still reviews alone. Nothing here blocks the PR on a provider outage. The scope lens reads the PR's title, body, and linked issues from `PR_CONTEXT_FILE` when available to verify the diff matches the author's claim.
+Claude still reviews alone. Nothing here blocks the PR on a provider outage.
+
+### Lens routing
+
+Council members are dispatched by the **kind of file** a delta touches — never by diff
+size, line count, or file count. Each lens reviews only the kinds it can speak to:
+
+| Lens | File kinds |
+| --- | --- |
+| scope | always (every delta) |
+| correctness | source, test, CI, deps, agent instructions |
+| security | source, CI, deps, agent instructions |
+| maintainability | source, test, CI, agent instructions |
+| performance | source, style (CSS/SCSS/Less/Sass) |
+
+A lockfile-only push keeps scope, correctness, and security; it skips performance and
+maintainability. A docs-only delta keeps scope alone. An unparseable diff fails open and
+dispatches every lens. Dropped lenses are listed in the findings as "Lenses not dispatched".
+
+Set `VCR_LENS_ROUTING=off` to disable routing and dispatch the full roster.
+
+The scope lens reads the PR's title, body, and linked issues from `PR_CONTEXT_FILE` when available to verify the diff matches the author's claim.
 
 A pull request also has to show its work: a visible change carries before and after
 screenshots, a command carries its result. The scope member judges that evidence against

--- a/scripts/behavioral-surface.mjs
+++ b/scripts/behavioral-surface.mjs
@@ -3,28 +3,28 @@
 
 import { diffPaths } from "./review-delta.mjs";
 
-const EDITOR_NOISE = new Set([
+export const EDITOR_NOISE = new Set([
   ".gitignore", ".gitattributes", ".editorconfig", ".prettierignore",
   ".npmignore", ".dockerignore", ".cursorignore",
 ]);
 
-const LOCKFILES = new Set([
+export const LOCKFILES = new Set([
   "package-lock.json", "npm-shrinkwrap.json", "yarn.lock", "pnpm-lock.yaml",
   "bun.lock", "bun.lockb", "Cargo.lock", "poetry.lock", "Gemfile.lock",
   "composer.lock", "go.sum", "Pipfile.lock", "uv.lock", "flake.lock",
 ]);
 
-const INERT_EXTENSIONS = new Set([
+export const INERT_EXTENSIONS = new Set([
   ".md", ".mdx", ".txt", ".rst",
   ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".ico",
   ".mp4", ".mov", ".woff", ".woff2", ".ttf", ".otf",
 ]);
 
-const AGENT_INSTRUCTION_NAMES = new Set([
+export const AGENT_INSTRUCTION_NAMES = new Set([
   "AGENTS.md", "CLAUDE.md", "GEMINI.md", ".cursorrules", ".windsurfrules", "SKILL.md",
 ]);
 
-const BEHAVIORAL_DIRS = new Set([
+export const BEHAVIORAL_DIRS = new Set([
   ".claude", ".agents", ".cursor", ".github",
   "skills", "commands", "prompts", "rules", "hooks",
 ]);
@@ -39,13 +39,12 @@ function extensionOf(path) {
   return i === -1 ? "" : path.slice(i).toLowerCase();
 }
 
-function isAgentInstructionPath(path) {
+export function isAgentInstructionPath(path) {
   if (AGENT_INSTRUCTION_NAMES.has(basename(path))) return true;
   return path.split("/").some((seg) => BEHAVIORAL_DIRS.has(seg));
 }
 
-function isInertPath(path) {
-  if (isAgentInstructionPath(path)) return false;
+export function isProseMediaPath(path) {
   const base = basename(path);
   if (EDITOR_NOISE.has(base)) return true;
   if (base === "LICENSE" || base === "NOTICE") return true;
@@ -54,8 +53,13 @@ function isInertPath(path) {
   // never fail in. A real changelog with an extension is already covered by
   // INERT_EXTENSIONS below.
   if (base === "CHANGELOG") return true;
-  if (LOCKFILES.has(base)) return true;
   return INERT_EXTENSIONS.has(extensionOf(path));
+}
+
+function isInertPath(path) {
+  if (isAgentInstructionPath(path)) return false;
+  if (LOCKFILES.has(basename(path))) return true;
+  return isProseMediaPath(path);
 }
 
 /** @returns {{ trivial: boolean, paths: string[], reason: string }} */

--- a/scripts/council-config.mjs
+++ b/scripts/council-config.mjs
@@ -104,7 +104,7 @@ const TEST_PATH = /(^|\/)(tests?|spec|__tests__)\/|[._-](test|spec)\.[a-z]+$|(^|
 // `Latest.js`) match too. Requiring the capitalized suffix rules that out.
 const CONVENTIONAL_TEST_SUFFIX = /(Test|Tests|Spec|Specs)\.[A-Za-z0-9]+$/;
 
-function isTestPath(path) {
+export function isTestPath(path) {
   return TEST_PATH.test(path) || CONVENTIONAL_TEST_SUFFIX.test(path);
 }
 

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -50,6 +50,7 @@ import {
 } from "./council-members.mjs";
 import { cacheKey, loadCouncilResults, saveCouncilResult } from "./council-cache.mjs";
 import { behavioralSurface } from "./behavioral-surface.mjs";
+import { filterMembersByKindRouting, lensesForKinds, routeLenses } from "./lens-routing.mjs";
 
 async function main() {
   if (process.argv.includes("--selfcheck")) {
@@ -117,6 +118,15 @@ async function main() {
     // would fail the selfcheck that AGENTS.md requires it to run.
     if (!DEFAULT_MODELS.some((m) => m.lens === "scope")) throw new Error("selfcheck: scope lens missing from default members");
     selfcheckMutationRoster(buildFindingsMarkdown);
+
+    const allRoutedLenses = ["correctness", "performance", "security", "maintainability", "scope"];
+    const emptyRoute = routeLenses("");
+    if (!allRoutedLenses.every((l) => emptyRoute.lenses.includes(l))) {
+      throw new Error("selfcheck: empty diff must fail open with every routed lens");
+    }
+    if (!lensesForKinds(new Set(["docs"])).includes("scope")) {
+      throw new Error("selfcheck: routing must never drop scope");
+    }
 
     // A unique temp dir, not a fixed name in the working directory: the old
     // fixture would clobber a real test_ctx.tmp and broke concurrent runs.
@@ -249,7 +259,7 @@ async function main() {
   // on the diff read above.
   let { members, mutationSkipped } = withMutationMember(models, memberDiffRaw);
   const lensPathFilter = process.env.LENS_PATH_FILTER;
-  const skippedLenses = [...new Set(
+  let skippedLenses = [...new Set(
     members.filter((m) => !lensCanReviewDiff(m.lens, memberDiffRaw, lensPathFilter)).map((m) => m.lens),
   )];
   members = members.filter((m) => lensCanReviewDiff(m.lens, memberDiffRaw, lensPathFilter));
@@ -263,6 +273,10 @@ async function main() {
     mutationSkipped = "the member delta was truncated before its added test lines";
   }
   if (mutationSkipped) console.log(`Mutation lens enabled but not dispatched: ${mutationSkipped}`);
+  const kindRouting = filterMembersByKindRouting(members, memberDiffRaw);
+  members = kindRouting.members;
+  skippedLenses.push(...kindRouting.skippedLenses);
+  skippedLenses = [...new Set(skippedLenses)];
   const reportOptions = { ...baseReportOptions, skippedLenses, mutationSkipped };
 
   if (members.length === 0) {

--- a/scripts/lens-routing.mjs
+++ b/scripts/lens-routing.mjs
@@ -1,0 +1,120 @@
+// Route council lenses by the kind of file touched, not by diff size. A one-line
+// auth change can need every lens; a lockfile-only push should not pay for
+// performance. The classifier is pure — env and roster filtering live in the engine.
+
+import {
+  LOCKFILES,
+  isAgentInstructionPath,
+  isProseMediaPath,
+} from "./behavioral-surface.mjs";
+import { isTestPath } from "./council-config.mjs";
+import { diffPaths } from "./review-delta.mjs";
+
+const DEP_MANIFESTS = new Set([
+  "package.json", "requirements.txt", "go.mod", "Cargo.toml", "pyproject.toml", "Gemfile",
+]);
+
+const STYLE_EXTENSIONS = new Set([".css", ".scss", ".less", ".sass"]);
+
+// Same order as DEFAULT_MODELS so routed lenses match roster order, not alpha.
+const ROUTED_LENS_ORDER = ["correctness", "performance", "security", "maintainability", "scope"];
+
+const ALL_ROUTED_LENSES = [...ROUTED_LENS_ORDER];
+
+const LENS_KINDS = {
+  scope: null, // always dispatched — judged on the PR as a whole
+  correctness: new Set(["source", "test", "ci", "deps", "agent"]),
+  security: new Set(["source", "ci", "deps", "agent"]),
+  maintainability: new Set(["source", "test", "agent", "ci"]),
+  performance: new Set(["source", "style"]),
+};
+
+function basename(path) {
+  const i = path.lastIndexOf("/");
+  return i === -1 ? path : path.slice(i + 1);
+}
+
+function extensionOf(path) {
+  const i = path.lastIndexOf(".");
+  return i === -1 ? "" : path.slice(i).toLowerCase();
+}
+
+function isCiPath(path) {
+  if (path.startsWith(".github/workflows/")) return true;
+  const base = basename(path);
+  if (base === "Dockerfile" || base === "action.yml") return true;
+  return base.startsWith("docker-compose");
+}
+
+function isDepsPath(path) {
+  const base = basename(path);
+  if (LOCKFILES.has(base)) return true;
+  return DEP_MANIFESTS.has(base);
+}
+
+function isDocsPath(path) {
+  if (isAgentInstructionPath(path)) return false;
+  return isProseMediaPath(path);
+}
+
+/** @returns {"docs"|"deps"|"ci"|"agent"|"test"|"style"|"source"} */
+export function classifyPath(path) {
+  // CI before agent: `.github` is a behavioral dir but workflow files need the ci lens.
+  if (isCiPath(path)) return "ci";
+  if (isAgentInstructionPath(path)) return "agent";
+  if (isTestPath(path)) return "test";
+  if (isDepsPath(path)) return "deps";
+  if (STYLE_EXTENSIONS.has(extensionOf(path))) return "style";
+  if (isDocsPath(path)) return "docs";
+  // Unknown extensions are source, never docs — skipping review on real code is the
+  // one direction this gate must never fail in.
+  return "source";
+}
+
+/** @param {Iterable<string>} kinds */
+export function lensesForKinds(kinds) {
+  const kindSet = kinds instanceof Set ? kinds : new Set(kinds);
+  return ROUTED_LENS_ORDER.filter((lens) => {
+    if (lens === "scope") return true;
+    return [...kindSet].some((kind) => LENS_KINDS[lens].has(kind));
+  });
+}
+
+/** @returns {{ lenses: string[], kinds: string[] }} */
+export function routeLenses(diff) {
+  const paths = diffPaths(diff);
+  if (paths.length === 0) {
+    // Unparseable diff — fail open with the full council, never silently shrink coverage.
+    return { lenses: ALL_ROUTED_LENSES, kinds: [] };
+  }
+  const kinds = [];
+  for (const path of paths) {
+    const kind = classifyPath(path);
+    if (!kinds.includes(kind)) kinds.push(kind);
+  }
+  return { lenses: lensesForKinds(kinds), kinds };
+}
+
+export function isLensRoutingEnabled() {
+  return String(process.env.VCR_LENS_ROUTING || "").trim().toLowerCase() !== "off";
+}
+
+// A lens this table does not know about. `COUNCIL_MODELS` accepts any lens
+// string, and `mutation` has its own opt-in gate, so neither is ours to route:
+// dropping a lens we cannot reason about would silently disable a roster the
+// repo asked for, and blame it on paths that were in fact reviewable.
+function isRoutable(lens) {
+  return lens !== "mutation" && Object.hasOwn(LENS_KINDS, lens);
+}
+
+/** Filter roster members by kind routing; an unroutable lens passes through. */
+export function filterMembersByKindRouting(members, diff, { routingEnabled = isLensRoutingEnabled() } = {}) {
+  if (!routingEnabled) return { members, skippedLenses: [] };
+  const { lenses } = routeLenses(diff);
+  const allowed = new Set(lenses);
+  const keeps = (m) => !isRoutable(m.lens) || allowed.has(m.lens);
+  return {
+    members: members.filter(keeps),
+    skippedLenses: members.filter((m) => !keeps(m)).map((m) => m.lens),
+  };
+}

--- a/scripts/lens-routing.test.mjs
+++ b/scripts/lens-routing.test.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { DEFAULT_MODELS } from "./council-config.mjs";
+import {
+  classifyPath,
+  filterMembersByKindRouting,
+  isLensRoutingEnabled,
+  lensesForKinds,
+  routeLenses,
+} from "./lens-routing.mjs";
+
+const ALL_LENSES = ["correctness", "performance", "security", "maintainability", "scope"];
+
+function diffFor(path) {
+  return `diff --git a/${path} b/${path}\n--- a/${path}\n+++ b/${path}\n+change\n`;
+}
+
+function assertScopePresent(lenses, label) {
+  assert.ok(lenses.includes("scope"), `${label}: scope must always be dispatched`);
+}
+
+// Lockfile-only: scope + correctness + security; no performance or maintainability.
+const lockRoute = routeLenses(diffFor("package-lock.json"));
+assert.deepEqual(lockRoute.kinds, ["deps"]);
+assert.deepEqual(lockRoute.lenses, ["correctness", "security", "scope"]);
+assertScopePresent(lockRoute.lenses, "lockfile-only");
+
+// Docs-only: scope alone.
+const docsRoute = routeLenses(diffFor("README.md"));
+assert.deepEqual(docsRoute.kinds, ["docs"]);
+assert.deepEqual(docsRoute.lenses, ["scope"]);
+assertScopePresent(docsRoute.lenses, "docs-only");
+
+// TypeScript source: full council.
+const tsRoute = routeLenses(diffFor("src/app.ts"));
+assert.deepEqual(tsRoute.kinds, ["source"]);
+assert.deepEqual(tsRoute.lenses, ALL_LENSES);
+assertScopePresent(tsRoute.lenses, "source");
+
+// Test-only: drops security and performance.
+const testRoute = routeLenses(diffFor("tests/app.test.ts"));
+assert.deepEqual(testRoute.kinds, ["test"]);
+assert.deepEqual(testRoute.lenses, ["correctness", "maintainability", "scope"]);
+assertScopePresent(testRoute.lenses, "test-only");
+
+// CSS-only: performance + scope; security dropped.
+const cssRoute = routeLenses(diffFor("styles/main.css"));
+assert.deepEqual(cssRoute.kinds, ["style"]);
+assert.deepEqual(cssRoute.lenses, ["performance", "scope"]);
+assertScopePresent(cssRoute.lenses, "css-only");
+assert.ok(!cssRoute.lenses.includes("security"), "css-only must drop security");
+
+// Unknown extension is source, not docs.
+assert.equal(classifyPath("src/thing.zig"), "source");
+const zigRoute = routeLenses(diffFor("src/thing.zig"));
+assert.deepEqual(zigRoute.lenses, ALL_LENSES);
+
+// Empty / unparseable diff fails open.
+assert.deepEqual(routeLenses("").lenses, ALL_LENSES);
+assert.deepEqual(routeLenses("not a git diff").lenses, ALL_LENSES);
+assertScopePresent(routeLenses("").lenses, "empty diff");
+
+// lensesForKinds preserves roster order, not alphabetical.
+assert.deepEqual(lensesForKinds(["deps"]), ["correctness", "security", "scope"]);
+
+// VCR_LENS_ROUTING=off leaves the roster untouched.
+const roster = structuredClone(DEFAULT_MODELS);
+const lockDiff = diffFor("package-lock.json");
+const savedRouting = process.env.VCR_LENS_ROUTING;
+try {
+  delete process.env.VCR_LENS_ROUTING;
+  assert.equal(isLensRoutingEnabled(), true, "unset env means routing on");
+  const on = filterMembersByKindRouting(roster, lockDiff);
+  assert.ok(on.members.length < roster.length, "routing on should drop lenses on a lockfile diff");
+
+  process.env.VCR_LENS_ROUTING = "off";
+  assert.equal(isLensRoutingEnabled(), false);
+  const off = filterMembersByKindRouting(roster, lockDiff);
+  assert.deepEqual(off.members, roster);
+  assert.deepEqual(off.skippedLenses, []);
+} finally {
+  if (savedRouting === undefined) delete process.env.VCR_LENS_ROUTING;
+  else process.env.VCR_LENS_ROUTING = savedRouting;
+}
+
+// A ci path still earns maintainability: a workflow can carry the same missing
+// error handling and broken contracts the lens looks for in source.
+const ciRoute = routeLenses(diffFor(".github/workflows/build.yml"));
+assert.deepEqual(ciRoute.kinds, ["ci"]);
+assert.ok(ciRoute.lenses.includes("maintainability"), "ci must keep maintainability");
+
+// COUNCIL_MODELS accepts any lens string. Routing knows only its own table, so
+// an unknown lens must survive a diff that routing would otherwise shrink.
+const customRoster = [
+  { provider: "openrouter", model: "m", name: "Custom", lens: "accessibility" },
+  { provider: "openrouter", model: "m", name: "Perf", lens: "performance" },
+];
+const custom = filterMembersByKindRouting(customRoster, diffFor("package-lock.json"));
+assert.deepEqual(custom.members.map((m) => m.lens), ["accessibility"], "an unknown lens must pass through");
+assert.deepEqual(custom.skippedLenses, ["performance"], "a known lens is still routed");
+
+// Mutation has its own opt-in gate and is never routed away here.
+const withMutation = filterMembersByKindRouting(
+  [{ provider: "openrouter", model: "m", name: "Mut", lens: "mutation" }],
+  diffFor("README.md"),
+);
+assert.deepEqual(withMutation.members.map((m) => m.lens), ["mutation"]);
+assert.deepEqual(withMutation.skippedLenses, []);
+
+console.log("lens routing tests passed");


### PR DESCRIPTION
Closes #127

## What

Each council lens now declares the file kinds it can speak to, and only the lenses with something to review are dispatched. A test-only push dispatches 3 members instead of 5, and a style-only push 2.

## Routing table

`scripts/lens-routing.mjs` classifies every path from the delta as one of `docs`, `deps`, `ci`, `agent`, `test`, `style` or `source`, then maps those kinds to a lens set.

| Lens | File kinds |
| --- | --- |
| scope | always |
| correctness | source, test, ci, deps, agent |
| security | source, ci, deps, agent |
| maintainability | source, test, ci, agent |
| performance | source, style |

Routing sits *after* the existing trivial-delta gate, so it only ever decides the roster for a delta that already has a non-inert path. A lockfile-only or docs-only push never reaches it — `behavioralSurface` skips the whole council first.

Dropped lenses ride the existing `skippedLenses` channel and are named in the report under "Lenses not dispatched". `VCR_LENS_ROUTING=off` restores the full roster, and `LENS_PATH_FILTER` still applies on top.

The classifier reuses the vocabulary already in the repo rather than restating it: `LOCKFILES` and the agent-instruction predicate come from `behavioral-surface.mjs`, `isTestPath` from `council-config.mjs`, and `diffPaths` from `review-delta.mjs`. jscpd would fail a second copy of any of them.

## Why

The only spend gates were all-or-nothing. `behavioralSurface` skips every member on an inert delta and the budget guard skips every member on a ceiling; between them nothing decided how many members a delta deserved, so a test-only push still paid for a security and a performance review with nothing to look at.

Routing keys on the kind of file touched and never on a file count, a line count, or a diff size. That constraint is deliberate: a one-line auth change can need every lens and a 500-line mechanical rename can need none, so size is not a proxy for review uncertainty.

Two paths deliberately do not route:

- An unparseable diff yields no paths and **fails open** to the full council. Shrinking coverage on a diff we cannot read is the one direction this gate must never fail in.
- A lens outside the routing table **passes through untouched**. `COUNCIL_MODELS` accepts any lens string, so dropping one the table cannot reason about would silently disable a roster the repo asked for and blame it on paths that were in fact reviewable.

Per-lens reasoning effort is a separate concern and is not here. It would need `cacheKey` to include effort, or changing effort would reuse the old completion.

## How I verified

`node scripts/council-review.mjs --selfcheck` — prints `selfcheck ok`. Two new assertions in it: routing never drops `scope`, and an empty diff fails open with every routed lens.

`node --test scripts/*.test.mjs` — 20 tests, 20 pass, 0 fail, re-run after the chair's README commit. That includes the existing `behavioral-surface.test.mjs`, which covers the extraction of `isProseMediaPath` out of `isInertPath` (lockfiles moved to the caller so a lockfile classifies as `deps` here and stays inert there; `isInertPath` behaviour is unchanged).

`npx oxlint scripts/lens-routing.mjs scripts/lens-routing.test.mjs scripts/behavioral-surface.mjs scripts/council-review.mjs` — no warnings.

Both new assertions were mutation-tested to prove they can fail. Reverting the passthrough to `m.lens === "mutation" || allowed.has(m.lens)` gave `AssertionError: an unknown lens must pass through`; dropping `ci` from the maintainability kind set gave `AssertionError: ci must keep maintainability`. Restoring each returned the suite to 1 pass, 0 fail.

The council reviewed this PR and caught a real defect in it: the original body and README claimed a lockfile-only push would drop from 5 members to 3, but a lockfile-only delta is inert and never reaches routing at all. Verified by driving both gates directly:

```
package-lock.json      trivial=true   COUNCIL SKIPPED (trivial)
README.md              trivial=true   COUNCIL SKIPPED (trivial)
package.json           trivial=false  correctness, security, scope
scripts/a.test.mjs     trivial=false  correctness, maintainability, scope
src/a.css              trivial=false  performance, scope
src/a.ts               trivial=false  correctness, performance, security, maintainability, scope
```

The claim is corrected above and in the README.

Proof: n/a — no user-visible surface. This changes which members the engine dispatches; the evidence is the output above.

Assisted-by: cursor:composer-2.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file-type-based routing for source, documentation, tests, dependencies, CI, style, and agent-instruction changes.
  * Scope review remains included, with unsupported or unroutable lenses reported.
  * Empty or unparseable diffs fall back to the full review council.
  * Added an environment setting to disable lens routing when needed.

* **Documentation**
  * Documented routing for lockfile-only, docs-only, dependency-manifest-only, test-only, and style-only changes, along with routing overrides and dropped-lens reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->