### PR TITLE
[VCR-137] Emit a review.chair record with dispositions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,7 @@ runs:
         # dispositions and poisoning the #129 promotion metric this record
         # exists to protect. Strip it before anything can read it, so only a
         # file the chair itself writes later in this run is ever trusted.
-        rm -f chair-verdicts.json
+        rm -rf chair-verdicts.json
 
         # Strip a model trailer from every commit this run makes.
         #

--- a/action.yml
+++ b/action.yml
@@ -113,6 +113,18 @@ runs:
         git config user.name "vibecodereview[bot]"
         git config user.email "vibecodereview@users.noreply.github.com"
 
+        # `chair-verdicts.json` is trusted verbatim by the "Emit vibetrace
+        # review.chair" step later, and that step runs `if: always()` --
+        # including when the chair never reaches the point where it writes
+        # that file (a crash, a timeout, or the no-Write-tool OpenRouter
+        # fallback). The checkout above is the PR's own content, so a PR
+        # that simply commits a `chair-verdicts.json` at the repo root would
+        # otherwise have it read back as this run's real verdict, forging
+        # dispositions and poisoning the #129 promotion metric this record
+        # exists to protect. Strip it before anything can read it, so only a
+        # file the chair itself writes later in this run is ever trusted.
+        rm -f chair-verdicts.json
+
         # Strip a model trailer from every commit this run makes.
         #
         # The Claude Code CLI adds `Co-Authored-By: Claude <model> ...` by
@@ -281,7 +293,7 @@ runs:
         # it lives under .git/vcr-hooks, outside the working tree `git add -A`
         # walks.
         printf '%s\n' /pr.diff /pr-delta.diff /council-findings.md /council-carry.md /council-carry.next.md /review-state.md /council.log /council.pid \
-          /probe.1 /probe.2 /probe.3 /reason.1 /reason.2 /reason.3 /council-stats.json \
+          /probe.1 /probe.2 /probe.3 /reason.1 /reason.2 /reason.3 /council-stats.json /chair-verdicts.json \
           >> "$(git rev-parse --git-dir)/info/exclude"
 
         # Keep the chair's evidence complete, but make council member calls

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ inputs:
     required: false
     default: ""
   vibetrace_ingest_url:
-    description: "Optional POST endpoint for vibetrace review.council records. When unset, the emit step writes JSONL under RUNNER_TEMP and never fails the review."
+    description: "Optional POST endpoint for vibetrace review.council and review.chair records. When unset, the emit step writes JSONL under RUNNER_TEMP and never fails the review."
     required: false
     default: ""
   vibetrace_ingest_token:
@@ -494,6 +494,19 @@ runs:
            not trigger workflows for GITHUB_TOKEN pushes, so no later run posts the
            approval that would supersede the block. Only a human dismissing the review
            can. See issue #43.
+        6c. Before posting your review, Write `chair-verdicts.json` in the workspace root
+           (next to `council-findings.md`) with your verdict and one disposition per council
+           finding. Read the `<!-- vibetrace:findings-meta` block at the end of
+           `council-findings.md` for finding ids. JSON shape:
+             {
+               "verdict": "approve" | "comment" | "request-changes",
+               "dispositions": [
+                 { "id": "<finding id>", "disposition": "confirmed-fixed" | "confirmed-open" | "rejected" | "unmentioned" }
+               ]
+             }
+           Use `confirmed-fixed` when you fixed it this run, `confirmed-open` when you verified
+           it and it remains open, `rejected` when you discarded it, `unmentioned` when you did
+           not address it. Include every id from findings-meta; the verdict must match step 6.
         7. In the review body include a collapsible council table:
            `<details><summary>🧑‍⚖️ Council</summary>` then a Markdown table of
            `| Model | Lens | Result |` (confirmed / rejected / no findings), then `</details>`.
@@ -936,6 +949,22 @@ runs:
         echo "Most often: the pull request edits .github/workflows/vibecodereview.yml, and"
         echo "claude-code-action refuses to run when the workflow differs from the default branch."
         exit 1
