### PR TITLE
[VCR-136] Carry the class key into the filed issue

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -998,10 +998,23 @@ runs:
       continue-on-error: true
       env:
         GH_TOKEN: ${{ inputs.github_token }}
+        VCR_MEMBER_DIFF_NOTE: ${{ env.VCR_MEMBER_DIFF_NOTE }}
       run: |
         [ -f council-findings.md ] || { echo "no findings file"; exit 0; }
+        MODE=full
+        case "${VCR_MEMBER_DIFF_NOTE:-}" in
+          delta*) MODE=delta ;;
+        esac
+        STRENGTH=$(MODE="$MODE" node --input-type=module <<'VCR_STRENGTH_EOF'
+        import fs from "node:fs";
+        import { detectStrength } from "${{ github.action_path }}/scripts/vibetrace-records.mjs";
+        const markdown = fs.readFileSync("council-findings.md", "utf8");
+        process.stdout.write(detectStrength(markdown, process.env.MODE));
+        VCR_STRENGTH_EOF
+        )
         node "${{ github.action_path }}/scripts/file-findings.mjs" \
           --findings council-findings.md \
           --repo "${{ github.repository }}" \
           --pr "${{ github.event.pull_request.number }}" \
-          --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+          --strength "$STRENGTH"

--- a/action.yml
+++ b/action.yml
@@ -1005,13 +1005,17 @@ runs:
         case "${VCR_MEMBER_DIFF_NOTE:-}" in
           delta*) MODE=delta ;;
         esac
+        # GitHub's bash shell runs with `set -eo pipefail`, and a failing command
+        # substitution in an assignment aborts the step right there, which would
+        # skip the filing below entirely. `|| STRENGTH=` neutralizes the exit
+        # status so filing still runs and strength is simply omitted.
         STRENGTH=$(MODE="$MODE" node --input-type=module <<'VCR_STRENGTH_EOF'
         import fs from "node:fs";
         import { detectStrength } from "${{ github.action_path }}/scripts/vibetrace-records.mjs";
         const markdown = fs.readFileSync("council-findings.md", "utf8");
         process.stdout.write(detectStrength(markdown, process.env.MODE));
         VCR_STRENGTH_EOF
-        )
+        ) || STRENGTH=
         node "${{ github.action_path }}/scripts/file-findings.mjs" \
           --findings council-findings.md \
           --repo "${{ github.repository }}" \

--- a/action.yml
+++ b/action.yml
@@ -1007,15 +1007,16 @@ runs:
         esac
         # GitHub's bash shell runs with `set -eo pipefail`, and a failing command
         # substitution in an assignment aborts the step right there, which would
-        # skip the filing below entirely. `|| STRENGTH=` neutralizes the exit
-        # status so filing still runs and strength is simply omitted.
+        # skip the filing below entirely. `|| { ...; STRENGTH=; }` neutralizes the
+        # exit status so filing still runs and strength is simply omitted, but a
+        # warning is still surfaced so a genuine regression here is not silent.
         STRENGTH=$(MODE="$MODE" node --input-type=module <<'VCR_STRENGTH_EOF'
         import fs from "node:fs";
         import { detectStrength } from "${{ github.action_path }}/scripts/vibetrace-records.mjs";
         const markdown = fs.readFileSync("council-findings.md", "utf8");
         process.stdout.write(detectStrength(markdown, process.env.MODE));
         VCR_STRENGTH_EOF
-        ) || STRENGTH=
+        ) || { echo "::warning::strength detection failed; filing findings without vibecodereview-strength"; STRENGTH=; }
         node "${{ github.action_path }}/scripts/file-findings.mjs" \
           --findings council-findings.md \
           --repo "${{ github.repository }}" \

