### PR TITLE
[VCR-128] Record what the council found, not its cost

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -280,7 +280,7 @@ runs:
         # The commit-trailer hook from "Configure git" needs no entry here:
         # it lives under .git/vcr-hooks, outside the working tree `git add -A`
         # walks.
-        printf '%s\n' /pr.diff /pr-delta.diff /council-findings.md /council-carry.md /council-carry.next.md /review-state.md /council.log /council.pid \
+        printf '%s\n' /pr.diff /pr-delta.diff /council-findings.md /council-carry.md /council-carry.next.md /review-state.md /council.log /council.pid /chair-verdicts.json \
           /probe.1 /probe.2 /probe.3 /reason.1 /reason.2 /reason.3 \
           >> "$(git rev-parse --git-dir)/info/exclude"
 
@@ -496,6 +496,13 @@ runs:
            `<details><summary>🧑‍⚖️ Council</summary>` then a Markdown table of
            `| Model | Lens | Result |` (confirmed / rejected / no findings), then `</details>`.
            If council was skipped, write "Council: skipped".
+        8. Write `chair-verdicts.json` beside `council-findings.md`. Read the
+           `<!-- vibetrace:findings-meta -->` block at the end of
+           `council-findings.md` for each finding's `id` and `classKey`. Emit
+           one disposition per finding: `confirmed-fixed`, `confirmed-open`,
+           `rejected`, or `unmentioned`. Schema:
+           `{"verdict":"approve"|"request-changes"|"comment","dispositions":[{"id","classKey","disposition"}]}`
+           Match your `gh pr review` verdict to `verdict`.
         VCR_PROMPT_EOF
         # The heredoc is quoted so the prompt stays literal (it contains
         # backticks and $ that must not be expanded). Fill the run's values in
@@ -685,8 +692,11 @@ runs:
         if [ "${{ steps.council_await.outcome }}" = "cancelled" ]; then
           CANCELLED=1
         fi
+        DIFF_FILE=pr-delta.diff
+        [ -f "$DIFF_FILE" ] || DIFF_FILE=pr.diff
         node "${{ github.action_path }}/scripts/vibetrace-emit.mjs" review.council \
-          --mode "$MODE" --cache-hit "$CACHE_HIT" --members "$MEMBERS" --cancelled "$CANCELLED"
+          --mode "$MODE" --cache-hit "$CACHE_HIT" --members "$MEMBERS" --cancelled "$CANCELLED" \
+          --findings council-findings.md --diff "$DIFF_FILE"
 
     # Failover chain: each attempt runs the SAME prompt (built once above) with
     # a different subscription. Every attempt costs ~10s of setup even when the
@@ -935,6 +945,22 @@ runs:
         echo "Most often: the pull request edits .github/workflows/vibecodereview.yml, and"
         echo "claude-code-action refuses to run when the workflow differs from the default branch."
         exit 1