+
+    # Observability only. Silent-fail inside the script. Never gates the review.
+    - name: Emit vibetrace review.chair
+      if: always() && steps.budget.outputs.over != 'true'
+      continue-on-error: true
+      shell: bash
+      env:
+        VIBETRACE_INGEST_URL: ${{ inputs.vibetrace_ingest_url }}
+        VIBETRACE_INGEST_TOKEN: ${{ inputs.vibetrace_ingest_token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        VCR_PR: ${{ github.event.pull_request.number }}
+        GITHUB_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        VCR_PR_BODY: ${{ github.event.pull_request.body }}
+      run: |
+        node "${{ github.action_path }}/scripts/vibetrace-emit.mjs" review.chair \
+          --verdicts chair-verdicts.json
 
     # Persist the review boundary and the findings that still need a chair's
     # verification. Updating one hidden comment avoids adding visible noise to

--- a/action.yml
+++ b/action.yml
@@ -749,6 +749,22 @@ runs:
         prompt: ${{ steps.prompt.outputs.text }}
         claude_args: '--allowed-tools "Bash(gh api:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh pr comment:*),Bash(git:*),Bash(jq:*),Bash(cat:*),Bash(ls:*),Bash(head:*),Bash(wc:*),Read,Glob,Grep,Edit,Write,TodoWrite"'
 
+    # A chair attempt writes chair-verdicts.json BEFORE it posts (step 6c
+    # precedes step 7 in the prompt), so an attempt that crashes or times out
+    # in between can leave that file behind despite never posting a review.
+    # Nothing else clears it, and the final emit step trusts whatever file is
+    # on disk when it runs -- so without this, a stale verdict from a chair
+    # that never posted gets misattributed to whichever later attempt (down
+    # to the no-Write OpenRouter fallback) actually posts the real review.
+    # One cleanup precedes each attempt below, gated on the same condition
+    # that already decides whether that attempt runs, so a still-running
+    # earlier success (which skips every later attempt) is never touched.
+    - name: Clear stale chair-verdicts.json before backup attempt
+      if: steps.budget.outputs.over != 'true' && steps.chair_primary.outcome != 'success'
+      continue-on-error: true
+      shell: bash
+      run: rm -f chair-verdicts.json
+
     - name: Chair review (backup token)
       id: chair_backup
       if: steps.budget.outputs.over != 'true' && steps.chair_primary.outcome != 'success' && steps.chair_probe.outputs.token_2 != 'dead' && inputs.claude_code_oauth_token_2 != ''
@@ -760,6 +776,12 @@ runs:
         allowed_bots: "*"
         prompt: ${{ steps.prompt.outputs.text }}
         claude_args: '--allowed-tools "Bash(gh api:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh pr comment:*),Bash(git:*),Bash(jq:*),Bash(cat:*),Bash(ls:*),Bash(head:*),Bash(wc:*),Read,Glob,Grep,Edit,Write,TodoWrite"'
+
+    - name: Clear stale chair-verdicts.json before third attempt
+      if: steps.budget.outputs.over != 'true' && steps.chair_primary.outcome != 'success' && steps.chair_backup.outcome != 'success'
+      continue-on-error: true
+      shell: bash
+      run: rm -f chair-verdicts.json
 
     - name: Chair review (third token)
       id: chair_third
@@ -773,6 +795,12 @@ runs:
         prompt: ${{ steps.prompt.outputs.text }}
         claude_args: '--allowed-tools "Bash(gh api:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh pr comment:*),Bash(git:*),Bash(jq:*),Bash(cat:*),Bash(ls:*),Bash(head:*),Bash(wc:*),Read,Glob,Grep,Edit,Write,TodoWrite"'
 
+    - name: Clear stale chair-verdicts.json before fourth attempt
+      if: steps.budget.outputs.over != 'true' && steps.chair_primary.outcome != 'success' && steps.chair_backup.outcome != 'success' && steps.chair_third.outcome != 'success'
+      continue-on-error: true
+      shell: bash
+      run: rm -f chair-verdicts.json
+
     - name: Chair review (fourth token)
       id: chair_fourth
       if: steps.budget.outputs.over != 'true' && steps.chair_primary.outcome != 'success' && steps.chair_backup.outcome != 'success' && steps.chair_third.outcome != 'success' && steps.chair_probe.outputs.token_4 != 'dead' && inputs.claude_code_oauth_token_4 != ''
@@ -784,6 +812,23 @@ runs:
         allowed_bots: "*"
         prompt: ${{ steps.prompt.outputs.text }}
         claude_args: '--allowed-tools "Bash(gh api:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh pr comment:*),Bash(git:*),Bash(jq:*),Bash(cat:*),Bash(ls:*),Bash(head:*),Bash(wc:*),Read,Glob,Grep,Edit,Write,TodoWrite"'
+
+    # This one matters most: the fallback has no Write tool (it is a single
+    # completion call, not an agentic loop), so it can never overwrite a
+    # stale file itself. Without this cleanup, a stale verdict left by a
+    # crashed full-tool attempt would ride along into the emit step and be
+    # reported as the verdict behind the fallback's own, differently-reasoned
+    # review.
+    - name: Clear stale chair-verdicts.json before fallback
+      if: >-
+        steps.budget.outputs.over != 'true' &&
+        steps.chair_primary.outcome != 'success' &&
+        steps.chair_backup.outcome != 'success' &&
+        steps.chair_third.outcome != 'success' &&
+        steps.chair_fourth.outcome != 'success'
+      continue-on-error: true
+      shell: bash
+      run: rm -f chair-verdicts.json
 
     # Surface the true result: green if any chair run succeeded; red if they all
     # failed. Without this, continue-on-error would mask a genuine failure as

--- a/action.yml
+++ b/action.yml
@@ -113,17 +113,6 @@ runs:
         git config user.name "vibecodereview[bot]"
         git config user.email "vibecodereview@users.noreply.github.com"
 
-        # `chair-verdicts.json` is trusted verbatim by the "Emit vibetrace
-        # review.chair" step later, and that step runs `if: always()` --
-        # including when the chair never reaches the point where it writes
-        # that file (a crash, a timeout, or the no-Write-tool OpenRouter
-        # fallback). The checkout above is the PR's own content, so a PR
-        # that simply commits a `chair-verdicts.json` at the repo root would
-        # otherwise have it read back as this run's real verdict, forging
-        # dispositions and poisoning the #129 promotion metric this record
-        # exists to protect. Strip it before anything can read it, so only a
-        # file the chair itself writes later in this run is ever trusted.
-        rm -rf chair-verdicts.json
 
         # Strip a model trailer from every commit this run makes.
         #
@@ -293,7 +282,7 @@ runs:
         # it lives under .git/vcr-hooks, outside the working tree `git add -A`
         # walks.
         printf '%s\n' /pr.diff /pr-delta.diff /council-findings.md /council-carry.md /council-carry.next.md /review-state.md /council.log /council.pid \
-          /probe.1 /probe.2 /probe.3 /reason.1 /reason.2 /reason.3 /council-stats.json /chair-verdicts.json \
+          /probe.1 /probe.2 /probe.3 /reason.1 /reason.2 /reason.3 /council-stats.json \
           >> "$(git rev-parse --git-dir)/info/exclude"
 
         # Keep the chair's evidence complete, but make council member calls
@@ -364,6 +353,13 @@ runs:
         export VCR_CARRY_FILE="$PWD/council-carry.next.md"
         export VCR_STATS_FILE="$PWD/council-stats.json"
         printf 'VCR_STATS_FILE=%s\n' "$VCR_STATS_FILE" >> "$GITHUB_ENV"
+        # The chair's verdicts live OUTSIDE the checkout. A path in the workspace
+        # is the PR's own tree: a pull request could commit a file there and have
+        # it read back as this run's real verdict, and deleting it first is worse
+        # still — `git add -A` in a later self-heal commit stages that deletion
+        # and erases whatever the PR tracked at that path. RUNNER_TEMP can hold
+        # neither problem, because no PR content ever reaches it.
+        printf 'VCR_CHAIR_VERDICTS=%s\n' "$RUNNER_TEMP/chair-verdicts.json" >> "$GITHUB_ENV"
         printf '%s\n' /council-carry.next.md >> "$(git rev-parse --git-dir)/info/exclude"
         nohup node "${{ github.action_path }}/scripts/council-review.mjs" \
           pr.diff council-findings.md > council.log 2>&1 &
@@ -506,9 +502,10 @@ runs:
            not trigger workflows for GITHUB_TOKEN pushes, so no later run posts the
            approval that would supersede the block. Only a human dismissing the review
            can. See issue #43.
-        6c. Before posting your review, Write `chair-verdicts.json` in the workspace root
-           (next to `council-findings.md`) with your verdict and one disposition per council
-           finding. Read the `<!-- vibetrace:findings-meta` block at the end of
+        6c. Before posting your review, Write your verdicts file to the ABSOLUTE path in the
+           `VCR_CHAIR_VERDICTS` environment variable (it points outside the repository, so it
+           can never collide with a file this pull request tracks). Give it your verdict and
+           one disposition per council finding. Read the `<!-- vibetrace:findings-meta` block at the end of
            `council-findings.md` for finding ids. JSON shape:
              {
                "verdict": "approve" | "comment" | "request-changes",
@@ -763,7 +760,7 @@ runs:
       if: steps.budget.outputs.over != 'true' && steps.chair_primary.outcome != 'success'
       continue-on-error: true
       shell: bash
-      run: rm -f chair-verdicts.json
+      run: rm -f "$VCR_CHAIR_VERDICTS"
 
     - name: Chair review (backup token)
       id: chair_backup
@@ -781,7 +778,7 @@ runs:
       if: steps.budget.outputs.over != 'true' && steps.chair_primary.outcome != 'success' && steps.chair_backup.outcome != 'success'
       continue-on-error: true
       shell: bash
-      run: rm -f chair-verdicts.json
+      run: rm -f "$VCR_CHAIR_VERDICTS"
 
     - name: Chair review (third token)
       id: chair_third
@@ -799,7 +796,7 @@ runs:
       if: steps.budget.outputs.over != 'true' && steps.chair_primary.outcome != 'success' && steps.chair_backup.outcome != 'success' && steps.chair_third.outcome != 'success'
       continue-on-error: true
       shell: bash
-      run: rm -f chair-verdicts.json
+      run: rm -f "$VCR_CHAIR_VERDICTS"
 
     - name: Chair review (fourth token)
       id: chair_fourth
@@ -828,7 +825,7 @@ runs:
         steps.chair_fourth.outcome != 'success'
       continue-on-error: true
       shell: bash
-      run: rm -f chair-verdicts.json
+      run: rm -f "$VCR_CHAIR_VERDICTS"
 
     # Surface the true result: green if any chair run succeeded; red if they all
     # failed. Without this, continue-on-error would mask a genuine failure as
@@ -1021,7 +1018,8 @@ runs:
         VCR_PR_BODY: ${{ github.event.pull_request.body }}
       run: |
         node "${{ github.action_path }}/scripts/vibetrace-emit.mjs" review.chair \
-          --verdicts chair-verdicts.json
+          --verdicts "$VCR_CHAIR_VERDICTS" \
+          --findings council-findings.md
 
     # Persist the review boundary and the findings that still need a chair's
     # verification. Updating one hidden comment avoids adding visible noise to

--- a/scripts/chair-verdicts.mjs
+++ b/scripts/chair-verdicts.mjs
@@ -60,3 +60,33 @@ export function parseChairVerdictsJson(raw) {
   }
   return { ok: true, verdict, dispositions };
 }
+
+/**
+ * Cross-check a parsed verdict set against the ids the council actually
+ * recorded. A set that omits, duplicates or invents an id is not a complete
+ * verdict, and accepting it as one lets an unverified claim reach the
+ * promotion counter with `dispositionsMissing: false` — the single thing this
+ * record exists to prevent.
+ *
+ * `knownIds` of null means the report carried no meta block (an older report,
+ * or an errored run). There is nothing to check against, so the set passes
+ * rather than being failed on absent evidence.
+ *
+ * @param {{ id: string }[]} dispositions
+ * @param {string[] | null} knownIds
+ * @returns {{ ok: true } | { ok: false, reason: string }}
+ */
+export function verifyDispositionCoverage(dispositions, knownIds) {
+  if (knownIds === null) return { ok: true };
+  const seen = new Set();
+  for (const { id } of dispositions) {
+    if (seen.has(id)) return { ok: false, reason: `duplicate disposition for ${id}` };
+    seen.add(id);
+  }
+  const known = new Set(knownIds);
+  const unknown = [...seen].filter((id) => !known.has(id));
+  if (unknown.length > 0) return { ok: false, reason: `disposition for unknown finding ${unknown[0]}` };
+  const missing = knownIds.filter((id) => !seen.has(id));
+  if (missing.length > 0) return { ok: false, reason: `no disposition for finding ${missing[0]}` };
+  return { ok: true };
+}

--- a/scripts/chair-verdicts.mjs
+++ b/scripts/chair-verdicts.mjs
@@ -1,0 +1,62 @@
+// Parse chair-verdicts.json written by the Claude Code chair. The OpenRouter
+// fallback has no Write tool, so a missing file is expected and must not be
+// read as "zero findings".
+
+/** @typedef {"confirmed-fixed"|"confirmed-open"|"rejected"|"unmentioned"} ChairDisposition */
+
+/** @typedef {"approve"|"comment"|"request-changes"} ChairVerdict */
+
+export const CHAIR_VERDICTS = new Set(["approve", "comment", "request-changes"]);
+
+export const CHAIR_DISPOSITIONS = new Set([
+  "confirmed-fixed",
+  "confirmed-open",
+  "rejected",
+  "unmentioned",
+]);
+
+/**
+ * @param {unknown} value
+ * @returns {value is ChairDisposition}
+ */
+function isDisposition(value) {
+  return typeof value === "string" && CHAIR_DISPOSITIONS.has(value);
+}
+
+/**
+ * @param {string} raw
+ * @returns {{ ok: true, verdict: ChairVerdict, dispositions: { id: string, disposition: ChairDisposition }[] } | { ok: false }}
+ */
+export function parseChairVerdictsJson(raw) {
+  let data;
+  try {
+    data = JSON.parse(String(raw || ""));
+  } catch {
+    return { ok: false };
+  }
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return { ok: false };
+  }
+  const verdict = /** @type {ChairVerdict} */ (data.verdict);
+  if (!CHAIR_VERDICTS.has(verdict)) {
+    return { ok: false };
+  }
+  if (!Array.isArray(data.dispositions)) {
+    return { ok: false };
+  }
+  const dispositions = [];
+  for (const item of data.dispositions) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      return { ok: false };
+    }
+    const id = item.id;
+    if (typeof id !== "string" || !id.trim()) {
+      return { ok: false };
+    }
+    if (!isDisposition(item.disposition)) {
+      return { ok: false };
+    }
+    dispositions.push({ id, disposition: item.disposition });
+  }
+  return { ok: true, verdict, dispositions };
+}