--- a/scripts/file-findings.mjs
+++ b/scripts/file-findings.mjs
@@ -217,7 +217,7 @@ export function fileFindings(markdown, { repo, prNumber, runUrl, dryRun = false,
 
 function usage() {
   return `Usage:
-  file-findings.mjs --findings F --repo owner/name --pr N [--run-url U] [--dry-run]`;
+  file-findings.mjs --findings F --repo owner/name --pr N [--run-url U] [--strength S] [--dry-run]`;
 }
 
 export async function main(argv) {
@@ -225,7 +225,7 @@ export async function main(argv) {
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === '--dry-run') { options.dryRun = true; continue; }
-    if (['--findings', '--repo', '--pr', '--run-url'].includes(arg)) {
+    if (['--findings', '--repo', '--pr', '--run-url', '--strength'].includes(arg)) {
       options[arg.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = argv[index + 1];
       index += 1;
       continue;
@@ -252,6 +252,7 @@ export async function main(argv) {
     runUrl: options.runUrl,
     dryRun: options.dryRun,
     headSha: process.env.VCR_REVIEW_HEAD_SHA,
+    strength: options.strength,
   });
   for (const item of result.filed) {
     process.stdout.write(`${item.dryRun ? 'would file' : 'filed'}  ${item.location}  ${item.url || ''}\n`);

--- a/scripts/file-findings.mjs
+++ b/scripts/file-findings.mjs
@@ -148,7 +148,7 @@ export function buildTitle(finding, path) {
 // Written to the issue standard so `issue-standards check` passes on what this
 // files. A finding is a defect, so it is filed as a bug: the trigger the
 // council was required to name is the reproduction.
-export function buildIssue(finding, { repo, prNumber, runUrl }) {
+export function buildIssue(finding, { repo, prNumber, runUrl, headSha, strength }) {
   const [path] = finding.location.split(':');
   const title = buildTitle(finding, path);
   const body = [
@@ -175,6 +175,10 @@ export function buildIssue(finding, { repo, prNumber, runUrl }) {
     `> Filed automatically from a review that #${prNumber} did not fix. Not triaged, and not agreed: read it before acting.`,
     runUrl ? `> Review run: ${runUrl}` : '',
     `> \`${MARKER}:${finding.id}\``,
+    `> \`vibecodereview-class:${finding.classKey}\``,
+    `> \`vibecodereview-lens:${finding.lensFamily}\``,
+    strength ? `> \`vibecodereview-strength:${strength}\`` : '',
+    headSha ? `> \`vibecodereview-head:${headSha}\`` : '',
   ].filter((line) => line !== '').join('\n');
   return { title, body };
 }
@@ -182,7 +186,7 @@ export function buildIssue(finding, { repo, prNumber, runUrl }) {
 // Every filed issue lands in triage. Nothing here decides priority.
 const LABELS = ['bug', 'triage'];
 
-export function fileFindings(markdown, { repo, prNumber, runUrl, dryRun = false } = {}) {
+export function fileFindings(markdown, { repo, prNumber, runUrl, dryRun = false, headSha, strength } = {}) {
   const findings = parseFindings(markdown);
   const filed = [];
   const skipped = [];
@@ -192,7 +196,7 @@ export function fileFindings(markdown, { repo, prNumber, runUrl, dryRun = false 
       skipped.push({ ...finding, reason: `already filed as #${existing}` });
       continue;
     }
-    const { title, body } = buildIssue(finding, { repo, prNumber, runUrl });
+    const { title, body } = buildIssue(finding, { repo, prNumber, runUrl, headSha, strength });
     if (dryRun) {
       filed.push({ ...finding, title, dryRun: true });
       continue;
@@ -247,6 +251,7 @@ export async function main(argv) {
     prNumber: options.pr,
     runUrl: options.runUrl,
     dryRun: options.dryRun,
+    headSha: process.env.VCR_REVIEW_HEAD_SHA,
   });
   for (const item of result.filed) {
     process.stdout.write(`${item.dryRun ? 'would file' : 'filed'}  ${item.location}  ${item.url || ''}\n`);

--- a/scripts/file-findings.test.mjs
+++ b/scripts/file-findings.test.mjs
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
 import {
+  alreadyFiled,
   buildIssue,
   extractLensFamily,
   fingerprint,
@@ -176,4 +180,65 @@ test('parseFindings path drops the line suffix for classKey', () => {
 
 test('extractLensFamily ignores cached suffix on heading', () => {
   assert.equal(extractLensFamily('GPT — correctness lens (cached)'), 'correctness');
+});
+
+test('buildIssue output contains both the finding and class key markers', () => {
+  const [finding] = parseFindings(REVIEW);
+  const { body } = buildIssue(finding, { repo: 'pooriaarab/x', prNumber: 42 });
+  assert.ok(body.includes(`vibecodereview-finding:${finding.id}`));
+  assert.ok(body.includes(`vibecodereview-class:${finding.classKey}`));
+  assert.ok(body.includes(`vibecodereview-lens:${finding.lensFamily}`));
+});
+
+test('findings differing only by line number produce different finding markers and the same class marker in buildIssue', () => {
+  const text = 'leak on error path -> handle it.';
+  const a = parseFindings(`## GPT — correctness lens\n\n- \`src/x.ts:10\` — ${text}\n`);
+  const b = parseFindings(`## GPT — correctness lens\n\n- \`src/x.ts:99\` — ${text}\n`);
+  assert.equal(a.length, 1);
+  assert.equal(b.length, 1);
+  assert.notEqual(a[0].id, b[0].id);
+  assert.equal(a[0].classKey, b[0].classKey);
+  const { body: bodyA } = buildIssue(a[0], { repo: 'pooriaarab/x', prNumber: 1 });
+  const { body: bodyB } = buildIssue(b[0], { repo: 'pooriaarab/x', prNumber: 1 });
+  assert.ok(bodyA.includes(`vibecodereview-finding:${a[0].id}`));
+  assert.ok(bodyB.includes(`vibecodereview-finding:${b[0].id}`));
+  assert.ok(bodyA.includes(`vibecodereview-class:${a[0].classKey}`));
+  assert.ok(bodyB.includes(`vibecodereview-class:${b[0].classKey}`));
+});
+
+test('buildIssue carries optional head sha and strength when provided', () => {
+  const [finding] = parseFindings(REVIEW);
+  const { body } = buildIssue(finding, {
+    repo: 'pooriaarab/x',
+    prNumber: 42,
+    headSha: 'abc123def456',
+    strength: 'full',
+  });
+  assert.ok(body.includes('vibecodereview-head:abc123def456'));
+  assert.ok(body.includes('vibecodereview-strength:full'));
+});
+
+test('alreadyFiled still searches the finding id marker, not the class marker', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vcr-gh-'));
+  const ghPath = path.join(tmpDir, 'gh');
+  const recorded = path.join(tmpDir, 'recorded.json');
+  const fakeGh = `#!/usr/bin/env node\nconst fs = require('fs');\nconst out = process.env.VCR_GH_RECORD;\nif (out) fs.writeFileSync(out, JSON.stringify(process.argv.slice(2)) + '\\n');\nprocess.stdout.write('[]\\n');\n`;
+  fs.writeFileSync(ghPath, fakeGh);
+  fs.chmodSync(ghPath, 0o755);
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${tmpDir}${path.delimiter}${originalPath}`;
+  process.env.VCR_GH_RECORD = recorded;
+  try {
+    const result = alreadyFiled('pooriaarab/x', 'finding-id-123');
+    assert.equal(result, null);
+    const args = JSON.parse(fs.readFileSync(recorded, 'utf8').trim());
+    const joined = args.join(' ');
+    assert.ok(joined.includes('vibecodereview-finding:finding-id-123'));
+    assert.ok(!joined.includes('vibecodereview-class:'));
+    assert.ok(!joined.includes('vibecodereview-lens:'));
+  } finally {
+    process.env.PATH = originalPath;
+    delete process.env.VCR_GH_RECORD;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Closes #136

## What

A filed issue now carries a second marker beside the existing one:

```
> `vibecodereview-finding:<id>`      <- unchanged, dedupe still keys on this alone
> `vibecodereview-class:<classKey>`  <- new
> `vibecodereview-lens:<lens>`
> `vibecodereview-strength:<strength>`   (omitted when unknown)
> `vibecodereview-head:<sha>`            (omitted when unknown)
```

## Why

`id` hashes the location **and** the full prose. Correct for dedupe inside one PR, useless across them: the same defect one line further down, or worded differently by another model, gets a fresh `id` and files a **new, unlinked issue**. The history was already being written and nothing tied two instances of one class together.

Verified across two PRs:

```
PR1 finding: 09b693d8dbcedc72 | class: 1f8b74439a0e | strength: full  | lens: security
PR2 finding: b2ca095a181ecfee | class: 1f8b74439a0e | strength: delta

different finding markers (dedupe unchanged): true
SAME class marker across PRs                : true
```

`strength` rides along because a finding from a `delta` review carries less evidence than one from a `full` review, and #129 must not count them the same. The head SHA rides along so a later reader knows which commit the claim was made against. Both are omitted when unavailable rather than written as empty.

## GitHub is the recurrence store

This is what makes the promotion counter buildable with **no new service**:

```bash
gh search issues --repo <r> --match body "vibecodereview-class:<key>" --json number,createdAt
```

Distinct PRs, dates and open/closed state all come back from that. No external trace store, no database, nothing to host. It works on any repo the action is installed on, including ones with vibetrace ingest switched off.

## How I verified

npm test -> 34 tests, 34 pass, 0 fail; selfcheck ok; chair-fallback selfcheck passed; exit 0

node --test scripts/*.test.mjs -> 34 tests, 34 pass, 0 fail

Dedupe is provably untouched: `findExistingIssue` still searches `${MARKER}:${id}` and the `id` marker line is byte-identical.

Optional fields are omitted when absent, verified — no empty `strength:` or `head:` line appears when they are not supplied.

Mutation-tested by the implementing worker: pointing the class marker at `finding.id` instead of `finding.classKey` fails both the "both markers present" and "same class across line numbers" assertions, 2 fail, non-zero exit.

`npx oxlint scripts/file-findings.mjs` reports 2 warnings, both pre-existing on main (`no-unused-vars` on `repo`, `preserve-caught-error`).

The last two commits changed real control flow in `action.yml`'s bash, which `npm test` does not exercise, so that block was driven directly. GitHub's shell runs `set -eo pipefail`, where a failing command substitution in an assignment kills the step — which would have skipped **filing the issue entirely**, not merely omitted a field.

bash -eo pipefail, strength probe succeeds:

```
FILING RUNS. strength=[full]
```

bash -eo pipefail, strength probe fails (import path broken to force a non-zero exit):

```
::warning::strength detection failed; filing findings without vibecodereview-strength
FILING RUNS. strength=[]
```

So the warning fires, filing still completes, and the issue is simply written without a `vibecodereview-strength` marker. A missing marker costs #129 a little evidence; a skipped filing would cost it the finding altogether.

Proof: n/a — issue body text and tests. The evidence is the output above.

Assisted-by: devin:swe-1-7