### PR TITLE
[VCR-124] Stop naming the lenses in the chair prompt

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -425,8 +425,8 @@ runs:
 
         LOOP GUARD: if "Can push fixes" is false, DO NOT push any commits — leave a review comment only. If a prior cycle already tried to fix an issue and it persists, stop fixing it and flag it for a human instead of pushing again.
 
-        Council members each reviewed this PR through one lens (correctness, performance,
-        security, maintainability) and wrote findings to `council-findings.md`. You are the
+        Council members each reviewed this PR through one lens and wrote findings to
+        `council-findings.md`, under a heading per member that names its lens. You are the
         synthesizer and the ONLY member who can push fixes.
 
         1. Read the diff. It is ALREADY on disk at `pr.diff` — `cat pr.diff`. Do not spend a

--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "name": "vibecodereview",
   "version": "0.1.1",
-  "publishConfig": {
-    "access": "public"
-  },
+  "publishConfig": { "access": "public" },
   "description": "LLM-council PR review: many models, diverse lenses, one self-healing GitHub check. Also reviews your local diff before you push.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "vibecodereview",
   "version": "0.1.1",
-  "publishConfig": { "access": "public" },
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "LLM-council PR review: many models, diverse lenses, one self-healing GitHub check. Also reviews your local diff before you push.",
   "type": "module",
   "bin": {
     "vibecodereview": "bin/vibecodereview.mjs"
   },
   "scripts": {
-    "test": "node scripts/review-delta.test.mjs && node scripts/council-cache.test.mjs && node scripts/vibetrace-emit.test.mjs && node scripts/lint-workflow.test.mjs && node scripts/release.test.mjs && node scripts/behavioral-surface.test.mjs && node scripts/council-carry.test.mjs && npm run selfcheck",
+    "test": "node scripts/review-delta.test.mjs && node scripts/council-cache.test.mjs && node scripts/vibetrace-emit.test.mjs && node scripts/lint-workflow.test.mjs && node scripts/release.test.mjs && node scripts/behavioral-surface.test.mjs && node scripts/council-carry.test.mjs && node scripts/chair-prompt.test.mjs && npm run selfcheck",
     "selfcheck": "node scripts/council-review.mjs --selfcheck && node scripts/chair-fallback.mjs --selfcheck",
     "mcp": "node mcp/server.mjs"
   },

--- a/scripts/chair-prompt.test.mjs
+++ b/scripts/chair-prompt.test.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+// The chair prompt must not carry a hand-typed lens inventory. The roster is
+// data (DEFAULT_MODELS), the findings file names each lens in its own heading,
+// and a third copy in the prompt prose drifts from both — which is exactly what
+// happened: it listed four lenses while five ran, omitting `scope`.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { DEFAULT_MODELS } from "./council-config.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const actionYml = readFileSync(`${here}/../action.yml`, "utf8");
+
+const OPEN = "<<'VCR_PROMPT_EOF'\n";
+const openAt = actionYml.indexOf(OPEN);
+assert.notEqual(openAt, -1, "chair prompt heredoc opener not found in action.yml");
+
+// Search for the terminator AFTER the opening delimiter ends, not after its
+// first character: the opener contains the marker itself, so starting at
+// openAt + 1 finds that same marker and yields an EMPTY prompt — a guard that
+// silently scans nothing and can never fail.
+const bodyAt = openAt + OPEN.length;
+const closeAt = actionYml.indexOf("VCR_PROMPT_EOF", bodyAt);
+assert.notEqual(closeAt, -1, "chair prompt heredoc terminator not found");
+
+const prompt = actionYml.slice(bodyAt, closeAt);
+assert.ok(prompt.length > 1000, `extracted prompt implausibly short (${prompt.length} chars) — the slice is wrong, not the prompt`);
+
+const lenses = [...new Set(DEFAULT_MODELS.map((m) => m.lens))];
+assert.ok(lenses.length >= 2, "roster must have at least two lenses for this guard to mean anything");
+
+// Two or more distinct roster lens names inside one parenthesis is an inventory.
+const alternation = lenses.join("|");
+const offenders = [];
+for (const [, inner] of prompt.matchAll(/\(([^()]*)\)/g)) {
+  const hits = new Set((inner.match(new RegExp(`\\b(?:${alternation})\\b`, "gi")) || []).map((w) => w.toLowerCase()));
+  if (hits.size >= 2) offenders.push(inner.replace(/\s+/g, " ").trim());
+}
+// ...as is a bare comma/and/or list of them outside parentheses.
+for (const [match] of prompt.matchAll(new RegExp(`\\b(?:${alternation})\\b(?:\\s*(?:,|and|or)\\s*\\b(?:${alternation})\\b)+`, "gi"))) {
+  offenders.push(match.replace(/\s+/g, " ").trim());
+}
+
+assert.deepEqual(
+  offenders,
+  [],
+  `chair prompt names lenses inline; the roster is ${lenses.join(", ")} and the findings file already ` +
+    `heads each section with its lens. Drop the list rather than syncing it. Found: ${offenders.join(" | ")}`,
+);
+
+console.log("chair prompt tests passed");