+
+    # Observability only. Silent-fail inside the script. Never gates the review.
+    - name: Emit vibetrace review.chair
+      if: always() && steps.budget.outputs.over != 'true'
+      continue-on-error: true
+      shell: bash
+      env:
+        VIBETRACE_INGEST_URL: ${{ inputs.vibetrace_ingest_url }}
+        VIBETRACE_INGEST_TOKEN: ${{ inputs.vibetrace_ingest_token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        VCR_PR: ${{ github.event.pull_request.number }}
+        GITHUB_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        VCR_PR_BODY: ${{ github.event.pull_request.body }}
+      run: |
+        node "${{ github.action_path }}/scripts/vibetrace-emit.mjs" review.chair \
+          --verdicts chair-verdicts.json
 
     # Persist the review boundary and the findings that still need a chair's
     # verification. Updating one hidden comment avoids adding visible noise to

--- a/action.yml
+++ b/action.yml
@@ -686,7 +686,8 @@ runs:
           CANCELLED=1
         fi
         node "${{ github.action_path }}/scripts/vibetrace-emit.mjs" review.council \
-          --mode "$MODE" --cache-hit "$CACHE_HIT" --members "$MEMBERS" --cancelled "$CANCELLED"
+          --mode "$MODE" --cache-hit "$CACHE_HIT" --members "$MEMBERS" --cancelled "$CANCELLED" \
+          --findings council-findings.md --diff pr-delta.diff
 
     # Failover chain: each attempt runs the SAME prompt (built once above) with
     # a different subscription. Every attempt costs ~10s of setup even when the

--- a/action.yml
+++ b/action.yml
@@ -280,7 +280,7 @@ runs:
         # The commit-trailer hook from "Configure git" needs no entry here:
         # it lives under .git/vcr-hooks, outside the working tree `git add -A`
         # walks.
-        printf '%s\n' /pr.diff /pr-delta.diff /council-findings.md /council-carry.md /council-carry.next.md /review-state.md /council.log /council.pid /chair-verdicts.json \
+        printf '%s\n' /pr.diff /pr-delta.diff /council-findings.md /council-carry.md /council-carry.next.md /review-state.md /council.log /council.pid \
           /probe.1 /probe.2 /probe.3 /reason.1 /reason.2 /reason.3 \
           >> "$(git rev-parse --git-dir)/info/exclude"
 
@@ -496,13 +496,6 @@ runs:
            `<details><summary>🧑‍⚖️ Council</summary>` then a Markdown table of
            `| Model | Lens | Result |` (confirmed / rejected / no findings), then `</details>`.
            If council was skipped, write "Council: skipped".
-        8. Write `chair-verdicts.json` beside `council-findings.md`. Read the
-           `<!-- vibetrace:findings-meta -->` block at the end of
-           `council-findings.md` for each finding's `id` and `classKey`. Emit
-           one disposition per finding: `confirmed-fixed`, `confirmed-open`,
-           `rejected`, or `unmentioned`. Schema:
-           `{"verdict":"approve"|"request-changes"|"comment","dispositions":[{"id","classKey","disposition"}]}`
-           Match your `gh pr review` verdict to `verdict`.
         VCR_PROMPT_EOF
         # The heredoc is quoted so the prompt stays literal (it contains
         # backticks and $ that must not be expanded). Fill the run's values in
@@ -692,11 +685,8 @@ runs:
         if [ "${{ steps.council_await.outcome }}" = "cancelled" ]; then
           CANCELLED=1
         fi
-        DIFF_FILE=pr-delta.diff
-        [ -f "$DIFF_FILE" ] || DIFF_FILE=pr.diff
         node "${{ github.action_path }}/scripts/vibetrace-emit.mjs" review.council \
-          --mode "$MODE" --cache-hit "$CACHE_HIT" --members "$MEMBERS" --cancelled "$CANCELLED" \
-          --findings council-findings.md --diff "$DIFF_FILE"
+          --mode "$MODE" --cache-hit "$CACHE_HIT" --members "$MEMBERS" --cancelled "$CANCELLED"
 
     # Failover chain: each attempt runs the SAME prompt (built once above) with
     # a different subscription. Every attempt costs ~10s of setup even when the
@@ -945,22 +935,6 @@ runs:
         echo "Most often: the pull request edits .github/workflows/vibecodereview.yml, and"
         echo "claude-code-action refuses to run when the workflow differs from the default branch."
         exit 1
-
-    # Observability only. Silent-fail inside the script. Never gates the review.
-    - name: Emit vibetrace review.chair
-      if: always() && steps.budget.outputs.over != 'true'
-      continue-on-error: true
-      shell: bash
-      env:
-        VIBETRACE_INGEST_URL: ${{ inputs.vibetrace_ingest_url }}
-        VIBETRACE_INGEST_TOKEN: ${{ inputs.vibetrace_ingest_token }}
-        GITHUB_REPOSITORY: ${{ github.repository }}
-        VCR_PR: ${{ github.event.pull_request.number }}
-        GITHUB_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        VCR_PR_BODY: ${{ github.event.pull_request.body }}
-      run: |
-        node "${{ github.action_path }}/scripts/vibetrace-emit.mjs" review.chair \
-          --verdicts chair-verdicts.json
 
     # Persist the review boundary and the findings that still need a chair's
     # verification. Updating one hidden comment avoids adding visible noise to

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "vibecodereview": "bin/vibecodereview.mjs"
   },
   "scripts": {
-    "test": "node scripts/review-delta.test.mjs && node scripts/council-cache.test.mjs && node scripts/vibetrace-emit.test.mjs && node scripts/lint-workflow.test.mjs && node scripts/release.test.mjs && node scripts/behavioral-surface.test.mjs && node scripts/council-carry.test.mjs && node scripts/chair-prompt.test.mjs && node scripts/vibetrace-records.test.mjs && npm run selfcheck",
+    "test": "node scripts/review-delta.test.mjs && node scripts/council-cache.test.mjs && node scripts/vibetrace-emit.test.mjs && node scripts/lint-workflow.test.mjs && node scripts/release.test.mjs && node scripts/behavioral-surface.test.mjs && node scripts/council-carry.test.mjs && node scripts/vibetrace-records.test.mjs && npm run selfcheck",
     "selfcheck": "node scripts/council-review.mjs --selfcheck && node scripts/chair-fallback.mjs --selfcheck",
     "mcp": "node mcp/server.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "vibecodereview",
   "version": "0.1.1",
-  "publishConfig": { "access": "public" },
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "LLM-council PR review: many models, diverse lenses, one self-healing GitHub check. Also reviews your local diff before you push.",
   "type": "module",
   "bin": {
     "vibecodereview": "bin/vibecodereview.mjs"
   },
   "scripts": {
-    "test": "node scripts/review-delta.test.mjs && node scripts/council-cache.test.mjs && node scripts/vibetrace-emit.test.mjs && node scripts/lint-workflow.test.mjs && node scripts/release.test.mjs && node scripts/behavioral-surface.test.mjs && node scripts/council-carry.test.mjs && node scripts/chair-prompt.test.mjs && npm run selfcheck",
+    "test": "node scripts/review-delta.test.mjs && node scripts/council-cache.test.mjs && node scripts/vibetrace-emit.test.mjs && node scripts/lint-workflow.test.mjs && node scripts/release.test.mjs && node scripts/behavioral-surface.test.mjs && node scripts/council-carry.test.mjs && node scripts/chair-prompt.test.mjs && node scripts/vibetrace-records.test.mjs && npm run selfcheck",
     "selfcheck": "node scripts/council-review.mjs --selfcheck && node scripts/chair-fallback.mjs --selfcheck",
     "mcp": "node mcp/server.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "vibecodereview": "bin/vibecodereview.mjs"
   },
   "scripts": {
-    "test": "node scripts/review-delta.test.mjs && node scripts/council-cache.test.mjs && node scripts/vibetrace-emit.test.mjs && node scripts/lint-workflow.test.mjs && node scripts/release.test.mjs && node scripts/behavioral-surface.test.mjs && node scripts/council-carry.test.mjs && node scripts/vibetrace-records.test.mjs && npm run selfcheck",
+    "test": "node scripts/review-delta.test.mjs && node scripts/council-cache.test.mjs && node scripts/vibetrace-emit.test.mjs && node scripts/lint-workflow.test.mjs && node scripts/release.test.mjs && node scripts/behavioral-surface.test.mjs && node scripts/council-carry.test.mjs && node scripts/chair-prompt.test.mjs && node scripts/vibetrace-records.test.mjs && npm run selfcheck",
     "selfcheck": "node scripts/council-review.mjs --selfcheck && node scripts/chair-fallback.mjs --selfcheck",
     "mcp": "node mcp/server.mjs"
   },

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -51,6 +51,7 @@ import {
 import { cacheKey, loadCouncilResults, saveCouncilResult } from "./council-cache.mjs";
 import { behavioralSurface } from "./behavioral-surface.mjs";
 import { filterMembersByKindRouting, lensesForKinds, routeLenses } from "./lens-routing.mjs";
+import { appendFindingsMeta } from "./file-findings.mjs";
 
 async function main() {
   if (process.argv.includes("--selfcheck")) {
@@ -211,10 +212,11 @@ async function main() {
   const priorFindings = process.env.VCR_PRIOR_FINDINGS_FILE && fs.existsSync(process.env.VCR_PRIOR_FINDINGS_FILE)
     ? fs.readFileSync(process.env.VCR_PRIOR_FINDINGS_FILE, "utf8")
     : "";
-  // The ONLY way to write the report. It preserves the carry alongside it, so
-  // a future early return that uses `write` cannot forget the carry file.
+  // The ONLY way to write the report. It appends the findings metadata the
+  // trace records read, and preserves the carry alongside the report, so a
+  // future early return that uses `write` can forget neither.
   const write = (md, carry = priorFindings) => {
-    fs.writeFileSync(outFile, md);
+    fs.writeFileSync(outFile, appendFindingsMeta(md));
     if (process.env.VCR_CARRY_FILE) fs.writeFileSync(process.env.VCR_CARRY_FILE, carry);
   };
 
@@ -355,7 +357,7 @@ main().catch((err) => {
   try {
     fs.writeFileSync(
       process.argv[3] || "council-findings.md",
-      `# 🧑‍⚖️ LLM Council findings\n\n_Council errored: ${String(err?.message || err)}_\n`,
+      appendFindingsMeta(`# 🧑‍⚖️ LLM Council findings\n\n_Council errored: ${String(err?.message || err)}_\n`),
     );
   } catch {}
   process.exit(0);

--- a/scripts/file-findings.mjs
+++ b/scripts/file-findings.mjs
@@ -35,6 +35,24 @@ export function fingerprint(location, text) {
   return crypto.createHash('sha256').update(normal).digest('hex').slice(0, 16);
 }
 
+// First clause before the arrow — shared by buildTitle and classKey so jscpd
+// does not flag a second cut.
+export function stemText(text) {
+  return String(text || '').split(/->|—|\.\s|;/)[0].trim().replace(/[.,:;]$/, '');
+}
+
+// Lens token from a model heading, e.g. "GPT — correctness lens" -> "correctness".
+export function extractLensFamily(heading) {
+  const match = /—\s*(\w+)\s*lens/i.exec(String(heading || ''));
+  return match ? match[1].toLowerCase() : String(heading || '').toLowerCase();
+}
+
+export function buildClassKey(lensFamily, path, text) {
+  const stem = stemText(text).toLowerCase().replace(/\s+/g, ' ').trim();
+  const normal = `${lensFamily}|${path}|${stem}`;
+  return crypto.createHash('sha256').update(normal).digest('hex');
+}
+
 export function parseFindings(markdown) {
   const findings = [];
   let lens = null;
@@ -54,9 +72,34 @@ export function parseFindings(markdown) {
     // The council is asked to name a concrete trigger. A line without one is
     // not a finding, and `path:line` is the shape that carries it.
     if (!/:\d+/.test(location) && !location.includes('/')) continue;
-    findings.push({ location, text, lens, id: fingerprint(location, text) });
+    const path = location.split(':')[0];
+    const lensFamily = extractLensFamily(lens);
+    findings.push({
+      location,
+      text,
+      lens,
+      lensFamily,
+      path,
+      id: fingerprint(location, text),
+      classKey: buildClassKey(lensFamily, path, text),
+    });
   }
   return findings;
+}
+
+/** Machine-readable finding keys for the chair verdict file. */
+export function findingsMetaBlock(findings) {
+  const payload = findings.map((f) => ({
+    id: f.id,
+    classKey: f.classKey,
+    path: f.path,
+    lens: f.lensFamily,
+  }));
+  return `\n<!-- vibetrace:findings-meta\n${JSON.stringify(payload)}\n-->\n`;
+}
+
+export function appendFindingsMeta(markdown) {
+  return `${String(markdown || '').trimEnd()}${findingsMetaBlock(parseFindings(markdown))}`;
 }
 
 // The council says this in so many words when it has nothing.
@@ -91,7 +134,7 @@ export function alreadyFiled(repo, id) {
 // leaves a title severed mid-phrase, so drop whole words until it fits and fall
 // back to the file name when the clause carries nothing usable.
 export function buildTitle(finding, path) {
-  const clause = finding.text.split(/->|—|\.\s|;/)[0].trim().replace(/[.,:;]$/, '');
+  const clause = stemText(finding.text);
   const file = String(path || '').split('/').pop() || 'the reported defect';
   let subject = clause.charAt(0).toLowerCase() + clause.slice(1);
   while (subject.length > 46 && subject.includes(' ')) {

--- a/scripts/file-findings.test.mjs
+++ b/scripts/file-findings.test.mjs
@@ -2,11 +2,12 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
-  buildTitle,
   buildIssue,
+  extractLensFamily,
   fingerprint,
   isEmptyReview,
   parseFindings,
+  stemText,
 } from './file-findings.mjs';
 
 const REVIEW = `# 🧑‍⚖️ LLM Council findings
@@ -135,4 +136,44 @@ test('a finding with no usable clause still gets a title', () => {
   const { title } = buildIssue(finding, { repo: 'pooriaarab/x', prNumber: 1 });
   assert.ok(title.length >= 10, title);
   assert.match(title, /thing\.ts/);
+});
+
+test('findings differing only by line number share a classKey', () => {
+  const a = parseFindings('## GPT — correctness lens\n\n- `src/x.ts:10` — leak on error path -> handle it.\n');
+  const b = parseFindings('## GPT — correctness lens\n\n- `src/x.ts:99` — leak on error path -> handle it.\n');
+  assert.equal(a[0].classKey, b[0].classKey);
+  assert.notEqual(a[0].id, b[0].id);
+});
+
+test('findings differing only by model name share a classKey', () => {
+  const a = parseFindings('## GPT-5.6 — security lens\n\n- `src/auth.ts:1` — token not validated -> validate.\n');
+  const b = parseFindings('## Kimi K3 — security lens\n\n- `src/auth.ts:1` — token not validated -> validate.\n');
+  assert.equal(a[0].classKey, b[0].classKey);
+  assert.equal(a[0].lensFamily, 'security');
+  assert.equal(b[0].lensFamily, 'security');
+});
+
+test('genuinely different defects do not share a classKey', () => {
+  const a = parseFindings('## M — security lens\n\n- `src/a.ts:1` — missing auth check -> add guard.\n');
+  const b = parseFindings('## M — security lens\n\n- `src/a.ts:1` — sql injection in query -> parameterize.\n');
+  assert.notEqual(a[0].classKey, b[0].classKey);
+});
+
+test('stemText matches buildTitle first-clause cut', () => {
+  const text = 'prepareCreditCharge runs twice -> skip when header present.';
+  assert.equal(stemText(text), 'prepareCreditCharge runs twice');
+  const [finding] = parseFindings(`## M — lens\n\n- \`src/x.ts:1\` — ${text}\n`);
+  const { title } = buildIssue(finding, { repo: 'pooriaarab/x', prNumber: 1 });
+  assert.match(title.toLowerCase(), /preparecreditcharge runs twice/);
+});
+
+test('parseFindings path drops the line suffix for classKey', () => {
+  const a = parseFindings('## M — security lens\n\n- `src/auth.ts:9` — bad token handling -> fix.\n');
+  const b = parseFindings('## M — security lens\n\n- `src/auth.ts:42` — bad token handling -> fix.\n');
+  assert.equal(a[0].path, 'src/auth.ts');
+  assert.equal(a[0].classKey, b[0].classKey);
+});
+
+test('extractLensFamily ignores cached suffix on heading', () => {
+  assert.equal(extractLensFamily('GPT — correctness lens (cached)'), 'correctness');
 });

--- a/scripts/review-delta.mjs
+++ b/scripts/review-delta.mjs
@@ -21,6 +21,16 @@ function patternsForLens(pathFilter, lens) {
   return Array.isArray(patterns) ? patterns.filter((pattern) => typeof pattern === "string") : [];
 }
 
+/** Count `+` lines in a unified diff (denominator for finding recurrence). */
+export function countAddedLines(diff) {
+  let count = 0;
+  for (const line of String(diff || "").split("\n")) {
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    if (line.startsWith("+")) count += 1;
+  }
+  return count;
+}
+
 export function diffPaths(diff) {
   const paths = [];
   for (const line of String(diff || "").split("\n")) {

--- a/scripts/review-delta.mjs
+++ b/scripts/review-delta.mjs
@@ -21,11 +21,17 @@ function patternsForLens(pathFilter, lens) {
   return Array.isArray(patterns) ? patterns.filter((pattern) => typeof pattern === "string") : [];
 }
 
+// A real header is always "+++ b/path" or "--- a/path" (space-separated,
+// a/ b/ or /dev/null). An added content line like `++counter;` renders as
+// `+++counter;` with no space, so a bare `startsWith("+++")` would wrongly
+// treat it as a header and undercount.
+const DIFF_HEADER = /^(?:--- (?:a\/|\/dev\/null)|\+\+\+ (?:b\/|\/dev\/null))/;
+
 /** Count `+` lines in a unified diff (denominator for finding recurrence). */
 export function countAddedLines(diff) {
   let count = 0;
   for (const line of String(diff || "").split("\n")) {
-    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    if (DIFF_HEADER.test(line)) continue;
     if (line.startsWith("+")) count += 1;
   }
   return count;

--- a/scripts/review-delta.test.mjs
+++ b/scripts/review-delta.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   REVIEW_STATE_MARKER,
   buildReviewState,
+  countAddedLines,
   diffPaths,
   lensCanReviewDiff,
   parseReviewState,
@@ -59,5 +60,13 @@ assert.deepEqual(parseReviewState(wrappedState), {
 });
 assert.equal(parseReviewState(state.replace("carry:", "broken:")), null);
 assert.equal(parseReviewState("not a state comment"), null);
+
+assert.equal(countAddedLines(sourceDiff), 1);
+// A real added line whose content itself starts with `++` renders as
+// `+++counter;` (no space), which must still count as content, not be
+// mistaken for a `+++ b/path` file header.
+const plusPlusDiff = "diff --git a/src/x.ts b/src/x.ts\n--- a/src/x.ts\n+++ b/src/x.ts\n+++counter;\n+return true;\n";
+assert.equal(countAddedLines(plusPlusDiff), 2);
+assert.equal(countAddedLines(""), 0);
 
 console.log("review delta tests passed");

--- a/scripts/vibetrace-emit.mjs
+++ b/scripts/vibetrace-emit.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 // Silent-fail vibetrace emitter for council runs. Matches @vibetrace/schema
-// review.council shape. Never throws; never blocks the review check.
+// review.council and review.chair shapes. Never throws; never blocks the review check.
 //
 // Usage:
 //   node vibetrace-emit.mjs review.council \
-//     --mode delta|full --cache-hit 0|1 --members N --cancelled 0|1
+//     --mode delta|full --cache-hit 0|1 --members N --cancelled 0|1 \
+//     [--findings council-findings.md] [--diff pr-delta.diff]
+//   node vibetrace-emit.mjs review.chair [--verdicts chair-verdicts.json]
 //
 // Env (all optional): VIBETRACE_INGEST_URL, VIBETRACE_INGEST_TOKEN, VIBETRACE_FILE,
 // GITHUB_REPOSITORY, VCR_PR / GITHUB_PR_NUMBER, GITHUB_HEAD_REF,
@@ -12,13 +14,21 @@
 
 import fs from "node:fs";
 import path from "node:path";
-
-const SCHEMA_VERSION = "0.1.0";
+import { buildChairRecord, buildCouncilRecord } from "./vibetrace-records.mjs";
 
 function arg(name, fallback = undefined) {
   const i = process.argv.indexOf(name);
   if (i === -1 || i + 1 >= process.argv.length) return fallback;
   return process.argv[i + 1];
+}
+
+function readOptional(file) {
+  if (!file || !fs.existsSync(file)) return "";
+  try {
+    return fs.readFileSync(file, "utf8");
+  } catch {
+    return "";
+  }
 }
 
 function parseIssueFromBranch(branch) {
@@ -60,30 +70,30 @@ function attribution() {
   return out;
 }
 
-function buildCouncilRecord() {
-  const mode = arg("--mode", "full");
-  if (mode !== "full" && mode !== "delta") {
-    return { ok: false, reason: "mode must be full or delta" };
-  }
-  const cacheHit = arg("--cache-hit", "0") === "1";
-  const cancelled = arg("--cancelled", "0") === "1";
-  const memberCount = Number(arg("--members", "0"));
-  if (!Number.isInteger(memberCount) || memberCount < 0) {
-    return { ok: false, reason: "members must be a non-negative integer" };
-  }
-  return {
-    ok: true,
-    record: {
-      schemaVersion: SCHEMA_VERSION,
-      ts: new Date().toISOString(),
-      type: "review.council",
+function buildRecord(kind) {
+  const attr = attribution();
+  if (kind === "review.council") {
+    const mode = arg("--mode", "full");
+    const cacheHit = arg("--cache-hit", "0") === "1";
+    const cancelled = arg("--cancelled", "0") === "1";
+    const memberCount = Number(arg("--members", "0"));
+    return buildCouncilRecord({
       mode,
       cacheHit,
       memberCount,
       cancelled,
-      attribution: attribution(),
-    },
-  };
+      attribution: attr,
+      findingsMarkdown: readOptional(arg("--findings")),
+      diffMarkdown: readOptional(arg("--diff")),
+    });
+  }
+  if (kind === "review.chair") {
+    return buildChairRecord({
+      verdictsPath: arg("--verdicts", "chair-verdicts.json"),
+      attribution: attr,
+    });
+  }
+  return { ok: false, reason: `unsupported type; only review.council and review.chair` };
 }
 
 async function emit(record) {
@@ -129,18 +139,18 @@ async function emit(record) {
 async function main() {
   try {
     const kind = process.argv[2];
-    if (kind !== "review.council") {
-      console.error("vibetrace-emit: unsupported type; only review.council");
+    if (!kind) {
+      console.error("vibetrace-emit: missing record type");
       process.exit(0);
     }
-    const built = buildCouncilRecord();
+    const built = buildRecord(kind);
     if (!built.ok) {
       console.error(`vibetrace-emit: ${built.reason}`);
       process.exit(0);
     }
     const where = await emit(built.record);
     if (where) {
-      console.log(`vibetrace-emit: wrote review.council -> ${where}`);
+      console.log(`vibetrace-emit: wrote ${kind} -> ${where}`);
     }
   } catch (err) {
     // Fetch failures are sanitized inside emit(), so anything reaching here

--- a/scripts/vibetrace-emit.mjs
+++ b/scripts/vibetrace-emit.mjs
@@ -1,12 +1,11 @@
 #!/usr/bin/env node
 // Silent-fail vibetrace emitter for council runs. Matches @vibetrace/schema
-// review.council and review.chair shapes. Never throws; never blocks the review check.
+// the review.council shape. Never throws; never blocks the review check.
 //
 // Usage:
 //   node vibetrace-emit.mjs review.council \
 //     --mode delta|full --cache-hit 0|1 --members N --cancelled 0|1 \
 //     [--findings council-findings.md] [--diff pr-delta.diff]
-//   node vibetrace-emit.mjs review.chair [--verdicts chair-verdicts.json]
 //
 // Env (all optional): VIBETRACE_INGEST_URL, VIBETRACE_INGEST_TOKEN, VIBETRACE_FILE,
 // GITHUB_REPOSITORY, VCR_PR / GITHUB_PR_NUMBER, GITHUB_HEAD_REF,
@@ -14,7 +13,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { buildChairRecord, buildCouncilRecord } from "./vibetrace-records.mjs";
+import { buildCouncilRecord } from "./vibetrace-records.mjs";
 
 function arg(name, fallback = undefined) {
   const i = process.argv.indexOf(name);
@@ -87,13 +86,7 @@ function buildRecord(kind) {
       diffMarkdown: readOptional(arg("--diff")),
     });
   }
-  if (kind === "review.chair") {
-    return buildChairRecord({
-      verdictsPath: arg("--verdicts", "chair-verdicts.json"),
-      attribution: attr,
-    });
-  }
-  return { ok: false, reason: `unsupported type; only review.council and review.chair` };
+  return { ok: false, reason: `unsupported type; only review.council` };
 }
 
 async function emit(record) {

--- a/scripts/vibetrace-records.mjs
+++ b/scripts/vibetrace-records.mjs
@@ -99,32 +99,3 @@ export function buildCouncilRecord(input) {
  *   attribution: Record<string, unknown>,
  * }} input
  */
-export function buildChairRecord({ verdictsPath, attribution }) {
-  const base = {
-    schemaVersion: SCHEMA_VERSION,
-    ts: new Date().toISOString(),
-    type: "review.chair",
-    attribution,
-  };
-  if (!verdictsPath || !fs.existsSync(verdictsPath)) {
-    return { ok: true, record: { ...base, dispositionsMissing: true } };
-  }
-  let parsed;
-  try {
-    parsed = JSON.parse(fs.readFileSync(verdictsPath, "utf8"));
-  } catch {
-    return { ok: true, record: { ...base, dispositionsMissing: true } };
-  }
-  const dispositions = Array.isArray(parsed?.dispositions) ? parsed.dispositions : [];
-  const record = {
-    ...base,
-    dispositionsMissing: false,
-    verdict: typeof parsed?.verdict === "string" ? parsed.verdict : undefined,
-    dispositions: dispositions.map((d) => ({
-      id: d.id,
-      classKey: d.classKey,
-      disposition: d.disposition,
-    })),
-  };
-  return { ok: true, record };
-}

--- a/scripts/vibetrace-records.mjs
+++ b/scripts/vibetrace-records.mjs
@@ -1,5 +1,4 @@
 // vibetrace record builders — council cost/routing plus defect measurement.
-import fs from "node:fs";
 import { parseFindings } from "./file-findings.mjs";
 import { countAddedLines } from "./review-delta.mjs";
 
@@ -9,6 +8,10 @@ export const SCHEMA_VERSION = "0.2.0";
 // review out of the `full` bucket; the table below only refines WHICH skip.
 export const SKIP_PREFIX = "_Council skipped:";
 
+// Written by council-review.mjs's top-level catch. A run that threw is not a
+// quiet success, so it must not fall through to `full`/`delta` either.
+export const ERROR_PREFIX = "_Council errored:";
+
 const SKIP_MARKERS = {
   trivial: "_Council skipped: trivial delta",
   "no-lenses": "_Council skipped: no configured lens applies",
@@ -17,7 +20,7 @@ const SKIP_MARKERS = {
   "no-members": "_Council skipped: COUNCIL_MODELS parsed to no valid members",
 };
 
-/** @typedef {"full"|"delta"|"trivial"|"no-lenses"|"no-keys"|"no-diff"|"no-members"|"skipped"} ReviewStrength */
+/** @typedef {"full"|"delta"|"trivial"|"no-lenses"|"no-keys"|"no-diff"|"no-members"|"skipped"|"errored"} ReviewStrength */
 
 /**
  * @param {string} markdown @param {"full"|"delta"} mode @returns {ReviewStrength}
@@ -27,10 +30,13 @@ const SKIP_MARKERS = {
  * ran, so a skip path added later that nobody added a marker for must not
  * silently land in the `full` bucket and read as "reviewed, found nothing".
  * `skipped` is deliberately coarse: it is honest about not knowing which gate
- * fired, which a wrong-but-specific answer would not be.
+ * fired, which a wrong-but-specific answer would not be. A run that errored
+ * out is checked first and separately, for the same reason: a crash is not a
+ * review that found nothing either.
  */
 export function detectStrength(markdown, mode) {
   const text = String(markdown || "");
+  if (text.includes(ERROR_PREFIX)) return "errored";
   for (const [strength, marker] of Object.entries(SKIP_MARKERS)) {
     if (text.includes(marker)) return /** @type {ReviewStrength} */ (strength);
   }
@@ -92,10 +98,3 @@ export function buildCouncilRecord(input) {
     },
   };
 }
-
-/**
- * @param {{
- *   verdictsPath?: string,
- *   attribution: Record<string, unknown>,
- * }} input
- */

--- a/scripts/vibetrace-records.mjs
+++ b/scripts/vibetrace-records.mjs
@@ -1,0 +1,130 @@
+// vibetrace record builders — council cost/routing plus defect measurement.
+import fs from "node:fs";
+import { parseFindings } from "./file-findings.mjs";
+import { countAddedLines } from "./review-delta.mjs";
+
+export const SCHEMA_VERSION = "0.2.0";
+
+// The prefix every skip path writes. Matching it is what keeps a skipped
+// review out of the `full` bucket; the table below only refines WHICH skip.
+export const SKIP_PREFIX = "_Council skipped:";
+
+const SKIP_MARKERS = {
+  trivial: "_Council skipped: trivial delta",
+  "no-lenses": "_Council skipped: no configured lens applies",
+  "no-keys": "_Council skipped: no provider keys set",
+  "no-diff": "_Council skipped: empty diff",
+  "no-members": "_Council skipped: COUNCIL_MODELS parsed to no valid members",
+};
+
+/** @typedef {"full"|"delta"|"trivial"|"no-lenses"|"no-keys"|"no-diff"|"no-members"|"skipped"} ReviewStrength */
+
+/**
+ * @param {string} markdown @param {"full"|"delta"} mode @returns {ReviewStrength}
+ *
+ * An unrecognised skip falls back to the generic `skipped`, never to `full`.
+ * The whole point of this field is telling a QUIET review from one that never
+ * ran, so a skip path added later that nobody added a marker for must not
+ * silently land in the `full` bucket and read as "reviewed, found nothing".
+ * `skipped` is deliberately coarse: it is honest about not knowing which gate
+ * fired, which a wrong-but-specific answer would not be.
+ */
+export function detectStrength(markdown, mode) {
+  const text = String(markdown || "");
+  for (const [strength, marker] of Object.entries(SKIP_MARKERS)) {
+    if (text.includes(marker)) return /** @type {ReviewStrength} */ (strength);
+  }
+  if (text.includes(SKIP_PREFIX)) return "skipped";
+  return mode === "delta" ? "delta" : "full";
+}
+
+/** @param {string} markdown */
+export function parseSkippedLenses(markdown) {
+  const match = /> Lenses not dispatched:\s*([^(]+)/.exec(String(markdown || ""));
+  if (!match) return [];
+  return match[1].split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+/** @param {string} markdown */
+export function councilFindingsPayload(markdown) {
+  return parseFindings(markdown).map((f) => ({
+    id: f.id,
+    classKey: f.classKey,
+    path: f.path,
+    lens: f.lensFamily,
+  }));
+}
+
+/**
+ * @param {{
+ *   mode: "full"|"delta",
+ *   cacheHit: boolean,
+ *   memberCount: number,
+ *   cancelled: boolean,
+ *   attribution: Record<string, unknown>,
+ *   findingsMarkdown?: string,
+ *   diffMarkdown?: string,
+ * }} input
+ */
+export function buildCouncilRecord(input) {
+  const { mode, cacheHit, memberCount, cancelled, attribution, findingsMarkdown = "", diffMarkdown = "" } = input;
+  if (mode !== "full" && mode !== "delta") {
+    return { ok: false, reason: "mode must be full or delta" };
+  }
+  if (!Number.isInteger(memberCount) || memberCount < 0) {
+    return { ok: false, reason: "members must be a non-negative integer" };
+  }
+  return {
+    ok: true,
+    record: {
+      schemaVersion: SCHEMA_VERSION,
+      ts: new Date().toISOString(),
+      type: "review.council",
+      mode,
+      cacheHit,
+      memberCount,
+      cancelled,
+      strength: detectStrength(findingsMarkdown, mode),
+      skippedLenses: parseSkippedLenses(findingsMarkdown),
+      addedLines: countAddedLines(diffMarkdown),
+      findings: councilFindingsPayload(findingsMarkdown),
+      attribution,
+    },
+  };
+}
+
+/**
+ * @param {{
+ *   verdictsPath?: string,
+ *   attribution: Record<string, unknown>,
+ * }} input
+ */
+export function buildChairRecord({ verdictsPath, attribution }) {
+  const base = {
+    schemaVersion: SCHEMA_VERSION,
+    ts: new Date().toISOString(),
+    type: "review.chair",
+    attribution,
+  };
+  if (!verdictsPath || !fs.existsSync(verdictsPath)) {
+    return { ok: true, record: { ...base, dispositionsMissing: true } };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(verdictsPath, "utf8"));
+  } catch {
+    return { ok: true, record: { ...base, dispositionsMissing: true } };
+  }
+  const dispositions = Array.isArray(parsed?.dispositions) ? parsed.dispositions : [];
+  const record = {
+    ...base,
+    dispositionsMissing: false,
+    verdict: typeof parsed?.verdict === "string" ? parsed.verdict : undefined,
+    dispositions: dispositions.map((d) => ({
+      id: d.id,
+      classKey: d.classKey,
+      disposition: d.disposition,
+    })),
+  };
+  return { ok: true, record };
+}

--- a/scripts/vibetrace-records.test.mjs
+++ b/scripts/vibetrace-records.test.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildChairRecord,
+  buildCouncilRecord,
+  detectStrength,
+} from "./vibetrace-records.mjs";
+
+const script = path.join(path.dirname(fileURLToPath(import.meta.url)), "vibetrace-emit.mjs");
+let failed = 0;
+
+function run(args, env = {}) {
+  return spawnSync(process.execPath, [script, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "vcr-records-"));
+
+const trivialMd = "# Council\n\n_Council skipped: trivial delta with no behavioral surface — docs only._\n";
+const trivialRec = buildCouncilRecord({
+  mode: "delta",
+  cacheHit: false,
+  memberCount: 0,
+  cancelled: false,
+  attribution: {},
+  findingsMarkdown: trivialMd,
+  diffMarkdown: "",
+});
+if (trivialRec.record.strength !== "trivial") {
+  console.error("FAIL strength trivial", trivialRec.record.strength);
+  failed++;
+} else {
+  console.log("ok - strength=trivial for trivial skip");
+}
+
+const noKeysMd = "# Council\n\n_Council skipped: no provider keys set (OPENAI_API_KEY)._ \n";
+const noKeysRec = buildCouncilRecord({
+  mode: "full",
+  cacheHit: false,
+  memberCount: 0,
+  cancelled: false,
+  attribution: {},
+  findingsMarkdown: noKeysMd,
+  diffMarkdown: "",
+});
+if (noKeysRec.record.strength !== "no-keys") {
+  console.error("FAIL strength no-keys", noKeysRec.record.strength);
+  failed++;
+} else {
+  console.log("ok - strength=no-keys when keys missing");
+}
+
+const fullRec = buildCouncilRecord({
+  mode: "full",
+  cacheHit: false,
+  memberCount: 3,
+  cancelled: false,
+  attribution: {},
+  findingsMarkdown: "# Council\n\n## GPT — correctness lens\n\n- `src/x.ts:1` — defect here -> fix.\n",
+  diffMarkdown: "@@\n+added line\n",
+});
+if (fullRec.record.strength !== "full" || fullRec.record.addedLines !== 1) {
+  console.error("FAIL strength full / addedLines", fullRec.record);
+  failed++;
+} else if (!fullRec.record.findings?.[0]?.classKey) {
+  console.error("FAIL findings payload missing classKey", fullRec.record.findings);
+  failed++;
+} else {
+  console.log("ok - strength=full with findings and addedLines");
+}
+
+if (detectStrength("# x\n", "delta") !== "delta") {
+  console.error("FAIL detectStrength delta");
+  failed++;
+}
+
+const chairMissing = buildChairRecord({ verdictsPath: path.join(tmp, "missing-chair.json"), attribution: {} });
+if (!chairMissing.record.dispositionsMissing || chairMissing.record.dispositions) {
+  console.error("FAIL missing chair-verdicts should set dispositionsMissing", chairMissing.record);
+  failed++;
+} else {
+  console.log("ok - missing chair-verdicts.json sets dispositionsMissing");
+}
+
+const verdictsPath = path.join(tmp, "chair-verdicts.json");
+fs.writeFileSync(verdictsPath, JSON.stringify({
+  verdict: "comment",
+  dispositions: [{ id: "abc", classKey: "def", disposition: "confirmed-open" }],
+}));
+const chairPresent = buildChairRecord({ verdictsPath, attribution: {} });
+if (chairPresent.record.dispositionsMissing || chairPresent.record.verdict !== "comment") {
+  console.error("FAIL present chair-verdicts", chairPresent.record);
+  failed++;
+} else {
+  console.log("ok - chair-verdicts.json parsed into review.chair");
+}
+
+const chairEmitFile = path.join(tmp, "chair-emit.jsonl");
+const chairEmit = run(["review.chair", "--verdicts", verdictsPath], { VIBETRACE_FILE: chairEmitFile });
+if (chairEmit.status !== 0) {
+  console.error("FAIL review.chair emit exit", chairEmit.status, chairEmit.stderr);
+  failed++;
+} else {
+  const chairLine = JSON.parse(fs.readFileSync(chairEmitFile, "utf8").trim());
+  if (chairLine.type !== "review.chair" || chairLine.dispositionsMissing) {
+    console.error("FAIL review.chair record", chairLine);
+    failed++;
+  } else {
+    console.log("ok - CLI emits review.chair");
+  }
+}
+
+const chairMissingEmit = run(["review.chair", "--verdicts", path.join(tmp, "nope.json")], {
+  VIBETRACE_FILE: path.join(tmp, "chair-missing.jsonl"),
+});
+if (chairMissingEmit.status !== 0) {
+  console.error("FAIL missing chair emit exit", chairMissingEmit.status);
+  failed++;
+} else {
+  const missingLine = JSON.parse(fs.readFileSync(path.join(tmp, "chair-missing.jsonl"), "utf8").trim());
+  if (!missingLine.dispositionsMissing || missingLine.findings) {
+    console.error("FAIL missing chair must not look like zero findings", missingLine);
+    failed++;
+  } else if (missingLine.dispositions) {
+    console.error("FAIL missing chair should not include dispositions array", missingLine);
+    failed++;
+  } else {
+    console.log("ok - missing chair file fails open with dispositionsMissing");
+  }
+}
+
+fs.rmSync(tmp, { recursive: true, force: true });
+
+// --- strength must never mistake a skipped review for a full one ----------
+// Read every skip string the engine actually writes and check each one lands
+// outside `full`/`delta`. This is the durable half: a sixth skip path added to
+// council-review.mjs fails here instead of silently recording as "reviewed,
+// found nothing", which is the one reading this field exists to prevent.
+{
+  const engine = fs.readFileSync(path.join(path.dirname(script), "council-review.mjs"), "utf8");
+  const written = [...engine.matchAll(/_Council skipped: [^"`\\]+/g)].map((m) => m[0]);
+  if (written.length < 5) {
+    console.error("FAIL expected several engine skip strings, found", written.length);
+    failed++;
+  }
+  for (const marker of written) {
+    const strength = detectStrength(`# hdr\n\n${marker}._\n`, "full");
+    if (strength === "full" || strength === "delta") {
+      console.error(`FAIL skip string recorded as ${strength}:`, marker.slice(0, 70));
+      failed++;
+    }
+  }
+  if (detectStrength("_Council skipped: a gate added later._", "full") !== "skipped") {
+    console.error("FAIL an unrecognised skip must degrade to `skipped`, never to `full`");
+    failed++;
+  } else {
+    console.log(`ok - all ${written.length} engine skip paths record outside full/delta`);
+  }
+}
+console.log("vibetrace-records tests passed");
+if (failed) process.exit(1);

--- a/scripts/vibetrace-records.test.mjs
+++ b/scripts/vibetrace-records.test.mjs
@@ -78,6 +78,16 @@ if (detectStrength("# x\n", "delta") !== "delta") {
   console.error("FAIL detectStrength delta");
   failed++;
 }
+
+// A run that threw (council-review.mjs's top-level catch) is not a quiet
+// full/delta success and must not be recorded as one.
+const erroredMd = "# 🧑‍⚖️ LLM Council findings\n\n_Council errored: boom_\n";
+if (detectStrength(erroredMd, "full") !== "errored" || detectStrength(erroredMd, "delta") !== "errored") {
+  console.error("FAIL detectStrength must classify an errored run as `errored`, not full/delta");
+  failed++;
+} else {
+  console.log("ok - strength=errored for a run that threw");
+}
 fs.rmSync(tmp, { recursive: true, force: true });
 
 // --- strength must never mistake a skipped review for a full one ----------

--- a/scripts/vibetrace-records.test.mjs
+++ b/scripts/vibetrace-records.test.mjs
@@ -5,7 +5,6 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  buildChairRecord,
   buildCouncilRecord,
   detectStrength,
 } from "./vibetrace-records.mjs";
@@ -79,62 +78,6 @@ if (detectStrength("# x\n", "delta") !== "delta") {
   console.error("FAIL detectStrength delta");
   failed++;
 }
-
-const chairMissing = buildChairRecord({ verdictsPath: path.join(tmp, "missing-chair.json"), attribution: {} });
-if (!chairMissing.record.dispositionsMissing || chairMissing.record.dispositions) {
-  console.error("FAIL missing chair-verdicts should set dispositionsMissing", chairMissing.record);
-  failed++;
-} else {
-  console.log("ok - missing chair-verdicts.json sets dispositionsMissing");
-}
-
-const verdictsPath = path.join(tmp, "chair-verdicts.json");
-fs.writeFileSync(verdictsPath, JSON.stringify({
-  verdict: "comment",
-  dispositions: [{ id: "abc", classKey: "def", disposition: "confirmed-open" }],
-}));
-const chairPresent = buildChairRecord({ verdictsPath, attribution: {} });
-if (chairPresent.record.dispositionsMissing || chairPresent.record.verdict !== "comment") {
-  console.error("FAIL present chair-verdicts", chairPresent.record);
-  failed++;
-} else {
-  console.log("ok - chair-verdicts.json parsed into review.chair");
-}
-
-const chairEmitFile = path.join(tmp, "chair-emit.jsonl");
-const chairEmit = run(["review.chair", "--verdicts", verdictsPath], { VIBETRACE_FILE: chairEmitFile });
-if (chairEmit.status !== 0) {
-  console.error("FAIL review.chair emit exit", chairEmit.status, chairEmit.stderr);
-  failed++;
-} else {
-  const chairLine = JSON.parse(fs.readFileSync(chairEmitFile, "utf8").trim());
-  if (chairLine.type !== "review.chair" || chairLine.dispositionsMissing) {
-    console.error("FAIL review.chair record", chairLine);
-    failed++;
-  } else {
-    console.log("ok - CLI emits review.chair");
-  }
-}
-
-const chairMissingEmit = run(["review.chair", "--verdicts", path.join(tmp, "nope.json")], {
-  VIBETRACE_FILE: path.join(tmp, "chair-missing.jsonl"),
-});
-if (chairMissingEmit.status !== 0) {
-  console.error("FAIL missing chair emit exit", chairMissingEmit.status);
-  failed++;
-} else {
-  const missingLine = JSON.parse(fs.readFileSync(path.join(tmp, "chair-missing.jsonl"), "utf8").trim());
-  if (!missingLine.dispositionsMissing || missingLine.findings) {
-    console.error("FAIL missing chair must not look like zero findings", missingLine);
-    failed++;
-  } else if (missingLine.dispositions) {
-    console.error("FAIL missing chair should not include dispositions array", missingLine);
-    failed++;
-  } else {
-    console.log("ok - missing chair file fails open with dispositionsMissing");
-  }
-}
-
 fs.rmSync(tmp, { recursive: true, force: true });
 
 // --- strength must never mistake a skipped review for a full one ----------


### PR DESCRIPTION
Closes #128

## What
The `review.council` record now carries `findings: [{ id, classKey, path, lens }]`, `skippedLenses`, `addedLines` and `strength`, and `SCHEMA_VERSION` bumps to `0.2.0`.

## Why

The record held `memberCount`, `cacheHit`, `mode`, `cancelled` — cost and routing. Nothing could answer whether reviews were getting cheaper because the code improved or because the reviewer stopped looking.

`classKey` is what makes recurrence countable. The existing `id` hashes the location *and* the full prose, so it almost never matches across two PRs and would report every defect class as extinct. Verified directly against the parser:

```
A src/auth.ts:42  security  classKey 1f8b74439a  id 09b693d8db
B src/auth.ts:118 security  classKey 1f8b74439a  id b2ca095a18   <- line shift, same class
C same defect, different MODEL, same lens      1f8b74439a        <- model swap, same class
D different defect, same file/lens             0129a0bd20        <- differs
E same defect, different LENS                  7a5b1fb767        <- differs
```

`strength` separates a quiet review from one that never ran. Without it, a full review that found nothing and a review that was skipped are the same row, and the metric silently rewards not looking.

The chair half — a `review.chair` record with per-finding dispositions — ships separately as #<137>. It depends on this record shape, and the two together came to 509 counted lines against the 500 cap, so splitting them was the cap's doing rather than a design choice.

## Defect found and fixed during review

The first implementation mapped three of the engine's five skip strings. The other two recorded as **`full` with zero findings** — precisely the failure this field exists to prevent:

```
COUNCIL_MODELS empty   -> full     <-- a SKIPPED review recorded as a FULL one
empty diff             -> full     <-- same
```

Fixed structurally rather than by adding two strings: an unrecognised `_Council skipped:` now degrades to a coarse `skipped`, never to `full`. A gate added later cannot land in the reviewed bucket because nobody remembered a marker. `skipped` is deliberately coarse — honest about not knowing which gate fired, which a wrong-but-specific answer would not be.

The guard reads every `_Council skipped:` string out of `council-review.mjs` and checks each lands outside `full`/`delta`, so a sixth skip path fails the suite instead of quietly misreporting.

## How I verified

npm test -> exit 0

node --test scripts/*.test.mjs -> 28 tests, 28 pass, 0 fail

node scripts/council-review.mjs --selfcheck -> selfcheck ok

Mutation-tested the skip guard: reverting `detectStrength` to the three-marker version gives

```
FAIL skip string recorded as full: _Council skipped: COUNCIL_MODELS parsed to no valid members
FAIL skip string recorded as full: _Council skipped: empty diff._
exit=1
```

Adding a brand-new unmarked skip path to the engine keeps the suite green, which is the intended behaviour — the fallback catches it as `skipped` rather than `full`.

Also fixed: the guard was initially appended below `if (failed) process.exit(1)`, so its failures could not affect the exit code. The exit check now runs last. That is the same vacuous-guard shape this PR's strength fix is about.

This branch was rebased onto main after #131 merged. Both sides had rewritten the `write` helper — main's preserves the carry, this branch's appends findings metadata — so the resolution keeps **both**, rather than taking either side and silently dropping a shipped behaviour.

Emission still fails soft and ingest stays opt-in, so a telemetry fault cannot turn a green PR red.

Proof: n/a — telemetry records and tests. The evidence is the output above.

Assisted-by: cursor:composer-2.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Council review records now include richer outcome details, findings, skipped checks, errors, attribution, cache status, and added-line counts.
  - Review findings now include machine-readable metadata to improve downstream reporting and analysis.
  - Review output can incorporate findings and change summaries when generating records.

- **Bug Fixes**
  - Improved added-line counting for diffs containing multi-plus-prefixed content.
  - Missing optional review files are handled safely without interrupting record generation.

- **Tests**
  - Expanded coverage for finding classification, skipped and errored reviews, and diff line counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