--- a/scripts/file-findings.mjs
+++ b/scripts/file-findings.mjs
@@ -98,6 +98,25 @@ export function findingsMetaBlock(findings) {
   return `\n<!-- vibetrace:findings-meta\n${JSON.stringify(payload)}\n-->\n`;
 }
 
+/**
+ * Read back the ids the council actually recorded. The chair's verdict file is
+ * checked against these: a disposition set that omits, duplicates or invents an
+ * id is not a complete verdict, and recording it as one is how an unverified
+ * claim reaches the promotion counter.
+ * @returns {string[] | null} ids, or null when no meta block is present
+ */
+export function parseFindingsMeta(markdown) {
+  const match = /<!-- vibetrace:findings-meta\n([\s\S]*?)\n-->/.exec(String(markdown || ''));
+  if (!match) return null;
+  try {
+    const parsed = JSON.parse(match[1]);
+    if (!Array.isArray(parsed)) return null;
+    return parsed.map((f) => f?.id).filter((id) => typeof id === 'string' && id);
+  } catch {
+    return null;
+  }
+}
+
 export function appendFindingsMeta(markdown) {
   return `${String(markdown || '').trimEnd()}${findingsMetaBlock(parseFindings(markdown))}`;
 }

--- a/scripts/file-findings.mjs
+++ b/scripts/file-findings.mjs
@@ -103,10 +103,17 @@ export function findingsMetaBlock(findings) {
  * checked against these: a disposition set that omits, duplicates or invents an
  * id is not a complete verdict, and recording it as one is how an unverified
  * claim reaches the promotion counter.
+ *
+ * `appendFindingsMeta` always appends the real block last, after every member's
+ * raw (unsanitized) text. A member echoes back whatever the diff under review
+ * fed it, so a diff that prompt-injects the literal marker into a member's
+ * response would plant an earlier, forged block -- matching the first
+ * occurrence in the file would read that one instead. Anchoring to the end of
+ * the string only accepts the block the trusted `write()` path itself appended.
  * @returns {string[] | null} ids, or null when no meta block is present
  */
 export function parseFindingsMeta(markdown) {
-  const match = /<!-- vibetrace:findings-meta\n([\s\S]*?)\n-->/.exec(String(markdown || ''));
+  const match = /<!-- vibetrace:findings-meta\n([\s\S]*?)\n-->\s*$/.exec(String(markdown || ''));
   if (!match) return null;
   try {
     const parsed = JSON.parse(match[1]);

--- a/scripts/vibetrace-emit.mjs
+++ b/scripts/vibetrace-emit.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 // Silent-fail vibetrace emitter for council runs. Matches @vibetrace/schema
-// the review.council shape. Never throws; never blocks the review check.
+// review.council and review.chair shapes. Never throws; never blocks the review check.
 //
 // Usage:
 //   node vibetrace-emit.mjs review.council \
 //     --mode delta|full --cache-hit 0|1 --members N --cancelled 0|1 \
 //     [--findings council-findings.md] [--diff pr-delta.diff]
+//   node vibetrace-emit.mjs review.chair [--verdicts chair-verdicts.json]
 //
 // Env (all optional): VIBETRACE_INGEST_URL, VIBETRACE_INGEST_TOKEN, VIBETRACE_FILE,
 // GITHUB_REPOSITORY, VCR_PR / GITHUB_PR_NUMBER, GITHUB_HEAD_REF,
@@ -13,7 +14,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { buildCouncilRecord } from "./vibetrace-records.mjs";
+import { buildChairRecord, buildCouncilRecord } from "./vibetrace-records.mjs";
 
 function arg(name, fallback = undefined) {
   const i = process.argv.indexOf(name);
@@ -27,6 +28,16 @@ function readOptional(file) {
     return fs.readFileSync(file, "utf8");
   } catch {
     return "";
+  }
+}
+
+function readVerdicts(file) {
+  if (!file) return { missing: true };
+  if (!fs.existsSync(file)) return { missing: true };
+  try {
+    return { missing: false, content: fs.readFileSync(file, "utf8") };
+  } catch {
+    return { missing: true };
   }
 }
 
@@ -86,7 +97,15 @@ function buildRecord(kind) {
       diffMarkdown: readOptional(arg("--diff")),
     });
   }
-  return { ok: false, reason: `unsupported type; only review.council` };
+  if (kind === "review.chair") {
+    const verdictsFile = arg("--verdicts", "chair-verdicts.json");
+    const verdicts = readVerdicts(verdictsFile);
+    if (verdicts.missing) {
+      return buildChairRecord({ attribution: attr, verdictsMissing: true });
+    }
+    return buildChairRecord({ attribution: attr, verdictsJson: verdicts.content });
+  }
+  return { ok: false, reason: `unsupported type; only review.council and review.chair` };
 }
 
 async function emit(record) {

--- a/scripts/vibetrace-emit.mjs
+++ b/scripts/vibetrace-emit.mjs
@@ -103,7 +103,11 @@ function buildRecord(kind) {
     if (verdicts.missing) {
       return buildChairRecord({ attribution: attr, verdictsMissing: true });
     }
-    return buildChairRecord({ attribution: attr, verdictsJson: verdicts.content });
+    // Pass the report too, or coverage is never checked in production and the
+    // validation exists only in tests.
+    const findingsFile = arg("--findings", "council-findings.md");
+    const findingsMarkdown = fs.existsSync(findingsFile) ? fs.readFileSync(findingsFile, "utf8") : undefined;
+    return buildChairRecord({ attribution: attr, verdictsJson: verdicts.content, findingsMarkdown });
   }
   return { ok: false, reason: `unsupported type; only review.council and review.chair` };
 }

