### PR TITLE
[VCR-141] Count a skip marker only at line start

### DIFF
--- a/scripts/vibetrace-records.mjs
+++ b/scripts/vibetrace-records.mjs
@@ -1,5 +1,4 @@
 // vibetrace record builders — council cost/routing plus defect measurement.
-import fs from "node:fs";
 import { parseFindings } from "./file-findings.mjs";
 import { countAddedLines } from "./review-delta.mjs";
 
@@ -9,6 +8,10 @@ export const SCHEMA_VERSION = "0.2.0";
 // review out of the `full` bucket; the table below only refines WHICH skip.
 export const SKIP_PREFIX = "_Council skipped:";
 
+// Written by council-review.mjs's top-level catch. A run that threw is not a
+// quiet success, so it must not fall through to `full`/`delta` either.
+export const ERROR_PREFIX = "_Council errored:";
+
 const SKIP_MARKERS = {
   trivial: "_Council skipped: trivial delta",
   "no-lenses": "_Council skipped: no configured lens applies",
@@ -17,7 +20,7 @@ const SKIP_MARKERS = {
   "no-members": "_Council skipped: COUNCIL_MODELS parsed to no valid members",
 };
 
-/** @typedef {"full"|"delta"|"trivial"|"no-lenses"|"no-keys"|"no-diff"|"no-members"|"skipped"} ReviewStrength */
+/** @typedef {"full"|"delta"|"trivial"|"no-lenses"|"no-keys"|"no-diff"|"no-members"|"skipped"|"errored"} ReviewStrength */
 
 /**
  * @param {string} markdown @param {"full"|"delta"} mode @returns {ReviewStrength}
@@ -27,22 +30,26 @@ const SKIP_MARKERS = {
  * ran, so a skip path added later that nobody added a marker for must not
  * silently land in the `full` bucket and read as "reviewed, found nothing".
  * `skipped` is deliberately coarse: it is honest about not knowing which gate
- * fired, which a wrong-but-specific answer would not be.
+ * fired, which a wrong-but-specific answer would not be. A run that errored
+ * out is checked first and separately, for the same reason: a crash is not a
+ * review that found nothing either.
+ *
+ * Only a line that BEGINS with a marker counts. The engine always writes each
+ * marker as its own line; a finding that merely quotes one is reviewer
+ * content. That distinction is load-bearing on this repo in particular, where
+ * the council reviews the very code these strings live in — an unanchored
+ * match turned a real full review with a genuine finding into `trivial`.
  */
 export function detectStrength(markdown, mode) {
-  // Only a line that BEGINS with the marker counts. The engine always writes it
-  // as its own line; a finding that merely quotes it is reviewer content. That
-  // distinction is load-bearing on this repo in particular, where the council
-  // reviews the very code these strings live in — an unanchored match turned a
-  // real full review with a genuine finding into `trivial`.
   const lines = String(markdown || "").split("\n");
-  const isSkipLine = (line) => line.trimStart().startsWith(SKIP_PREFIX);
+  const startsWithAnchored = (line, marker) => line.trimStart().startsWith(marker);
+  if (lines.some((line) => startsWithAnchored(line, ERROR_PREFIX))) return "errored";
   for (const [strength, marker] of Object.entries(SKIP_MARKERS)) {
-    if (lines.some((line) => isSkipLine(line) && line.trimStart().startsWith(marker))) {
+    if (lines.some((line) => startsWithAnchored(line, marker))) {
       return /** @type {ReviewStrength} */ (strength);
     }
   }
-  if (lines.some(isSkipLine)) return "skipped";
+  if (lines.some((line) => startsWithAnchored(line, SKIP_PREFIX))) return "skipped";
   return mode === "delta" ? "delta" : "full";
 }
 
@@ -100,10 +107,3 @@ export function buildCouncilRecord(input) {
     },
   };
 }
-
-/**
- * @param {{
- *   verdictsPath?: string,
- *   attribution: Record<string, unknown>,
- * }} input
- */

--- a/scripts/vibetrace-records.mjs
+++ b/scripts/vibetrace-records.mjs
@@ -1,4 +1,5 @@
 // vibetrace record builders — council cost/routing plus defect measurement.