--- a/scripts/chair-prompt.test.mjs
+++ b/scripts/chair-prompt.test.mjs
@@ -38,8 +38,13 @@ for (const [, inner] of prompt.matchAll(/\(([^()]*)\)/g)) {
   const hits = new Set((inner.match(new RegExp(`\\b(?:${alternation})\\b`, "gi")) || []).map((w) => w.toLowerCase()));
   if (hits.size >= 2) offenders.push(inner.replace(/\s+/g, " ").trim());
 }
-// ...as is a bare comma/and/or list of them outside parentheses.
-for (const [match] of prompt.matchAll(new RegExp(`\\b(?:${alternation})\\b(?:\\s*(?:,|and|or)\\s*\\b(?:${alternation})\\b)+`, "gi"))) {
+// ...as is a bare list of them outside parentheses, whatever the separator —
+// comma, "and"/"or", slash, semicolon, pipe, dash, bullet, or a line break
+// before the next bullet. The failure this guards against (VCR-124) was a
+// hand-typed inventory read as prose; the separator between the words is
+// incidental to that, so the guard must not depend on which one was used.
+const SEPARATOR = String.raw`(?:\s*(?:,|and|or|\/|;|\||-|–|—|•|\*)\s*)`;
+for (const [match] of prompt.matchAll(new RegExp(`\\b(?:${alternation})\\b(?:${SEPARATOR}\\b(?:${alternation})\\b)+`, "gi"))) {
   offenders.push(match.replace(/\s+/g, " ").trim());
 }
 

--- a/scripts/chair-prompt.test.mjs
+++ b/scripts/chair-prompt.test.mjs
@@ -31,28 +31,30 @@ assert.ok(prompt.length > 1000, `extracted prompt implausibly short (${prompt.le
 const lenses = [...new Set(DEFAULT_MODELS.map((m) => m.lens))];
 assert.ok(lenses.length >= 2, "roster must have at least two lenses for this guard to mean anything");
 
-// Two or more distinct roster lens names inside one parenthesis is an inventory.
+// An inventory is TWO OR MORE DISTINCT roster lens names anywhere in the prompt.
+//
+// Earlier versions of this guard enumerated the separator between them — first
+// `,`/and/or, then `/ ; | - – — • *`. Each widening was prompted by a reviewer
+// naming one more separator that slipped through, and `&` slipped through the
+// second one. Enumerating separators is unwinnable: the defect is the writer
+// re-typing the roster, and the punctuation between the words is incidental to
+// it. Counting distinct names has no separator to miss, and no formatting
+// (parentheses, a bullet list, a table row, prose) to special-case.
+//
+// One name is allowed, so the prompt can still refer to a single lens if it
+// ever needs to. Two is the point at which prose becomes a list.
 const alternation = lenses.join("|");
-const offenders = [];
-for (const [, inner] of prompt.matchAll(/\(([^()]*)\)/g)) {
-  const hits = new Set((inner.match(new RegExp(`\\b(?:${alternation})\\b`, "gi")) || []).map((w) => w.toLowerCase()));
-  if (hits.size >= 2) offenders.push(inner.replace(/\s+/g, " ").trim());
-}
-// ...as is a bare list of them outside parentheses, whatever the separator —
-// comma, "and"/"or", slash, semicolon, pipe, dash, bullet, or a line break
-// before the next bullet. The failure this guards against (VCR-124) was a
-// hand-typed inventory read as prose; the separator between the words is
-// incidental to that, so the guard must not depend on which one was used.
-const SEPARATOR = String.raw`(?:\s*(?:,|and|or|\/|;|\||-|–|—|•|\*)\s*)`;
-for (const [match] of prompt.matchAll(new RegExp(`\\b(?:${alternation})\\b(?:${SEPARATOR}\\b(?:${alternation})\\b)+`, "gi"))) {
-  offenders.push(match.replace(/\s+/g, " ").trim());
-}
+const named = [
+  ...new Set(
+    (prompt.match(new RegExp(`\\b(?:${alternation})\\b`, "gi")) || []).map((w) => w.toLowerCase()),
+  ),
+];
 
-assert.deepEqual(
-  offenders,
-  [],
-  `chair prompt names lenses inline; the roster is ${lenses.join(", ")} and the findings file already ` +
-    `heads each section with its lens. Drop the list rather than syncing it. Found: ${offenders.join(" | ")}`,
+assert.ok(
+  named.length < 2,
+  `chair prompt names ${named.length} lenses (${named.join(", ")}); the roster is ` +
+    `${lenses.join(", ")} and the findings file already heads each section with its lens. ` +
+    `Drop the list rather than syncing it — syncing postpones the drift instead of removing it.`,
 );
 
 console.log("chair prompt tests passed");


### PR DESCRIPTION
Closes #124

## What

The chair prompt no longer lists lens names. It points at the per-member headings in `council-findings.md`, which already name each lens.

## Why

`action.yml` told the chair that members reviewed through one lens of "correctness, performance, security, maintainability". Five lenses run — `scope` was missing, and `council-review.mjs --selfcheck` actively fails if `DEFAULT_MODELS` loses it. So the prompt and the roster contradicted each other, and the prompt is the chair's only description of what it is about to read.

The list is **dropped rather than corrected**. The roster is data in `DEFAULT_MODELS`, the findings file heads every section with its lens, and a third copy in prose can only drift from the other two. Syncing it would postpone the drift, not remove it — so the guard rejects the five-lens version as well.

Same defect class as the hand-listed test files in `package.json` (#84): an inventory maintained by memory, next to the data it claims to describe.

## How I verified

`npm test` — passes, exit 0. The guard is wired into that script, which is what CI runs (`.github/workflows/lint.yml:37`).

`node scripts/council-review.mjs --selfcheck` — `selfcheck ok`. `npx oxlint scripts/chair-prompt.test.mjs` — no warnings.

Mutation-tested three ways, restoring after each:

1. Re-add the original four-lens list → `chair prompt names lenses inline`, 1 fail.
2. Add the **five**-lens list, i.e. the "just sync it" fix → 1 fail. Syncing does not satisfy the guard.
3. Break the guard's own heredoc slice to start the terminator search at `openAt + 1` instead of after the opening delimiter → `AssertionError: extracted prompt implausibly short (0 chars) — the slice is wrong, not the prompt`.

Mutation 3 is the reason the guard asserts on prompt length. The opening delimiter `<<'VCR_PROMPT_EOF'` contains the marker, so searching from `openAt + 1` finds that same marker, slices an empty string, and yields a guard that scans nothing and can never fail. A first draft of this test had exactly that bug and passed against a prompt that still carried the inventory.

Proof: n/a — prompt text and a test. The evidence is the mutation output above.

Assisted-by: claude-personal:claude-opus-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated council findings guidance to organize results under headings for each member’s lens.

- **Tests**
  - Added validation to ensure the chair prompt uses member-specific headings without listing a fixed set of lenses inline.
  - Included the new prompt validation in the npm test sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->