### PR TITLE
[VCR-126] Preserve the carry on every return from main()

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "vibecodereview": "bin/vibecodereview.mjs"
   },
   "scripts": {
-    "test": "node scripts/review-delta.test.mjs && node scripts/council-cache.test.mjs && node scripts/vibetrace-emit.test.mjs && node scripts/lint-workflow.test.mjs && node scripts/release.test.mjs && node scripts/behavioral-surface.test.mjs && npm run selfcheck",
+    "test": "node scripts/review-delta.test.mjs && node scripts/council-cache.test.mjs && node scripts/vibetrace-emit.test.mjs && node scripts/lint-workflow.test.mjs && node scripts/release.test.mjs && node scripts/behavioral-surface.test.mjs && node scripts/council-carry.test.mjs && npm run selfcheck",
     "selfcheck": "node scripts/council-review.mjs --selfcheck && node scripts/chair-fallback.mjs --selfcheck",
     "mcp": "node mcp/server.mjs"
   },

--- a/scripts/council-carry.test.mjs
+++ b/scripts/council-carry.test.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Every early return from scripts/council-review.mjs must preserve the carry:
+// drive the engine with VCR_PRIOR_FINDINGS_FILE set and a diff that triggers
+// each return, then assert VCR_CARRY_FILE exists and still holds the prior
+// text. A return that forgets the carry write fails its case here.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const engine = path.join(path.dirname(fileURLToPath(import.meta.url)), "council-review.mjs");
+
+const PRIOR = "## unresolved\n\nKeep this finding.";
+const CODE_DIFF = "diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n+const x = 1;\n";
+const DOCS_DIFF = "diff --git a/README.md b/README.md\n--- a/README.md\n+++ b/README.md\n+details\n";
+
+// Drive the engine the way the workflow does: VCR_PRIOR_FINDINGS_FILE in,
+// VCR_CARRY_FILE out. The child gets a scrubbed environment — no provider
+// keys — so no case can reach the network and the no-keys return is honest.
+function runEngine(diff, extraEnv = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "council-carry-"));
+  const diffFile = path.join(dir, "pr.diff");
+  const outFile = path.join(dir, "council-findings.md");
+  const priorFile = path.join(dir, "council-carry.md");
+  const carryFile = path.join(dir, "council-carry.next.md");
+  fs.writeFileSync(diffFile, diff);
+  fs.writeFileSync(priorFile, PRIOR);
+  const result = spawnSync(process.execPath, [engine, diffFile, outFile], {
+    env: {
+      VCR_PRIOR_FINDINGS_FILE: priorFile,
+      VCR_CARRY_FILE: carryFile,
+      ...extraEnv,
+    },
+    encoding: "utf8",
+  });
+  return { result, carryFile };
+}
+
+function checkCarry(name, diff, extraEnv = {}) {
+  const { result, carryFile } = runEngine(diff, extraEnv);
+  assert.equal(result.status, 0, `${name}: engine exited ${result.status}: ${result.stderr}`);
+  assert.equal(fs.existsSync(carryFile), true, `${name}: VCR_CARRY_FILE was not written`);
+  const carry = fs.readFileSync(carryFile, "utf8");
+  assert.ok(carry.includes("Keep this finding"), `${name}: prior text lost from carry: ${JSON.stringify(carry)}`);
+  console.log(`ok    ${name}`);
+}
+
+// COUNCIL_MODELS parses to no valid members.
+checkCarry("no valid members preserves the carry", CODE_DIFF, { COUNCIL_MODELS: "bogus" });
+
+// Empty diff.
+checkCarry("empty diff preserves the carry", "");
+
+// Trivial delta with no behavioral surface.
+checkCarry("trivial delta preserves the carry", DOCS_DIFF);
+
+// Roster survives parsing, but the path filter leaves no applicable lens.
+checkCarry("no applicable lens preserves the carry", CODE_DIFF, {
+  COUNCIL_MODELS: "openai|gpt-x|G|correctness",
+  LENS_PATH_FILTER: JSON.stringify({ correctness: "." }),
+});
+
+// Applicable lenses exist, but no provider key (and no cache) can serve them.
+checkCarry("no provider keys preserves the carry", CODE_DIFF);
+
+console.log("\nall passing");

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -202,7 +202,21 @@ async function main() {
 
   const diffFile = process.argv[2];
   const outFile = process.argv[3] || "council-findings.md";
-  const write = (md) => fs.writeFileSync(outFile, md);
+
+  // Read before ANY return below: every path out of main() — including the
+  // config and empty-diff gates above the trivial-delta gate — must preserve
+  // the carried-forward findings, or a cycle that exits early rewrites the
+  // review-state comment with an empty carry and silently drops every
+  // unresolved finding from earlier cycles.
+  const priorFindings = process.env.VCR_PRIOR_FINDINGS_FILE && fs.existsSync(process.env.VCR_PRIOR_FINDINGS_FILE)
+    ? fs.readFileSync(process.env.VCR_PRIOR_FINDINGS_FILE, "utf8")
+    : "";
+  // The ONLY way to write the report. It preserves the carry alongside it, so
+  // a future early return that uses `write` cannot forget the carry file.
+  const write = (md, carry = priorFindings) => {
+    fs.writeFileSync(outFile, md);
+    if (process.env.VCR_CARRY_FILE) fs.writeFileSync(process.env.VCR_CARRY_FILE, carry);
+  };
 
   const models = parseModels();
   if (models.length === 0) {
@@ -230,13 +244,10 @@ async function main() {
     return;
   }
 
-  // Read before the trivial-delta gate below: every skip path from here on
-  // must still surface carried-forward findings, or a delta that goes trivial
-  // right after a cycle that left a real finding open silently drops it from
-  // the report instead of carrying it to the next cycle.
-  const priorFindings = process.env.VCR_PRIOR_FINDINGS_FILE && fs.existsSync(process.env.VCR_PRIOR_FINDINGS_FILE)
-    ? fs.readFileSync(process.env.VCR_PRIOR_FINDINGS_FILE, "utf8")
-    : "";
+  // Every skip path from here on surfaces carried-forward findings in the
+  // report (via `carriedFindings` below); the `write` helper preserves them in
+  // the carry file too, or a delta that goes trivial right after a cycle that
+  // left a real finding open silently drops it instead of carrying it on.
   const baseReportOptions = {
     reviewHeadSha: process.env.VCR_REVIEW_HEAD_SHA,
     memberDiffNote: process.env.VCR_MEMBER_DIFF_NOTE,
@@ -318,26 +329,23 @@ async function main() {
   );
 
   const report = buildFindingsMarkdown(results, reportOptions);
-  write(report);
-  if (process.env.VCR_CARRY_FILE) {
-    // Keep a flat list of every candidate from every cycle. The chair decides
-    // which entries are fixed; dropping an older entry here would hide an
-    // unresolved finding merely because the next delta did not repeat it.
-    const current = results.map((r) => `## ${r.model.name} — ${r.model.lens} lens\n\n${r.error ? `_${r.error}_` : r.text}`).join("\n\n");
-    let combined = [current, priorFindings].filter(Boolean).join("\n\n");
-    // The workflow base64-encodes this into a single hidden PR comment, which
-    // GitHub caps at 65536 characters. Newest content (this cycle's own
-    // findings, then the most recently carried ones) sits at the front of
-    // `combined`, so cutting the tail drops the oldest carried text first —
-    // without this cap, an unbounded carry file makes the state-comment write
-    // fail silently (it runs with continue-on-error) and the review boundary
-    // goes stale.
-    const CARRY_CHAR_BUDGET = 45_000;
-    if (combined.length > CARRY_CHAR_BUDGET) {
-      combined = combined.slice(0, CARRY_CHAR_BUDGET) + "\n\n_[older carried findings dropped to keep the review-state comment under GitHub's size limit]_";
-    }
-    fs.writeFileSync(process.env.VCR_CARRY_FILE, combined);
+  // Keep a flat list of every candidate from every cycle. The chair decides
+  // which entries are fixed; dropping an older entry here would hide an
+  // unresolved finding merely because the next delta did not repeat it.
+  const current = results.map((r) => `## ${r.model.name} — ${r.model.lens} lens\n\n${r.error ? `_${r.error}_` : r.text}`).join("\n\n");
+  let combined = [current, priorFindings].filter(Boolean).join("\n\n");
+  // The workflow base64-encodes this into a single hidden PR comment, which
+  // GitHub caps at 65536 characters. Newest content (this cycle's own
+  // findings, then the most recently carried ones) sits at the front of
+  // `combined`, so cutting the tail drops the oldest carried text first —
+  // without this cap, an unbounded carry file makes the state-comment write
+  // fail silently (it runs with continue-on-error) and the review boundary
+  // goes stale.
+  const CARRY_CHAR_BUDGET = 45_000;
+  if (combined.length > CARRY_CHAR_BUDGET) {
+    combined = combined.slice(0, CARRY_CHAR_BUDGET) + "\n\n_[older carried findings dropped to keep the review-state comment under GitHub's size limit]_";
   }
+  write(report, combined);
   console.log(`Wrote ${outFile}`);
 }
 


### PR DESCRIPTION
Closes #126

## What

`write()` in `scripts/council-review.mjs` now takes the carry alongside the markdown and defaults it to the prior findings, so every return from `main()` preserves carried-forward findings. There is no longer a way to write a report without writing the carry.

## Why

The carry file was written on the success path only. The workflow reads it with an empty string as its fallback (`action.yml:968-969`) and writes that value straight into the review-state comment, so **any** return that skipped the write rewrote the comment with an empty carry and silently discarded every unresolved finding from earlier cycles.

Two returns still did this: `models.length === 0` (`COUNCIL_MODELS` parsed to no valid members) and `!diff` (empty diff). Both are misconfiguration or terminal states rather than routine ones, which is why the trivial-delta fix in #123 did not cover them.

The structural fix was chosen over a guard per return, as the issue asked: a sixth early return cannot forget the carry, because writing a report and preserving the carry are now the same call.

`priorFindings` moved above the first return to make that possible. It was previously read after the config gates, which is why those two returns could not have preserved it even with a guard.

Out of scope, left as found and worth its own issue: the `main().catch` handler writes an error report without preserving the carry. That is an exception path, not a return.

## How I verified

`node scripts/council-review.mjs --selfcheck` — prints `selfcheck ok`.

`node --test scripts/*.test.mjs` — 21 tests, 21 pass, 0 fail.

New `scripts/council-carry.test.mjs` drives the real engine as a subprocess with a scrubbed env (no keys, so no network) and asserts `VCR_CARRY_FILE` exists and still contains the prior text, one case per early return. It is wired into `npm test`, which is what CI runs (`.github/workflows/lint.yml:37`) — that script hand-lists its files, so a new test file is invisible to CI until it is added there.

Mutation-tested: removing the carry write from the `write` helper gives

```
AssertionError: no valid members preserves the carry: VCR_CARRY_FILE was not written
ℹ pass 0
ℹ fail 1
```

Restoring it returns the suite to 1 pass, 0 fail.

Proof: n/a — no user-visible surface. The evidence is the test output above.

Assisted-by: muse:meta-muse-code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved prior review findings when processing exits early, including invalid configuration, empty changes, or missing credentials.
  * Ensured review reports and carry-forward files are consistently written across all processing paths.
  * Limited combined findings to prevent oversized carry-forward content.

* **Tests**
  * Added integration coverage for carry-forward behavior across multiple early-exit scenarios.
  * Included the new integration test in the standard test command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->