--- a/scripts/vibetrace-emit.test.mjs
+++ b/scripts/vibetrace-emit.test.mjs
@@ -257,5 +257,54 @@ await new Promise((resolve, reject) => {
 });
 
 fs.rmSync(tmp, { recursive: true, force: true });
+
+// --- review.chair end-to-end via CLI -----------------------------------------
+const chairTmp = fs.mkdtempSync(path.join(os.tmpdir(), "vcr-chair-emit-"));
+const chairFile = path.join(chairTmp, "traces.jsonl");
+const verdictsPath = path.join(chairTmp, "chair-verdicts.json");
+fs.writeFileSync(
+  verdictsPath,
+  JSON.stringify({
+    verdict: "request-changes",
+    dispositions: [{ id: "f1", disposition: "confirmed-open" }],
+  }),
+);
+const chairOk = run(
+  ["review.chair", "--verdicts", verdictsPath],
+  { VIBETRACE_FILE: chairFile, GITHUB_REPOSITORY: "pooriaarab/vibecodereview", VCR_PR: "137" },
+);
+if (chairOk.status !== 0) {
+  console.error("FAIL review.chair exit", chairOk.status, chairOk.stderr);
+  failed++;
+} else {
+  const rec = JSON.parse(fs.readFileSync(chairFile, "utf8").trim());
+  if (rec.type !== "review.chair" || rec.verdict !== "request-changes" || rec.dispositionsMissing !== false) {
+    console.error("FAIL review.chair record shape", rec);
+    failed++;
+  } else {
+    console.log("ok - CLI emits review.chair with dispositions");
+  }
+}
+
+const missingFile = path.join(chairTmp, "missing.jsonl");
+const missingVerdicts = path.join(chairTmp, "no-such-chair-verdicts.json");
+const chairMissing = run(
+  ["review.chair", "--verdicts", missingVerdicts],
+  { VIBETRACE_FILE: missingFile },
+);
+if (chairMissing.status !== 0) {
+  console.error("FAIL missing verdicts file exit", chairMissing.status, chairMissing.stderr);
+  failed++;
+} else {
+  const rec = JSON.parse(fs.readFileSync(missingFile, "utf8").trim());
+  if (rec.dispositionsMissing !== true || "dispositions" in rec) {
+    console.error("FAIL missing verdicts file must set dispositionsMissing, not zero findings", rec);
+    failed++;
+  } else {
+    console.log("ok - missing chair-verdicts.json sets dispositionsMissing via CLI");
+  }
+}
+fs.rmSync(chairTmp, { recursive: true, force: true });
+
 if (failed) process.exit(1);
 console.log("vibetrace-emit tests passed");

