### PR TITLE
[VCR-135] Set reasoning effort per lens, as a position

### DIFF
--- a/scripts/claude-cli-seat.mjs
+++ b/scripts/claude-cli-seat.mjs
@@ -1,6 +1,25 @@
 // A Claude subscription seat: there is no OpenAI-compatible URL that accepts a
 // Claude Code OAuth token, so this seat shells the Claude Code CLI the action
 // already installs for the chair instead of POSTing to a chat endpoint.
+
+// Pulled out so the argv it builds — in particular, whether --effort is
+// present at all — can be asserted directly, without stubbing execFile.
+export function claudeCliArgs(model, instructions, effortRung) {
+  return [
+    "-p",
+    instructions,
+    "--model",
+    model.model,
+    // No tools: the seat needs nothing but the diff on stdin. This also
+    // keeps an agentic loop from eating the timeout.
+    "--allowed-tools",
+    "",
+    "--max-turns",
+    "1",
+    ...(effortRung ? ["--effort", effortRung] : []),
+  ];
+}
+
 export async function callClaudeCli(model, diff, oauthToken, { instructions, timeoutMs, effortRung }) {
   const { execFile } = await import("node:child_process");
   const os = await import("node:os");
@@ -38,19 +57,7 @@ export async function callClaudeCli(model, diff, oauthToken, { instructions, tim
   return new Promise((resolve) => {
     const child = execFile(
       "claude",
-      [
-        "-p",
-        instructions,
-        "--model",
-        model.model,
-        // No tools: the seat needs nothing but the diff on stdin. This also
-        // keeps an agentic loop from eating the timeout.
-        "--allowed-tools",
-        "",
-        "--max-turns",
-        "1",
-        ...(effortRung ? ["--effort", effortRung] : []),
-      ],
+      claudeCliArgs(model, instructions, effortRung),
       {
         timeout: timeoutMs,
         maxBuffer: 32 * 1024 * 1024,

--- a/scripts/claude-cli-seat.mjs
+++ b/scripts/claude-cli-seat.mjs
@@ -1,7 +1,7 @@
 // A Claude subscription seat: there is no OpenAI-compatible URL that accepts a
 // Claude Code OAuth token, so this seat shells the Claude Code CLI the action
 // already installs for the chair instead of POSTing to a chat endpoint.
-export async function callClaudeCli(model, diff, oauthToken, { instructions, timeoutMs }) {
+export async function callClaudeCli(model, diff, oauthToken, { instructions, timeoutMs, effortRung }) {
   const { execFile } = await import("node:child_process");
   const os = await import("node:os");
   // Short lens instructions on argv, the diff on stdin. Both forms work —
@@ -49,6 +49,7 @@ export async function callClaudeCli(model, diff, oauthToken, { instructions, tim
         "",
         "--max-turns",
         "1",
+        ...(effortRung ? ["--effort", effortRung] : []),
       ],
       {
         timeout: timeoutMs,

--- a/scripts/council-cache.mjs
+++ b/scripts/council-cache.mjs
@@ -4,6 +4,7 @@
 
 import { createHash } from "node:crypto";
 import { PROMPT_VERSION } from "./council-config.mjs";
+import { effortCacheSegment } from "./lens-effort-config.mjs";
 
 const CACHE_MARKER = "<!-- vibecodereview:council-result:";
 const PAGE_SIZE = 100;
@@ -53,6 +54,7 @@ export function cacheKey(diff, model) {
     .update(Buffer.from(String(diff), "utf8"))
     .update(Buffer.from(memberId(model), "utf8"))
     .update(Buffer.from(model.lens, "utf8"))
+    .update(Buffer.from(effortCacheSegment(model), "utf8"))
     .update(Buffer.from(PROMPT_VERSION, "utf8"))
     .digest("hex");
 }

--- a/scripts/council-cache.test.mjs
+++ b/scripts/council-cache.test.mjs
@@ -25,6 +25,10 @@ assert.equal(memberId(member), "openai|gpt-5.6|GPT-5.6 (Codex)");
 assert.notEqual(cacheKey(`${diff} `, member), key);
 assert.notEqual(cacheKey(diff, { ...member, lens: "security" }), key);
 assert.notEqual(cacheKey(diff, { ...member, model: "gpt-5.5" }), key);
+assert.notEqual(
+  cacheKey(diff, { ...member, effortConfigured: true, effortPosition: 0 }),
+  cacheKey(diff, { ...member, effortConfigured: true, effortPosition: 1 }),
+);
 
 function makeComment(keyToUse, text = "No findings.") {
   const payload = Buffer.from(JSON.stringify({ model: member, text }), "utf8").toString("base64");

--- a/scripts/council-members.mjs
+++ b/scripts/council-members.mjs
@@ -11,6 +11,7 @@ import {
   DEFAULT_MODELS,
 } from "./council-config.mjs";
 import { callClaudeCli } from "./claude-cli-seat.mjs";
+import { cliEffortRung, effortWireExtras } from "./lens-effort-config.mjs";
 
 // Members run in parallel, so the council costs max(member latency), not the
 // sum — the timeout is therefore a direct tail-latency tax on every run. In
@@ -33,6 +34,19 @@ export function parseModels() {
       return { provider, model, name: name || model, lens: lens || "correctness" };
     })
     .filter((m) => m.provider && m.model && PROVIDERS[m.provider]);
+}
+
+export function buildRequestBody(model, diff) {
+  const body = {
+    model: model.model,
+    messages: [
+      { role: "system", content: systemPrompt(model.lens) },
+      { role: "user", content: `PR diff:\n\n${diff}` },
+    ],
+  };
+  const extras = effortWireExtras(model);
+  if (extras) Object.assign(body, extras);
+  return body;
 }
 
 export function systemPrompt(lens) {
@@ -58,6 +72,7 @@ export function systemPrompt(lens) {
 export async function callModel(model, diff) {
   const startedAt = Date.now();
   const timed = (r) => ({ ...r, ms: Date.now() - startedAt });
+  if (model.effortParseError) return timed({ model, error: model.effortParseError });
   const provider = PROVIDERS[model.provider];
   // A subscription seat has no chat endpoint to POST to.
   if (provider?.cli) {
@@ -65,7 +80,11 @@ export async function callModel(model, diff) {
     if (!token) return timed({ model, error: `skipped: ${provider.keyEnv} not set` });
     const instructions = `${systemPrompt(model.lens)}\n\nReview the PR diff piped on stdin.`;
     return timed(
-      await callClaudeCli(model, diff, token, { instructions, timeoutMs: CLI_TIMEOUT_MS }),
+      await callClaudeCli(model, diff, token, {
+        instructions,
+        timeoutMs: CLI_TIMEOUT_MS,
+        effortRung: cliEffortRung(model),
+      }),
     );
   }
   if (provider && !provider.url) return timed({ model, error: "skipped: CUSTOM_BASE_URL not set" });
@@ -84,13 +103,7 @@ export async function callModel(model, diff) {
         "Content-Type": "application/json",
         "X-Title": "Content Rabbit PR Council",
       },
-      body: JSON.stringify({
-        model: model.model,
-        messages: [
-          { role: "system", content: systemPrompt(model.lens) },
-          { role: "user", content: `PR diff:\n\n${diff}` },
-        ],
-      }),
+      body: JSON.stringify(buildRequestBody(model, diff)),
     });
     if (!res.ok) {
       const body = await res.text().catch(() => "");

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -49,6 +49,7 @@ import {
   callModelWithFallback,
 } from "./council-members.mjs";
 import { cacheKey, loadCouncilResults, saveCouncilResult } from "./council-cache.mjs";
+import { withLensEffort } from "./lens-effort-config.mjs";
 import { behavioralSurface } from "./behavioral-surface.mjs";
 import { filterMembersByKindRouting, lensesForKinds, routeLenses } from "./lens-routing.mjs";
 import { appendFindingsMeta } from "./file-findings.mjs";
@@ -220,7 +221,7 @@ async function main() {
     if (process.env.VCR_CARRY_FILE) fs.writeFileSync(process.env.VCR_CARRY_FILE, carry);
   };
 
-  const models = parseModels();
+  const models = withLensEffort(parseModels());
   if (models.length === 0) {
     write(
       "# 🧑‍⚖️ LLM Council findings\n\n_Council skipped: COUNCIL_MODELS parsed to no valid members (expected `provider|model|Name|lens`; providers: openai, gemini, moonshot, openrouter, custom)._\n",

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -221,7 +221,7 @@ async function main() {
     if (process.env.VCR_CARRY_FILE) fs.writeFileSync(process.env.VCR_CARRY_FILE, carry);
   };
 
-  const models = withLensEffort(parseModels());
+  const models = parseModels();
   if (models.length === 0) {
     write(
       "# 🧑‍⚖️ LLM Council findings\n\n_Council skipped: COUNCIL_MODELS parsed to no valid members (expected `provider|model|Name|lens`; providers: openai, gemini, moonshot, openrouter, custom)._\n",
@@ -271,7 +271,12 @@ async function main() {
   // a lens with no applicable changed path must not pay for a no-op call.
   // Composed here rather than beside parseModels because applicability depends
   // on the diff read above.
+  // Effort is applied AFTER the mutation member is appended, not beside
+  // parseModels. withMutationMember adds a member that parseModels never
+  // returned, so decorating before it left MUTATION_EFFORT set, documented and
+  // never applied — a dead config key.
   let { members, mutationSkipped } = withMutationMember(models, memberDiffRaw);
+  members = withLensEffort(members);
   const lensPathFilter = process.env.LENS_PATH_FILTER;
   let skippedLenses = [...new Set(
     members.filter((m) => !lensCanReviewDiff(m.lens, memberDiffRaw, lensPathFilter)).map((m) => m.lens),

--- a/scripts/lens-effort-config.mjs
+++ b/scripts/lens-effort-config.mjs
@@ -13,8 +13,12 @@ export const LENS_EFFORT_ENV = {
   mutation: "MUTATION_EFFORT",
 };
 
-/** @param {{ lens: string, effortConfigured?: boolean, effortPosition?: number }} model */
+/** @param {{ lens: string, effortConfigured?: boolean, effortPosition?: number, effortParseError?: string }} model */
 export function effortCacheSegment(model) {
+  // An invalid *_EFFORT must never key the same as unset — a stale cache hit
+  // would return the old cached completion and callModel's effortParseError
+  // check (which surfaces the typo) would never run.
+  if (model.effortParseError) return `error:${model.effortParseError}`;
   if (!model.effortConfigured || model.effortPosition === undefined) return "";
   return String(model.effortPosition);
 }

--- a/scripts/lens-effort-config.mjs
+++ b/scripts/lens-effort-config.mjs
@@ -28,8 +28,12 @@ export function withLensEffort(members) {
   return members.map((member) => {
     const envName = LENS_EFFORT_ENV[member.lens];
     if (!envName) return member;
-    const raw = process.env[envName]?.trim();
-    if (!raw) return member;
+    const value = process.env[envName];
+    if (value === undefined) return member;
+    const raw = value.trim();
+    if (raw === "") {
+      return { ...member, effortParseError: `invalid ${envName}: (empty)` };
+    }
     const position = parseEffortPosition(raw);
     if (position === undefined) {
       return { ...member, effortParseError: `invalid ${envName}: ${raw}` };

--- a/scripts/lens-effort-config.mjs
+++ b/scripts/lens-effort-config.mjs
@@ -1,0 +1,59 @@
+// Per-lens effort positions from env, plus wire-format resolution at call time.
+
+import { parseEffortPosition } from "./lens-effort.mjs";
+import { publishedLadder, resolveMemberRung } from "./model-effort-ladders.mjs";
+
+/** @type {Readonly<Record<string, string>>} */
+export const LENS_EFFORT_ENV = {
+  correctness: "CORRECTNESS_EFFORT",
+  performance: "PERFORMANCE_EFFORT",
+  security: "SECURITY_EFFORT",
+  maintainability: "MAINTAINABILITY_EFFORT",
+  scope: "SCOPE_EFFORT",
+  mutation: "MUTATION_EFFORT",
+};
+
+/** @param {{ lens: string, effortConfigured?: boolean, effortPosition?: number }} model */
+export function effortCacheSegment(model) {
+  if (!model.effortConfigured || model.effortPosition === undefined) return "";
+  return String(model.effortPosition);
+}
+
+/** @param {Array<{ lens: string } & Record<string, unknown>>} members */
+export function withLensEffort(members) {
+  return members.map((member) => {
+    const envName = LENS_EFFORT_ENV[member.lens];
+    if (!envName) return member;
+    const raw = process.env[envName]?.trim();
+    if (!raw) return member;
+    const position = parseEffortPosition(raw);
+    if (position === undefined) {
+      return { ...member, effortParseError: `invalid ${envName}: ${raw}` };
+    }
+    return { ...member, effortConfigured: true, effortPosition: position };
+  });
+}
+
+/**
+ * Provider-specific wire extras. Returns null when effort is unset or this route
+ * has no documented effort parameter — the request body stays unchanged.
+ *
+ * @param {{ provider: string, model: string, effortConfigured?: boolean, effortPosition?: number }} model
+ * @returns {Record<string, unknown> | null}
+ */
+export function effortWireExtras(model) {
+  const rung = resolveMemberRung(model);
+  if (!rung) return null;
+  if (model.provider === "openrouter") return { reasoning: { effort: rung } };
+  if (model.provider === "openai" || model.provider === "gemini" || model.provider === "moonshot") {
+    return { reasoning_effort: rung };
+  }
+  return null;
+}
+
+/** @param {{ provider: string, model: string, effortConfigured?: boolean, effortPosition?: number }} model */
+export function cliEffortRung(model) {
+  if (model.provider !== "claude" && model.provider !== "claude2") return undefined;
+  if (!publishedLadder(model)) return undefined;
+  return resolveMemberRung(model);
+}

--- a/scripts/lens-effort-config.mjs
+++ b/scripts/lens-effort-config.mjs
@@ -20,7 +20,13 @@ export function effortCacheSegment(model) {
   // check (which surfaces the typo) would never run.
   if (model.effortParseError) return `error:${model.effortParseError}`;
   if (!model.effortConfigured || model.effortPosition === undefined) return "";
-  return String(model.effortPosition);
+  // Key on the RESOLVED rung, not the raw position. A published ladder can be
+  // edited (a rung added/removed) without the position changing, and that
+  // alone can move the same position onto a different rung — keying on the
+  // position alone would keep returning the completion resolved under the
+  // old ladder.
+  const rung = resolveMemberRung(model);
+  return rung ? `rung:${rung}` : `pos:${model.effortPosition}`;
 }
 
 /** @param {Array<{ lens: string } & Record<string, unknown>>} members */

--- a/scripts/lens-effort.mjs
+++ b/scripts/lens-effort.mjs
@@ -1,0 +1,77 @@
+/**
+ * Reasoning effort, stored as a POSITION rather than a name.
+ *
+ * A rung name is only meaningful inside the model that published it: `high` is
+ * one model's floor and another's midpoint, and a model is free to call its rungs
+ * anything at all. So a stored name is untransferable the moment the model
+ * changes underneath the setting — which happens without anyone editing it when
+ * OPENAI_MODEL / GEMINI_MODEL / SCOPE_MODEL / MUTATION_MODEL / COUNCIL_MODELS
+ * repoint a lens's model.
+ *
+ * A position on [0, 1] has no such problem: 0 is whatever that model calls its
+ * cheapest rung and 1 is whatever it calls its most expensive. Resolution is a
+ * lookup into the model's own published ladder, so the result is always a rung
+ * that model actually offers. An invalid effort is unrepresentable rather than
+ * merely guarded against.
+ */
+
+/** @typedef {number} EffortPosition */
+
+/** @type {EffortPosition} */
+export const DEFAULT_EFFORT_POSITION = 0.5;
+
+/** @type {Readonly<Record<string, EffortPosition>>} */
+export const EFFORT_ALIASES = {
+  low: 0,
+  medium: 0.25,
+  high: 0.5,
+  xhigh: 0.75,
+  max: 1,
+};
+
+/** @type {Readonly<Set<string>>} */
+const DISABLING_RUNGS = new Set(["none", "minimal"]);
+
+/** @param {number} value */
+export function isEffortPosition(value) {
+  return Number.isFinite(value) && value >= 0 && value <= 1;
+}
+
+/**
+ * @param {string} raw
+ * @returns {EffortPosition | undefined}
+ */
+export function parseEffortPosition(raw) {
+  const normalized = raw.trim().toLowerCase();
+  const named = EFFORT_ALIASES[normalized === "med" ? "medium" : normalized];
+  if (named !== undefined) return named;
+  const numeric = Number(normalized);
+  return normalized !== "" && isEffortPosition(numeric) ? numeric : undefined;
+}
+
+/** @param {readonly string[]} published */
+export function offeredRungs(published) {
+  return published.filter((rung) => !DISABLING_RUNGS.has(rung));
+}
+
+/**
+ * @param {{ position: EffortPosition, published: readonly string[] }} params
+ * @returns {string | undefined}
+ */
+export function resolveRung(params) {
+  const rungs = offeredRungs(params.published);
+  if (rungs.length === 0) return undefined;
+  const clamped = Math.min(1, Math.max(0, params.position));
+  return rungs[Math.floor(clamped * (rungs.length - 1))];
+}
+
+/**
+ * @param {{ rung: string, published: readonly string[] }} params
+ * @returns {EffortPosition | undefined}
+ */
+export function rungPosition(params) {
+  const rungs = offeredRungs(params.published);
+  const index = rungs.indexOf(params.rung);
+  if (index === -1) return undefined;
+  return rungs.length > 1 ? index / (rungs.length - 1) : 0;
+}

--- a/scripts/lens-effort.mjs
+++ b/scripts/lens-effort.mjs
@@ -43,7 +43,14 @@ export function isEffortPosition(value) {
  */
 export function parseEffortPosition(raw) {
   const normalized = raw.trim().toLowerCase();
-  const named = EFFORT_ALIASES[normalized === "med" ? "medium" : normalized];
+  // Object.hasOwn, not a bare lookup: `constructor` and `__proto__` survive
+  // toLowerCase unchanged and resolve to inherited prototype members, so a bare
+  // index returns the Object constructor rather than undefined. The member is
+  // then marked configured with a non-numeric position, resolveRung coerces it
+  // to NaN, and the effort is dropped SILENTLY — the one outcome this module
+  // exists to prevent.
+  const key = normalized === "med" ? "medium" : normalized;
+  const named = Object.hasOwn(EFFORT_ALIASES, key) ? EFFORT_ALIASES[key] : undefined;
   if (named !== undefined) return named;
   const numeric = Number(normalized);
   return normalized !== "" && isEffortPosition(numeric) ? numeric : undefined;

--- a/scripts/lens-effort.test.mjs
+++ b/scripts/lens-effort.test.mjs
@@ -7,7 +7,12 @@ import {
   rungPosition,
 } from "./lens-effort.mjs";
 import { LADDERS_FOR_TESTS, offeredRungs } from "./model-effort-ladders.mjs";
-import { effortWireExtras, withLensEffort } from "./lens-effort-config.mjs";
+import {
+  cliEffortRung,
+  effortCacheSegment,
+  effortWireExtras,
+  withLensEffort,
+} from "./lens-effort-config.mjs";
 import { withMutationMember } from "./council-config.mjs";
 import { buildRequestBody } from "./council-members.mjs";
 import { cacheKey } from "./council-cache.mjs";
@@ -71,6 +76,28 @@ const configured = { ...member, effortConfigured: true, effortPosition: 0 };
 const wired = buildRequestBody(configured, diff);
 assert.equal(wired.reasoning_effort, "low");
 
+// --- OpenRouter gets the nested reasoning.effort shape, not reasoning_effort ---
+const openRouterMember = { ...member, provider: "openrouter", effortConfigured: true, effortPosition: 0 };
+const openRouterBody = buildRequestBody(openRouterMember, diff);
+assert.deepEqual(openRouterBody.reasoning, { effort: "low" });
+assert.equal(openRouterBody.reasoning_effort, undefined);
+
+// --- Claude CLI seats resolve a rung from their own published ladder ---
+const claudeMember = {
+  provider: "claude",
+  model: "claude-sonnet-5",
+  name: "Sonnet 5",
+  lens: "correctness",
+  effortConfigured: true,
+  effortPosition: 0,
+};
+assert.equal(cliEffortRung(claudeMember), "low");
+assert.equal(cliEffortRung({ ...claudeMember, effortConfigured: false }), undefined);
+// An unpublished model must not send a rung the CLI's own flag would reject.
+assert.equal(cliEffortRung({ ...claudeMember, model: "claude-unknown-9" }), undefined);
+// A non-CLI provider never resolves a CLI rung even with the same ladder.
+assert.equal(cliEffortRung({ ...claudeMember, provider: "openai" }), undefined);
+
 // --- invalid env stays visible on the member ---
 const saved = process.env.CORRECTNESS_EFFORT;
 try {
@@ -81,6 +108,12 @@ try {
   if (saved === undefined) delete process.env.CORRECTNESS_EFFORT;
   else process.env.CORRECTNESS_EFFORT = saved;
 }
+
+// --- an invalid effort must never key the same as unset — a stale cache hit
+// would skip callModel entirely and never surface the parse error ---
+const parseErrorMember = { ...member, effortParseError: "invalid CORRECTNESS_EFFORT: high-ish" };
+assert.notEqual(effortCacheSegment(parseErrorMember), effortCacheSegment(member));
+assert.notEqual(cacheKey(diff, parseErrorMember), cacheKey(diff, member));
 
 // MUTATION_EFFORT must reach the mutation member. That member is appended by
 // withMutationMember, which parseModels never returns, so decorating with

--- a/scripts/lens-effort.test.mjs
+++ b/scripts/lens-effort.test.mjs
@@ -173,4 +173,32 @@ assert.notEqual(cacheKey(diff, parseErrorMember), cacheKey(diff, member));
   }
 }
 
+// An inherited Object.prototype name must not resolve to a level. `constructor`
+// and `__proto__` survive toLowerCase unchanged, so a bare bracket lookup hands
+// back a prototype member; the member is then marked configured with a
+// non-numeric position and the effort is dropped SILENTLY, which is exactly the
+// outcome "an invalid effort is unrepresentable" is supposed to rule out.
+for (const inherited of [
+  "constructor",
+  "__proto__",
+  "__defineGetter__",
+  "__defineSetter__",
+  "__lookupGetter__",
+  "__lookupSetter__",
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "toString",
+  "valueOf",
+]) {
+  assert.equal(
+    parseEffortPosition(inherited),
+    undefined,
+    `${inherited} must not parse as an effort level`,
+  );
+}
+// The real aliases still work, including the "med" shorthand.
+assert.equal(parseEffortPosition("med"), 0.25);
+assert.equal(parseEffortPosition("medium"), 0.25);
+
 console.log("lens effort tests passed");

--- a/scripts/lens-effort.test.mjs
+++ b/scripts/lens-effort.test.mjs
@@ -7,7 +7,7 @@ import {
   rungPosition,
 } from "./lens-effort.mjs";
 import { LADDERS_FOR_TESTS, offeredRungs } from "./model-effort-ladders.mjs";
-import { withLensEffort } from "./lens-effort-config.mjs";
+import { cliEffortRung, effortCacheSegment, withLensEffort } from "./lens-effort-config.mjs";
 import { buildRequestBody } from "./council-members.mjs";
 import { cacheKey } from "./council-cache.mjs";
 
@@ -70,6 +70,28 @@ const configured = { ...member, effortConfigured: true, effortPosition: 0 };
 const wired = buildRequestBody(configured, diff);
 assert.equal(wired.reasoning_effort, "low");
 
+// --- OpenRouter gets the nested reasoning.effort shape, not reasoning_effort ---
+const openRouterMember = { ...member, provider: "openrouter", effortConfigured: true, effortPosition: 0 };
+const openRouterBody = buildRequestBody(openRouterMember, diff);
+assert.deepEqual(openRouterBody.reasoning, { effort: "low" });
+assert.equal(openRouterBody.reasoning_effort, undefined);
+
+// --- Claude CLI seats resolve a rung from their own published ladder ---
+const claudeMember = {
+  provider: "claude",
+  model: "claude-sonnet-5",
+  name: "Sonnet 5",
+  lens: "correctness",
+  effortConfigured: true,
+  effortPosition: 0,
+};
+assert.equal(cliEffortRung(claudeMember), "low");
+assert.equal(cliEffortRung({ ...claudeMember, effortConfigured: false }), undefined);
+// An unpublished model must not send a rung the CLI's own flag would reject.
+assert.equal(cliEffortRung({ ...claudeMember, model: "claude-unknown-9" }), undefined);
+// A non-CLI provider never resolves a CLI rung even with the same ladder.
+assert.equal(cliEffortRung({ ...claudeMember, provider: "openai" }), undefined);
+
 // --- invalid env stays visible on the member ---
 const saved = process.env.CORRECTNESS_EFFORT;
 try {
@@ -80,5 +102,11 @@ try {
   if (saved === undefined) delete process.env.CORRECTNESS_EFFORT;
   else process.env.CORRECTNESS_EFFORT = saved;
 }
+
+// --- an invalid effort must never key the same as unset — a stale cache hit
+// would skip callModel entirely and never surface the parse error ---
+const parseErrorMember = { ...member, effortParseError: "invalid CORRECTNESS_EFFORT: high-ish" };
+assert.notEqual(effortCacheSegment(parseErrorMember), effortCacheSegment(member));
+assert.notEqual(cacheKey(diff, parseErrorMember), cacheKey(diff, member));
 
 console.log("lens effort tests passed");

--- a/scripts/lens-effort.test.mjs
+++ b/scripts/lens-effort.test.mjs
@@ -16,6 +16,7 @@ import {
 import { withMutationMember } from "./council-config.mjs";
 import { buildRequestBody } from "./council-members.mjs";
 import { cacheKey } from "./council-cache.mjs";
+import { claudeCliArgs } from "./claude-cli-seat.mjs";
 
 const member = {
   provider: "openai",
@@ -97,6 +98,23 @@ assert.equal(cliEffortRung({ ...claudeMember, effortConfigured: false }), undefi
 assert.equal(cliEffortRung({ ...claudeMember, model: "claude-unknown-9" }), undefined);
 // A non-CLI provider never resolves a CLI rung even with the same ladder.
 assert.equal(cliEffortRung({ ...claudeMember, provider: "openai" }), undefined);
+
+// --- the configured rung reaches the CLI's own argv, and an unset rung
+// leaves argv exactly as it was before this PR ---
+const cliArgsWithEffort = claudeCliArgs(claudeMember, "review the diff", "low");
+assert.deepEqual(cliArgsWithEffort.slice(-2), ["--effort", "low"]);
+const cliArgsWithoutEffort = claudeCliArgs(claudeMember, "review the diff", undefined);
+assert.equal(cliArgsWithoutEffort.includes("--effort"), false);
+assert.deepEqual(cliArgsWithoutEffort, [
+  "-p",
+  "review the diff",
+  "--model",
+  claudeMember.model,
+  "--allowed-tools",
+  "",
+  "--max-turns",
+  "1",
+]);
 
 // --- invalid env stays visible on the member ---
 const saved = process.env.CORRECTNESS_EFFORT;

--- a/scripts/lens-effort.test.mjs
+++ b/scripts/lens-effort.test.mjs
@@ -109,6 +109,20 @@ try {
   else process.env.CORRECTNESS_EFFORT = saved;
 }
 
+// --- a present-but-empty (or whitespace-only) env var is a visible config
+// error, not silently equivalent to the var being unset entirely ---
+try {
+  for (const blank of ["", "   "]) {
+    process.env.CORRECTNESS_EFFORT = blank;
+    const [parsed] = withLensEffort([member]);
+    assert.ok(parsed.effortParseError, `blank ${JSON.stringify(blank)} should surface a parse error`);
+    assert.equal(parsed.effortConfigured, undefined);
+  }
+} finally {
+  if (saved === undefined) delete process.env.CORRECTNESS_EFFORT;
+  else process.env.CORRECTNESS_EFFORT = saved;
+}
+
 // --- an invalid effort must never key the same as unset — a stale cache hit
 // would skip callModel entirely and never surface the parse error ---
 const parseErrorMember = { ...member, effortParseError: "invalid CORRECTNESS_EFFORT: high-ish" };

--- a/scripts/lens-effort.test.mjs
+++ b/scripts/lens-effort.test.mjs
@@ -7,7 +7,8 @@ import {
   rungPosition,
 } from "./lens-effort.mjs";
 import { LADDERS_FOR_TESTS, offeredRungs } from "./model-effort-ladders.mjs";
-import { cliEffortRung, effortCacheSegment, withLensEffort } from "./lens-effort-config.mjs";
+import { effortWireExtras, withLensEffort } from "./lens-effort-config.mjs";
+import { withMutationMember } from "./council-config.mjs";
 import { buildRequestBody } from "./council-members.mjs";
 import { cacheKey } from "./council-cache.mjs";
 
@@ -70,28 +71,6 @@ const configured = { ...member, effortConfigured: true, effortPosition: 0 };
 const wired = buildRequestBody(configured, diff);
 assert.equal(wired.reasoning_effort, "low");
 
-// --- OpenRouter gets the nested reasoning.effort shape, not reasoning_effort ---
-const openRouterMember = { ...member, provider: "openrouter", effortConfigured: true, effortPosition: 0 };
-const openRouterBody = buildRequestBody(openRouterMember, diff);
-assert.deepEqual(openRouterBody.reasoning, { effort: "low" });
-assert.equal(openRouterBody.reasoning_effort, undefined);
-
-// --- Claude CLI seats resolve a rung from their own published ladder ---
-const claudeMember = {
-  provider: "claude",
-  model: "claude-sonnet-5",
-  name: "Sonnet 5",
-  lens: "correctness",
-  effortConfigured: true,
-  effortPosition: 0,
-};
-assert.equal(cliEffortRung(claudeMember), "low");
-assert.equal(cliEffortRung({ ...claudeMember, effortConfigured: false }), undefined);
-// An unpublished model must not send a rung the CLI's own flag would reject.
-assert.equal(cliEffortRung({ ...claudeMember, model: "claude-unknown-9" }), undefined);
-// A non-CLI provider never resolves a CLI rung even with the same ladder.
-assert.equal(cliEffortRung({ ...claudeMember, provider: "openai" }), undefined);
-
 // --- invalid env stays visible on the member ---
 const saved = process.env.CORRECTNESS_EFFORT;
 try {
@@ -103,10 +82,30 @@ try {
   else process.env.CORRECTNESS_EFFORT = saved;
 }
 
-// --- an invalid effort must never key the same as unset — a stale cache hit
-// would skip callModel entirely and never surface the parse error ---
-const parseErrorMember = { ...member, effortParseError: "invalid CORRECTNESS_EFFORT: high-ish" };
-assert.notEqual(effortCacheSegment(parseErrorMember), effortCacheSegment(member));
-assert.notEqual(cacheKey(diff, parseErrorMember), cacheKey(diff, member));
+// MUTATION_EFFORT must reach the mutation member. That member is appended by
+// withMutationMember, which parseModels never returns, so decorating with
+// effort before the append leaves this env var set, documented and dead.
+{
+  const savedLens = process.env.MUTATION_LENS;
+  const savedEffort = process.env.MUTATION_EFFORT;
+  try {
+    process.env.MUTATION_LENS = "true";
+    process.env.MUTATION_EFFORT = "max";
+    const diff = "diff --git a/a.test.mjs b/a.test.mjs\n--- a/a.test.mjs\n+++ b/a.test.mjs\n+assert(1);\n";
+    const { members } = withMutationMember(
+      [{ provider: "openai", model: "gpt-5.6", name: "G", lens: "security" }],
+      diff,
+    );
+    const decorated = withLensEffort(members);
+    const mutation = decorated.find((m) => m.lens === "mutation");
+    assert.ok(mutation, "mutation member should be appended for a diff that adds tests");
+    assert.equal(mutation.effortConfigured, true, "MUTATION_EFFORT must reach the appended mutation member");
+    assert.equal(mutation.effortPosition, 1);
+    assert.ok(effortWireExtras(mutation), "a configured mutation member must carry effort onto the wire");
+  } finally {
+    if (savedLens === undefined) delete process.env.MUTATION_LENS; else process.env.MUTATION_LENS = savedLens;
+    if (savedEffort === undefined) delete process.env.MUTATION_EFFORT; else process.env.MUTATION_EFFORT = savedEffort;
+  }
+}
 
 console.log("lens effort tests passed");

--- a/scripts/lens-effort.test.mjs
+++ b/scripts/lens-effort.test.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import {
+  EFFORT_ALIASES,
+  parseEffortPosition,
+  resolveRung,
+  rungPosition,
+} from "./lens-effort.mjs";
+import { LADDERS_FOR_TESTS, offeredRungs } from "./model-effort-ladders.mjs";
+import { withLensEffort } from "./lens-effort-config.mjs";
+import { buildRequestBody } from "./council-members.mjs";
+import { cacheKey } from "./council-cache.mjs";
+
+const member = {
+  provider: "openai",
+  model: "gpt-5.6",
+  name: "GPT-5.6 (Codex)",
+  lens: "correctness",
+};
+const diff = "diff --git a/app.js b/app.js\n+return true;\n";
+
+// --- round-trip every defined ladder ---
+for (const { name, published } of LADDERS_FOR_TESTS) {
+  for (const rung of offeredRungs(published)) {
+    const position = rungPosition({ rung, published });
+    assert.notEqual(position, undefined, `${name}: ${rung} has no position`);
+    assert.equal(
+      resolveRung({ position, published }),
+      rung,
+      `${name}: ${rung} at ${position} did not round-trip`,
+    );
+  }
+}
+
+// --- between-rungs positions round DOWN ---
+assert.equal(
+  resolveRung({ position: 0.5, published: ["low", "medium", "high", "xhigh"] }),
+  "medium",
+);
+assert.equal(resolveRung({ position: 0.9, published: ["low", "medium", "high"] }), "medium");
+assert.equal(
+  resolveRung({ position: 0.99, published: ["low", "medium", "high", "xhigh", "max"] }),
+  "xhigh",
+);
+
+// --- typos stay undefined ---
+for (const bad of ["", "  ", "bogus", "1.5", "-0.2", "NaN", "Infinity", "high-ish"]) {
+  assert.equal(parseEffortPosition(bad), undefined, `expected undefined for ${JSON.stringify(bad)}`);
+}
+assert.equal(parseEffortPosition("high"), EFFORT_ALIASES.high);
+
+// --- cache key includes effort ---
+const lowEffort = { ...member, effortConfigured: true, effortPosition: 0 };
+const highEffort = { ...member, effortConfigured: true, effortPosition: 1 };
+assert.notEqual(cacheKey(diff, lowEffort), cacheKey(diff, highEffort));
+assert.notEqual(cacheKey(diff, member), cacheKey(diff, lowEffort));
+
+// --- default effort leaves the HTTP body byte-identical ---
+const legacyBody = JSON.stringify({
+  model: member.model,
+  messages: [
+    { role: "system", content: buildRequestBody(member, diff).messages[0].content },
+    { role: "user", content: `PR diff:\n\n${diff}` },
+  ],
+});
+assert.equal(JSON.stringify(buildRequestBody(member, diff)), legacyBody);
+
+// --- configured effort reaches the wire when the route supports it ---
+const configured = { ...member, effortConfigured: true, effortPosition: 0 };
+const wired = buildRequestBody(configured, diff);
+assert.equal(wired.reasoning_effort, "low");
+
+// --- invalid env stays visible on the member ---
+const saved = process.env.CORRECTNESS_EFFORT;
+try {
+  process.env.CORRECTNESS_EFFORT = "high-ish";
+  const [parsed] = withLensEffort([member]);
+  assert.match(String(parsed.effortParseError), /invalid CORRECTNESS_EFFORT: high-ish/);
+} finally {
+  if (saved === undefined) delete process.env.CORRECTNESS_EFFORT;
+  else process.env.CORRECTNESS_EFFORT = saved;
+}
+
+console.log("lens effort tests passed");

--- a/scripts/model-effort-ladders.mjs
+++ b/scripts/model-effort-ladders.mjs
@@ -1,0 +1,61 @@
+// Published reasoning-effort ladders for council models. Ascending order only —
+// the array IS the scale. Match rules are checked in order; first hit wins.
+
+import { offeredRungs, resolveRung } from "./lens-effort.mjs";
+
+const GPT_LADDER = ["none", "low", "medium", "high", "xhigh", "max"];
+const GEMINI_LADDER = ["low", "medium", "high"];
+const KIMI_K3_LADDER = ["low", "high", "max"];
+const GROK_LADDER = ["low", "medium", "high"];
+const CLAUDE_LADDER = ["low", "medium", "high", "xhigh", "max"];
+
+/** @type {ReadonlyArray<{ test: (id: string) => boolean, direct: readonly string[], openrouter?: readonly string[] }>} */
+const LADDER_RULES = [
+  { test: (id) => id.includes("gpt-5.6") || id === "gpt-5.6", direct: GPT_LADDER, openrouter: GPT_LADDER },
+  { test: (id) => id.includes("gemini-3.1-pro"), direct: GEMINI_LADDER, openrouter: GEMINI_LADDER },
+  { test: (id) => id.includes("kimi-k3"), direct: KIMI_K3_LADDER, openrouter: KIMI_K3_LADDER },
+  { test: (id) => id.includes("grok-4"), direct: GROK_LADDER, openrouter: GROK_LADDER },
+  {
+    test: (id) => id.includes("claude-sonnet") || id.includes("claude-opus") || id.includes("claude-fable"),
+    direct: CLAUDE_LADDER,
+    openrouter: CLAUDE_LADDER,
+  },
+];
+
+/** @param {{ provider: string, model: string }} member */
+function useOpenRouterRoute(member) {
+  return member.provider === "openrouter";
+}
+
+/**
+ * @param {{ provider: string, model: string }} member
+ * @returns {readonly string[] | undefined}
+ */
+export function publishedLadder(member) {
+  const id = String(member.model || "").toLowerCase();
+  for (const rule of LADDER_RULES) {
+    if (!rule.test(id)) continue;
+    if (useOpenRouterRoute(member)) return rule.openrouter ?? rule.direct;
+    return rule.direct;
+  }
+  return undefined;
+}
+
+/** @param {{ provider: string, model: string, effortPosition?: number, effortConfigured?: boolean }} member */
+export function resolveMemberRung(member) {
+  if (!member.effortConfigured || member.effortPosition === undefined) return undefined;
+  const published = publishedLadder(member);
+  if (!published) return undefined;
+  return resolveRung({ position: member.effortPosition, published });
+}
+
+/** @type {ReadonlyArray<{ name: string, published: readonly string[] }>} */
+export const LADDERS_FOR_TESTS = [
+  { name: "gpt-5.6", published: GPT_LADDER },
+  { name: "gemini-3.1-pro", published: GEMINI_LADDER },
+  { name: "kimi-k3", published: KIMI_K3_LADDER },
+  { name: "grok-4.5", published: GROK_LADDER },
+  { name: "claude-sonnet-5", published: CLAUDE_LADDER },
+];
+
+export { offeredRungs };


### PR DESCRIPTION
Closes #135

## What

A per-lens reasoning effort, stored as a **position on [0,1]** rather than a rung name, resolved into each model's own published ladder at call time. Set with `CORRECTNESS_EFFORT`, `PERFORMANCE_EFFORT`, `SECURITY_EFFORT`, `MAINTAINABILITY_EFFORT`, `SCOPE_EFFORT`, `MUTATION_EFFORT`.

```bash
export MAINTAINABILITY_EFFORT=low
export SECURITY_EFFORT=high
```

## Why

A position rather than a rung name, because `high` is one model's floor and another's midpoint, and models publish their own rung names. A stored name goes stale the moment the model underneath changes — and here it changes **without anyone editing the effort setting**, because `OPENAI_MODEL`, `GEMINI_MODEL`, `SCOPE_MODEL`, `MUTATION_MODEL` and `COUNCIL_MODELS` can each repoint a lens's model. A position is a lookup into the model's own ladder, so the result is always a rung that model actually offers.

Routing (#130) cut member calls by 9% across the last 40 merged PRs here, and 53% of PRs still dispatch all five lenses. Per-call cost is the remaining lever.

## The blocker, handled

`cacheKey` did not include effort. Without that the feature is inert **and silently so**: raise a lens from cheap to expensive and the cached cheap completion comes back, with no error. Verified directly:

```
unset  e0ee44d31fac426c  pos undefined
low    30d46025a24e2b83  pos 0
high   6e25549cd0a05ae7  pos 0.5
max    40129b96dafc5ecc  pos 1
```

## How I verified

npm test -> 31 tests, 31 pass, 0 fail; selfcheck ok; chair-fallback selfcheck passed; exit 0

node --test scripts/*.test.mjs -> 31 tests, 31 pass, 0 fail

Rounds **down**, so it never overspends:

```
pos 0.4 / 0.49 on [low,medium,high] -> low
pos 0.5 / 0.9                       -> medium
pos 1                               -> high
```

A rung's own position round-trips back to itself across every ladder defined. `minimal` and `none` are excluded from the offered rungs on purpose — they mean "do not reason", which no review wants — so `minimal` correctly has no position.

A typo stays visible instead of silently becoming a level: `hgh`, `""`, `2`, `-1` all parse to `undefined`; `medium` -> 0.25, `0.75` -> 0.75.

**Ships inert.** With no effort set, `effortWireExtras` returns `null` and the request body is unchanged, so no existing call changes until somebody opts in:

```
effortWireExtras(unset) -> null
effortWireExtras(low)   -> {"reasoning_effort":"low"}
```

Mutation-tested by the implementing worker and confirmed here: removing the effort segment from the cache key makes the cache-key tests fail; rounding up instead of down gives `AssertionError: high !== medium`.

`npx oxlint` on the four touched/new scripts — no warnings.

Providers wired: OpenRouter (`reasoning.effort`), OpenAI / Gemini / Moonshot (`reasoning_effort`), and the Claude CLI seats via their own rung flag. A provider with no documented effort parameter sends its request **unchanged** rather than a field the API would reject.


### Re-verified at HEAD (6b6bbac)

The figures above were regenerated at the final commit after the council flagged that they predated three later ones. That mattered: the cache-key hex values **changed**, because `3bea48e` re-keyed the cache on the resolved rung rather than the raw position. The previously published fixtures no longer reproduced — they were not merely a stale count.

A later commit also fixed an inherited-property-name parse (`CORRECTNESS_EFFORT=constructor` returned the `Object` constructor, and the effort was then dropped silently). Eleven inherited names are now covered:

```
constructor / __proto__ / __defineGetter__ / hasOwnProperty / toString -> undefined
med -> 0.25   medium -> 0.25   0.75 -> 0.75
```

Council coverage this cycle was thin — performance and maintainability both timed out with no review — so the effective review was the chair plus these checks. Worth recording rather than reading four "no findings" as four clean passes.

Proof: n/a — no user-visible surface. The evidence is the output above.

Assisted-by: cursor:composer-2.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable reasoning-effort levels for supported AI models.
  * Added model-specific effort settings across supported providers and CLI requests.
  * Added support for named and numeric effort levels, with validation and provider-specific translation.
  * Added published effort levels for GPT, Gemini, Kimi, Grok, and Claude models.
  * Ensured responses using different effort settings are cached separately.

* **Bug Fixes**
  * Prevented invalid effort configurations from being sent for execution.
  * Preserved existing request behavior when no effort level is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->