+import fs from "node:fs";
 import { parseFindings } from "./file-findings.mjs";
 import { countAddedLines } from "./review-delta.mjs";
 
@@ -8,10 +9,6 @@ export const SCHEMA_VERSION = "0.2.0";
 // review out of the `full` bucket; the table below only refines WHICH skip.
 export const SKIP_PREFIX = "_Council skipped:";
 
-// Written by council-review.mjs's top-level catch. A run that threw is not a
-// quiet success, so it must not fall through to `full`/`delta` either.
-export const ERROR_PREFIX = "_Council errored:";
-
 const SKIP_MARKERS = {
   trivial: "_Council skipped: trivial delta",
   "no-lenses": "_Council skipped: no configured lens applies",
@@ -20,7 +17,7 @@ const SKIP_MARKERS = {
   "no-members": "_Council skipped: COUNCIL_MODELS parsed to no valid members",
 };
 
-/** @typedef {"full"|"delta"|"trivial"|"no-lenses"|"no-keys"|"no-diff"|"no-members"|"skipped"|"errored"} ReviewStrength */
+/** @typedef {"full"|"delta"|"trivial"|"no-lenses"|"no-keys"|"no-diff"|"no-members"|"skipped"} ReviewStrength */
 
 /**
  * @param {string} markdown @param {"full"|"delta"} mode @returns {ReviewStrength}
@@ -30,17 +27,22 @@ const SKIP_MARKERS = {
  * ran, so a skip path added later that nobody added a marker for must not
  * silently land in the `full` bucket and read as "reviewed, found nothing".
  * `skipped` is deliberately coarse: it is honest about not knowing which gate
- * fired, which a wrong-but-specific answer would not be. A run that errored
- * out is checked first and separately, for the same reason: a crash is not a
- * review that found nothing either.
+ * fired, which a wrong-but-specific answer would not be.
  */
 export function detectStrength(markdown, mode) {
-  const text = String(markdown || "");
-  if (text.includes(ERROR_PREFIX)) return "errored";
+  // Only a line that BEGINS with the marker counts. The engine always writes it
+  // as its own line; a finding that merely quotes it is reviewer content. That
+  // distinction is load-bearing on this repo in particular, where the council
+  // reviews the very code these strings live in — an unanchored match turned a
+  // real full review with a genuine finding into `trivial`.
+  const lines = String(markdown || "").split("\n");
+  const isSkipLine = (line) => line.trimStart().startsWith(SKIP_PREFIX);
   for (const [strength, marker] of Object.entries(SKIP_MARKERS)) {
-    if (text.includes(marker)) return /** @type {ReviewStrength} */ (strength);
+    if (lines.some((line) => isSkipLine(line) && line.trimStart().startsWith(marker))) {
+      return /** @type {ReviewStrength} */ (strength);
+    }
   }
-  if (text.includes(SKIP_PREFIX)) return "skipped";
+  if (lines.some(isSkipLine)) return "skipped";
   return mode === "delta" ? "delta" : "full";
 }
 
@@ -98,3 +100,10 @@ export function buildCouncilRecord(input) {
     },
   };
 }
+
+/**
+ * @param {{
+ *   verdictsPath?: string,
+ *   attribution: Record<string, unknown>,
+ * }} input
+ */

--- a/scripts/vibetrace-records.test.mjs
+++ b/scripts/vibetrace-records.test.mjs
@@ -78,16 +78,6 @@ if (detectStrength("# x\n", "delta") !== "delta") {
   console.error("FAIL detectStrength delta");
   failed++;
 }
-
-// A run that threw (council-review.mjs's top-level catch) is not a quiet
-// full/delta success and must not be recorded as one.
-const erroredMd = "# 🧑‍⚖️ LLM Council findings\n\n_Council errored: boom_\n";
-if (detectStrength(erroredMd, "full") !== "errored" || detectStrength(erroredMd, "delta") !== "errored") {
-  console.error("FAIL detectStrength must classify an errored run as `errored`, not full/delta");
-  failed++;
-} else {
-  console.log("ok - strength=errored for a run that threw");
-}
 fs.rmSync(tmp, { recursive: true, force: true });
 
 // --- strength must never mistake a skipped review for a full one ----------