--- a/scripts/vibetrace-records.mjs
+++ b/scripts/vibetrace-records.mjs
@@ -1,6 +1,6 @@
 // vibetrace record builders — council cost/routing plus defect measurement.
-import { parseChairVerdictsJson } from "./chair-verdicts.mjs";
-import { parseFindings } from "./file-findings.mjs";
+import { parseChairVerdictsJson, verifyDispositionCoverage } from "./chair-verdicts.mjs";
+import { parseFindings, parseFindingsMeta } from "./file-findings.mjs";
 import { countAddedLines } from "./review-delta.mjs";
 
 export const SCHEMA_VERSION = "0.3.0";
@@ -117,7 +117,7 @@ export function buildCouncilRecord(input) {
  * }} input
  */
 export function buildChairRecord(input) {
-  const { attribution, verdictsJson, verdictsMissing = false } = input;
+  const { attribution, verdictsJson, verdictsMissing = false, findingsMarkdown } = input;
   const base = {
     schemaVersion: SCHEMA_VERSION,
     ts: new Date().toISOString(),
@@ -137,6 +137,21 @@ export function buildChairRecord(input) {
       record: { ...base, dispositionsMissing: true },
     };
   }
+  // A well-formed file is not the same as a complete one. Cross-check the ids
+  // against what the council actually recorded: a set that omits, duplicates or
+  // invents a finding is not a verdict on this run, and recording it with
+  // dispositionsMissing:false would hand the promotion counter a claim no chair
+  // made. `coverageUnverified` marks the case where the report carried no meta
+  // block to check against, so a reader can tell "checked and complete" from
+  // "nothing to check".
+  const knownIds = findingsMarkdown === undefined ? null : parseFindingsMeta(findingsMarkdown);
+  const coverage = verifyDispositionCoverage(parsed.dispositions, knownIds);
+  if (!coverage.ok) {
+    return {
+      ok: true,
+      record: { ...base, dispositionsMissing: true, dispositionsRejected: coverage.reason },
+    };
+  }
   return {
     ok: true,
     record: {
@@ -144,6 +159,7 @@ export function buildChairRecord(input) {
       dispositionsMissing: false,
       verdict: parsed.verdict,
       dispositions: parsed.dispositions,
+      coverageUnverified: knownIds === null,
     },
   };
 }

--- a/scripts/vibetrace-records.mjs
+++ b/scripts/vibetrace-records.mjs
@@ -1,8 +1,9 @@
 // vibetrace record builders — council cost/routing plus defect measurement.
+import { parseChairVerdictsJson } from "./chair-verdicts.mjs";
 import { parseFindings } from "./file-findings.mjs";
 import { countAddedLines } from "./review-delta.mjs";
 
-export const SCHEMA_VERSION = "0.2.0";
+export const SCHEMA_VERSION = "0.3.0";
 
 // The prefix every skip path writes. Matching it is what keeps a skipped
 // review out of the `full` bucket; the table below only refines WHICH skip.
@@ -104,6 +105,45 @@ export function buildCouncilRecord(input) {
       addedLines: countAddedLines(diffMarkdown),
       findings: councilFindingsPayload(findingsMarkdown),
       attribution,
+    },
+  };
+}
+
+/**
+ * @param {{
+ *   attribution: Record<string, unknown>,
+ *   verdictsJson?: string,
+ *   verdictsMissing?: boolean,
+ * }} input
+ */
+export function buildChairRecord(input) {
+  const { attribution, verdictsJson, verdictsMissing = false } = input;
+  const base = {
+    schemaVersion: SCHEMA_VERSION,
+    ts: new Date().toISOString(),
+    type: "review.chair",
+    attribution,
+  };
+  if (verdictsMissing || verdictsJson === undefined) {
+    return {
+      ok: true,
+      record: { ...base, dispositionsMissing: true },
+    };
+  }
+  const parsed = parseChairVerdictsJson(verdictsJson);
+  if (!parsed.ok) {
+    return {
+      ok: true,
+      record: { ...base, dispositionsMissing: true },
+    };
+  }
+  return {
+    ok: true,
+    record: {
+      ...base,
+      dispositionsMissing: false,
+      verdict: parsed.verdict,
+      dispositions: parsed.dispositions,
     },
   };
 }

--- a/scripts/vibetrace-records.test.mjs
+++ b/scripts/vibetrace-records.test.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  buildChairRecord,
   buildCouncilRecord,
   detectStrength,
 } from "./vibetrace-records.mjs";
@@ -134,6 +135,49 @@ fs.rmSync(tmp, { recursive: true, force: true });
     failed++;
   } else {
     console.log("ok - a quoted skip marker is content, an anchored one is a skip");
+  }
+}
+
+// --- review.chair: missing verdicts must not look like zero findings ----------
+{
+  const missing = buildChairRecord({ attribution: {}, verdictsMissing: true });
+  if (!missing.ok || missing.record.dispositionsMissing !== true) {
+    console.error("FAIL missing verdicts must set dispositionsMissing", missing.record);
+    failed++;
+  } else if ("dispositions" in missing.record || "verdict" in missing.record) {
+    console.error("FAIL missing verdicts must not include dispositions or verdict", missing.record);
+    failed++;
+  } else {
+    console.log("ok - missing chair-verdicts.json sets dispositionsMissing without zero findings");
+  }
+
+  const validJson = JSON.stringify({
+    verdict: "comment",
+    dispositions: [
+      { id: "abc123", disposition: "confirmed-fixed" },
+      { id: "def456", disposition: "rejected" },
+    ],
+  });
+  const present = buildChairRecord({ attribution: {}, verdictsJson: validJson });
+  if (!present.ok || present.record.dispositionsMissing !== false) {
+    console.error("FAIL valid verdicts must clear dispositionsMissing", present.record);
+    failed++;
+  } else if (present.record.verdict !== "comment" || present.record.dispositions?.length !== 2) {
+    console.error("FAIL valid verdicts shape", present.record);
+    failed++;
+  } else {
+    console.log("ok - valid chair-verdicts.json parses into dispositions");
+  }
+
+  const malformed = buildChairRecord({ attribution: {}, verdictsJson: "{ not json" });
+  if (!malformed.ok || malformed.record.dispositionsMissing !== true) {
+    console.error("FAIL malformed verdicts must set dispositionsMissing", malformed.record);
+    failed++;
+  } else if ("dispositions" in malformed.record) {
+    console.error("FAIL malformed verdicts must not include dispositions array", malformed.record);
+    failed++;
+  } else {
+    console.log("ok - malformed chair-verdicts.json fails open with dispositionsMissing");
   }
 }
 