@@ -116,5 +106,26 @@ fs.rmSync(tmp, { recursive: true, force: true });
     console.log(`ok - all ${written.length} engine skip paths record outside full/delta`);
   }
 }
+// A finding that QUOTES a skip marker is reviewer content, not a skip. This
+// repo's council reviews the code these strings live in, so an unanchored
+// match turned a real full review with a genuine finding into `trivial`.
+{
+  const quoted = [
+    "# 🧑‍⚖️ LLM Council findings", "",
+    "## GPT-5.6 (Codex) — correctness lens", "",
+    "- `scripts/vibetrace-records.mjs:20` — the `_Council skipped: trivial delta` marker is matched anywhere in the body -> anchor it to line start.",
+    "",
+  ].join("\n");
+  if (detectStrength(quoted, "full") !== "full") {
+    console.error("FAIL a finding quoting a skip marker must stay `full`, got", detectStrength(quoted, "full"));
+    failed++;
+  } else if (detectStrength("# h\n\n  _Council skipped: empty diff._\n", "full") !== "no-diff") {
+    console.error("FAIL an indented real skip line must still be detected");
+    failed++;
+  } else {
+    console.log("ok - a quoted skip marker is content, an anchored one is a skip");
+  }
+}
+
 console.log("vibetrace-records tests passed");
 if (failed) process.exit(1);

--- a/scripts/vibetrace-records.test.mjs
+++ b/scripts/vibetrace-records.test.mjs
@@ -78,6 +78,16 @@ if (detectStrength("# x\n", "delta") !== "delta") {
   console.error("FAIL detectStrength delta");
   failed++;
 }
+
+// A run that threw (council-review.mjs's top-level catch) is not a quiet
+// full/delta success and must not be recorded as one.
+const erroredMd = "# 🧑‍⚖️ LLM Council findings\n\n_Council errored: boom_\n";
+if (detectStrength(erroredMd, "full") !== "errored" || detectStrength(erroredMd, "delta") !== "errored") {
+  console.error("FAIL detectStrength must classify an errored run as `errored`, not full/delta");
+  failed++;
+} else {
+  console.log("ok - strength=errored for a run that threw");
+}
 fs.rmSync(tmp, { recursive: true, force: true });
 
 // --- strength must never mistake a skipped review for a full one ----------


### PR DESCRIPTION
Closes #141

## What

`detectStrength` now matches a skip marker only on a line that begins with it. Leading whitespace is still tolerated.

## Why

Live on main since #134 merged. The markers were matched **anywhere** in the report body, so a finding whose text quotes one flipped a full review into a skipped one.

Not hypothetical on this repo — the council reviews the code these strings live in, so a review that mentions `_Council skipped:` is normal. Reproduced against the merged code:

```
## GPT — correctness lens

- `a.mjs:20` — the `_Council skipped: trivial delta` marker is matched anywhere -> anchor it.
```

```
MAIN (before fix): trivial      <- a full review with a real finding
WITH FIX         : full
real skip still  : no-diff      <- genuine skips unaffected
```

This points the **opposite way** to the defect `strength` was added to prevent. There a skipped review read as `full`; here a full review with findings reads as skipped, so its findings get discounted as low-evidence by anything reading the field — including the promotion counter in #129. Both directions corrupt the same measurement.

Found by CodeRabbit on #134. The fix was written and pushed to that branch, but #134 merged before it landed, so it needs its own PR.

## How I verified

npm test -> exit 0

node --test scripts/*.test.mjs -> 29 tests, 29 pass, 0 fail

Reproduced the bug against the merged code first (stashing the fix), then confirmed it resolved — output above. A genuine skip line, indented or not, still resolves to its specific strength.

Mutation-tested: replacing the line-start predicate with one that always returns true gives `FAIL a finding quoting a skip marker must stay full, got skipped`, exit 1.

Proof: n/a — telemetry logic and a test. The evidence is the output above.

Assisted-by: claude-personal:claude-opus-5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Review classification now ignores error and skip markers embedded within quoted or inline text.
  - Indented standalone skip markers continue to be recognized correctly.
  - Error markers take precedence over skip markers when both are present.

- **Tests**
  - Added regression coverage for quoted markers and indented skip lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->