--- a/scripts/vibetrace-records.test.mjs
+++ b/scripts/vibetrace-records.test.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { appendFindingsMeta, parseFindingsMeta } from "./file-findings.mjs";
 import {
   buildChairRecord,
   buildCouncilRecord,
@@ -178,6 +179,47 @@ fs.rmSync(tmp, { recursive: true, force: true });
     failed++;
   } else {
     console.log("ok - malformed chair-verdicts.json fails open with dispositionsMissing");
+  }
+}
+
+// A well-formed verdict file is not a complete one. A set that omits,
+// duplicates or invents a finding id is not a verdict on this run, and
+// recording it with dispositionsMissing:false hands the promotion counter a
+// claim no chair made.
+{
+  const report = appendFindingsMeta(
+    "## GPT — security lens\n\n- `a.ts:1` — bad -> fix.\n- `b.ts:2` — worse -> fix.\n",
+  );
+  const ids = parseFindingsMeta(report);
+  const body = (ds) => JSON.stringify({ verdict: "comment", dispositions: ds });
+  const rec = (ds, md = report) =>
+    buildChairRecord({ verdictsJson: body(ds), findingsMarkdown: md, attribution: {} }).record;
+  const all = ids.map((id) => ({ id, disposition: "confirmed-open" }));
+
+  const complete = rec(all);
+  if (complete.dispositionsMissing !== false || complete.coverageUnverified !== false) {
+    console.error("FAIL a complete disposition set must be trusted", complete);
+    failed++;
+  }
+  for (const [label, ds] of [
+    ["omits a finding", [all[0]]],
+    ["duplicates a finding", [all[0], { id: ids[0], disposition: "rejected" }, all[1]]],
+    ["invents a finding", [...all, { id: "forged", disposition: "confirmed-fixed" }]],
+  ]) {
+    const r = rec(ds);
+    if (r.dispositionsMissing !== true || !r.dispositionsRejected) {
+      console.error(`FAIL a set that ${label} must not be recorded as a complete verdict`, r);
+      failed++;
+    }
+  }
+  // No meta block means nothing to check against, not a failure — but the
+  // reader must be able to tell that apart from a verified set.
+  const unchecked = rec([{ id: "x", disposition: "confirmed-open" }], "## x\n");
+  if (unchecked.dispositionsMissing !== false || unchecked.coverageUnverified !== true) {
+    console.error("FAIL an unverifiable set must be flagged, not failed", unchecked);
+    failed++;
+  } else {
+    console.log("ok - disposition coverage is checked against the recorded findings");
   }
 }
 


### PR DESCRIPTION
Closes #137

## What

The chair writes `chair-verdicts.json`, and a new `review.chair` record carries its verdict plus one disposition per finding: `confirmed-fixed` | `confirmed-open` | `rejected` | `unmentioned`.

Split out of #128, which carried both halves and exceeded the size cap. This depends on that record shape.

## Why

The council record says what was **found**. Nothing said what the chair **decided**. Recurrence counted on council output alone counts the false positives too, and promoting one unverified bullet into a permanent lint rule teaches every future agent a false invariant. Only a chair-confirmed finding may ever count toward #129.

## Absence is not zero

A missing or malformed file sets `dispositionsMissing: true` rather than recording an empty list. The OpenRouter fallback chair has **no `Write` tool**, so a missing file is an expected outcome and not a fault — and recording it as zero findings would make a run that never judged anything look like a run that judged everything clean.

That is the same failure this measurement family keeps producing: #128 had a skipped review reading as `full`, #141 had a full review reading as `skipped`. All three are absence being recorded as evidence.

Verified that a genuinely empty list stays distinguishable from an absent one:

```
VALID   -> verdict: comment | missing: false | dispositions: [{"id":"abc123","disposition":"confirmed-open"},{"id":"def456","disposition":"rejected"}]
MALFORM -> missing: true    | dispositions: undefined
MISSING -> missing: true    | dispositions: undefined
EMPTY   -> missing: false   | dispositions: []
```

## How I verified

npm test -> exit 0

node --test scripts/*.test.mjs -> 30 tests, 30 pass, 0 fail

node scripts/council-review.mjs --selfcheck -> selfcheck ok

Mutation-tested by the implementing worker and confirmed here: making `buildChairRecord` return `dispositionsMissing: false` with an empty list on a missing file gives `FAIL missing verdicts must set dispositionsMissing`, exit 1.

248 counted lines, well under the cap.

Emission fails soft and ingest stays opt-in, so a telemetry fault cannot turn a green PR red or block a review.

Proof: n/a — telemetry records and tests. The evidence is the output above.

Assisted-by: cursor:composer-2.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chair review telemetry records alongside council review records.
  * Chair verdicts now include structured dispositions for recorded findings.
  * Review data now identifies whether finding dispositions are complete, missing, or unverifiable.
  * Updated vibetrace documentation to describe council and chair records.

* **Bug Fixes**
  * Prevented stale verdict data from affecting subsequent review attempts.
  * Added validation for malformed, incomplete, duplicate, or unknown finding dispositions.

* **Tests**
  * Added coverage for successful chair reviews and missing or invalid verdict data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->