### PR TITLE
[VCR-146] Count members from results, not the report

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -281,7 +281,7 @@ runs:
         # it lives under .git/vcr-hooks, outside the working tree `git add -A`
         # walks.
         printf '%s\n' /pr.diff /pr-delta.diff /council-findings.md /council-carry.md /council-carry.next.md /review-state.md /council.log /council.pid \
-          /probe.1 /probe.2 /probe.3 /reason.1 /reason.2 /reason.3 \
+          /probe.1 /probe.2 /probe.3 /reason.1 /reason.2 /reason.3 /council-stats.json \
           >> "$(git rev-parse --git-dir)/info/exclude"
 
         # Keep the chair's evidence complete, but make council member calls
@@ -350,6 +350,8 @@ runs:
         export VCR_MEMBER_DIFF_NOTE="$MEMBER_DIFF_NOTE"
         export VCR_PRIOR_FINDINGS_FILE="$PWD/council-carry.md"
         export VCR_CARRY_FILE="$PWD/council-carry.next.md"
+        export VCR_STATS_FILE="$PWD/council-stats.json"
+        printf 'VCR_STATS_FILE=%s\n' "$VCR_STATS_FILE" >> "$GITHUB_ENV"
         printf '%s\n' /council-carry.next.md >> "$(git rev-parse --git-dir)/info/exclude"
         nohup node "${{ github.action_path }}/scripts/council-review.mjs" \
           pr.diff council-findings.md > council.log 2>&1 &
@@ -656,28 +658,24 @@ runs:
         GITHUB_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         VCR_PR_BODY: ${{ github.event.pull_request.body }}
         VCR_MEMBER_DIFF_NOTE: ${{ env.VCR_MEMBER_DIFF_NOTE }}
+        VCR_STATS_FILE: ${{ env.VCR_STATS_FILE }}
       run: |
         MODE=full
         case "${VCR_MEMBER_DIFF_NOTE:-}" in
           delta*) MODE=delta ;;
         esac
-        MEMBERS=0
-        if [ -f council-findings.md ]; then
-          # grep -c exits 1 (but still prints "0") on zero matches. GitHub's
-          # bash shell runs with `set -eo pipefail`, and a failing command
-          # substitution in an assignment aborts the step right there -- even
-          # inside this `if` body -- which would skip the emit below entirely.
-          # `|| true` keeps the "0" stdout but neutralizes the exit status.
-          MEMBERS=$(grep -cE '^## .+ — .+ lens' council-findings.md 2>/dev/null || true)
-          MEMBERS=${MEMBERS:-0}
-        fi
-        # Anchored to the exact header the engine emits for a cached member
-        # (`## Name — lens lens (cached)`); a bare substring search would also
-        # match a finding that happens to quote that text from the diff.
-        CACHE_HIT=0
-        if [ -f council-findings.md ] && grep -qE '^## .+ lens \(cached\)$' council-findings.md 2>/dev/null; then
-          CACHE_HIT=1
-        fi
+        # Member and cache counts come from the engine's run-stats sidecar,
+        # never from parsing the report: findings carried forward keep their
+        # original `## Name — lens lens` headings (and any `(cached)` suffix),
+        # so grepping the markdown counts members this run never dispatched.
+        # A missing or unreadable sidecar means "no current members": 0 and 0.
+        # Every failure mode below degrades to "0 0", so telemetry can never
+        # fail the step (which also has continue-on-error).
+        STATS="$(node --input-type=module -e 'import fs from "node:fs"; try { const s = JSON.parse(fs.readFileSync(process.env.VCR_STATS_FILE, "utf8")); const m = Number(s.memberCount); if (!Number.isInteger(m) || m < 0) throw new Error("bad memberCount"); console.log(m + " " + (s.cacheHit === true ? "1" : "0")); } catch { console.log("0 0"); }' 2>/dev/null || echo "0 0")"
+        MEMBERS="$(printf '%s' "$STATS" | cut -d' ' -f1)"
+        CACHE_HIT="$(printf '%s' "$STATS" | cut -d' ' -f2)"
+        MEMBERS=${MEMBERS:-0}
+        CACHE_HIT=${CACHE_HIT:-0}
         # `job` is a workflow-job context; composite action steps don't receive
         # it, so `job.status` is always empty here. Read the fan-out step's own
         # outcome instead, the same way the chair steps are checked below.

--- a/action.yml
+++ b/action.yml
@@ -670,8 +670,10 @@ runs:
         # so grepping the markdown counts members this run never dispatched.
         # A missing or unreadable sidecar means "no current members": 0 and 0.
         # Every failure mode below degrades to "0 0", so telemetry can never
-        # fail the step (which also has continue-on-error).
-        STATS="$(node --input-type=module -e 'import fs from "node:fs"; try { const s = JSON.parse(fs.readFileSync(process.env.VCR_STATS_FILE, "utf8")); const m = Number(s.memberCount); if (!Number.isInteger(m) || m < 0) throw new Error("bad memberCount"); console.log(m + " " + (s.cacheHit === true ? "1" : "0")); } catch { console.log("0 0"); }' 2>/dev/null || echo "0 0")"
+        # fail the step (which also has continue-on-error). The read itself
+        # lives in scripts/read-council-stats.mjs so council-stats.test.mjs
+        # can exercise this exact code instead of a copy of it.
+        STATS="$(node "${{ github.action_path }}/scripts/read-council-stats.mjs" 2>/dev/null || echo "0 0")"
         MEMBERS="$(printf '%s' "$STATS" | cut -d' ' -f1)"
         CACHE_HIT="$(printf '%s' "$STATS" | cut -d' ' -f2)"
         MEMBERS=${MEMBERS:-0}

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -40,7 +40,7 @@ import {
   diffAddsTestLines,
   selfcheckMutationRoster,
 } from "./council-config.mjs";
-import { buildFindingsMarkdown, lensCanReviewDiff } from "./review-delta.mjs";
+import { buildFindingsMarkdown, councilRunStats, lensCanReviewDiff } from "./review-delta.mjs";
 import {
   REQUEST_TIMEOUT_MS,
   parseModels,
@@ -52,6 +52,19 @@ import { cacheKey, loadCouncilResults, saveCouncilResult } from "./council-cache
 import { behavioralSurface } from "./behavioral-surface.mjs";
 import { filterMembersByKindRouting, lensesForKinds, routeLenses } from "./lens-routing.mjs";
 import { appendFindingsMeta } from "./file-findings.mjs";
+
+// Council run stats for the telemetry record: how many members THIS run
+// dispatched and whether any returned from cache. Written to VCR_STATS_FILE
+// (when set) so the emitter never recovers these numbers by parsing the
+// report, whose carried-forward section reuses old member headings. A stats
+// write failure is silent: telemetry must never turn a green run red.
+function writeRunStats(stats) {
+  const statsFile = process.env.VCR_STATS_FILE;
+  if (!statsFile) return;
+  try {
+    fs.writeFileSync(statsFile, JSON.stringify(stats));
+  } catch {}
+}
 
 async function main() {
   if (process.argv.includes("--selfcheck")) {
@@ -215,9 +228,10 @@ async function main() {
   // The ONLY way to write the report. It appends the findings metadata the
   // trace records read, and preserves the carry alongside the report, so a
   // future early return that uses `write` can forget neither.
-  const write = (md, carry = priorFindings) => {
+  const write = (md, carry = priorFindings, stats = { memberCount: 0, cacheHit: false }) => {
     fs.writeFileSync(outFile, appendFindingsMeta(md));
     if (process.env.VCR_CARRY_FILE) fs.writeFileSync(process.env.VCR_CARRY_FILE, carry);
+    writeRunStats(stats);
   };
 
   const models = parseModels();
@@ -347,7 +361,7 @@ async function main() {
   if (combined.length > CARRY_CHAR_BUDGET) {
     combined = combined.slice(0, CARRY_CHAR_BUDGET) + "\n\n_[older carried findings dropped to keep the review-state comment under GitHub's size limit]_";
   }
-  write(report, combined);
+  write(report, combined, councilRunStats(results));
   console.log(`Wrote ${outFile}`);
 }
 
@@ -360,5 +374,6 @@ main().catch((err) => {
       appendFindingsMeta(`# 🧑‍⚖️ LLM Council findings\n\n_Council errored: ${String(err?.message || err)}_\n`),
     );
   } catch {}
+  writeRunStats({ memberCount: 0, cacheHit: false });
   process.exit(0);
 });

--- a/scripts/council-stats.test.mjs
+++ b/scripts/council-stats.test.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// Issue #146: memberCount/cacheHit must describe the CURRENT run, not the
+// report. Carried-forward findings reuse old `## Name — lens lens` headings
+// (and any `(cached)` suffix), so deriving counts by parsing the markdown
+// credits the run with members it never dispatched. The engine instead writes
+// a VCR_STATS_FILE sidecar from its own results via councilRunStats; these
+// checks drive the engine and assert the sidecar (and the record built from
+// it) always reflects this run alone.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { councilRunStats } from "./review-delta.mjs";
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const engine = path.join(scriptsDir, "council-review.mjs");
+const emit = path.join(scriptsDir, "vibetrace-emit.mjs");
+
+const CODE_DIFF = "diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n+const x = 1;\n";
+// Three carried member headings, one of them `(cached)`: under the old
+// grep-the-report derivation this counted as 3 members and a cache hit.
+const CARRIED = [
+  "## GPT-5.6 (Codex) — correctness lens (cached)",
+  "",
+  "- `src/app.ts:1` — stale defect -> fix it.",
+  "",
+  "## Gemini 3 Pro — performance lens",
+  "",
+  "- `src/app.ts:2` — stale defect -> fix it.",
+  "",
+  "## Kimi K3 — security lens",
+  "",
+  "- `src/app.ts:3` — stale defect -> fix it.",
+].join("\n");
+
+// Scrubbed environment (no provider keys) so no case can reach the network
+// unless it sets its own endpoint explicitly.
+function runEngine(diff, prior, extraEnv = {}) {
+  const work = fs.mkdtempSync(path.join(os.tmpdir(), "council-stats-"));
+  const diffFile = path.join(work, "pr.diff");
+  const outFile = path.join(work, "council-findings.md");
+  const priorFile = path.join(work, "council-carry.md");
+  const carryFile = path.join(work, "council-carry.next.md");
+  const statsFile = path.join(work, "council-stats.json");
+  fs.writeFileSync(diffFile, diff);
+  fs.writeFileSync(priorFile, prior);
+  const result = spawnSync(process.execPath, [engine, diffFile, outFile], {
+    env: {
+      VCR_PRIOR_FINDINGS_FILE: priorFile,
+      VCR_CARRY_FILE: carryFile,
+      VCR_STATS_FILE: statsFile,
+      ...extraEnv,
+    },
+    encoding: "utf8",
+  });
+  return { result, work, diffFile, outFile, statsFile };
+}
+
+function readStats(statsFile) {
+  return JSON.parse(fs.readFileSync(statsFile, "utf8"));
+}
+
+// Zero dispatched members plus carried headings (one cached): the sidecar
+// must read 0/false, while the report still carries the text unchanged.
+{
+  const { result, outFile, statsFile } = runEngine(CODE_DIFF, CARRIED);
+  assert.equal(result.status, 0, `engine exited ${result.status}: ${result.stderr}`);
+  const stats = readStats(statsFile);
+  assert.equal(stats.memberCount, 0, `carried headings counted as members: ${JSON.stringify(stats)}`);
+  assert.equal(stats.cacheHit, false, `carried (cached) heading counted as a hit: ${JSON.stringify(stats)}`);
+  const report = fs.readFileSync(outFile, "utf8");
+  assert.ok(report.includes("Findings carried forward"), "carry must stay in the report");
+  assert.ok(report.includes("(cached)"), "carried text must be untouched");
+  console.log("ok    zero dispatched members + carried (cached) headings -> memberCount 0, cacheHit false");
+}
+
+// A normal run with two dispatched members still reports two, with no cache
+// hit. The `custom` seats point at a refused port with a dummy key, so both
+// members dispatch and fail fast offline; error results still count as
+// dispatched, and none is cached.
+{
+  const run = runEngine(CODE_DIFF, "", {
+    CUSTOM_BASE_URL: "http://127.0.0.1:1/chat/completions",
+    CUSTOM_API_KEY: "dummy",
+    COUNCIL_MODELS: "custom|m1|M1|correctness,custom|m2|M2|performance",
+  });
+  assert.equal(run.result.status, 0, `engine exited ${run.result.status}: ${run.result.stderr}`);
+  const stats = readStats(run.statsFile);
+  assert.equal(stats.memberCount, 2, `two dispatched members must report 2: ${JSON.stringify(stats)}`);
+  assert.equal(stats.cacheHit, false, `no cached member must report false: ${JSON.stringify(stats)}`);
+  const report = fs.readFileSync(run.outFile, "utf8");
+  assert.ok(report.includes("M1 — correctness lens"), "dispatched headings must stay in the report");
+  assert.ok(!report.includes("(cached)"), "uncached run must not mark headings cached");
+  console.log("ok    two dispatched members -> memberCount 2, cacheHit false");
+}
+
+// councilRunStats is the exact derivation the engine passes to the sidecar:
+// cached members (and only those) flip the hit, and the count is the run's
+// own result list, whatever the report body contains.
+{
+  const none = councilRunStats([]);
+  assert.deepEqual(none, { memberCount: 0, cacheHit: false });
+  const live = councilRunStats([
+    { model: { name: "M1" }, text: "ok" },
+    { model: { name: "M2" }, error: "boom" },
+  ]);
+  assert.deepEqual(live, { memberCount: 2, cacheHit: false });
+  const mixed = councilRunStats([
+    { model: { name: "M1" }, text: "ok" },
+    { model: { name: "M2" }, text: "ok", cached: true },
+  ]);
+  assert.deepEqual(mixed, { memberCount: 2, cacheHit: true });
+  console.log("ok    councilRunStats counts results and hits cache only on cached results");
+}
+
+// The record built from the zero-member sidecar (the values the emit step
+// passes as --members/--cache-hit) carries 0/false even though the findings
+// file is full of carried member headings.
+{
+  const { result, work, diffFile, outFile } = runEngine(CODE_DIFF, CARRIED);
+  assert.equal(result.status, 0, `engine exited ${result.status}: ${result.stderr}`);
+  const traces = path.join(work, "traces.jsonl");
+  const emitted = spawnSync(
+    process.execPath,
+    [emit, "review.council", "--mode", "full", "--cache-hit", "0", "--members", "0",
+      "--cancelled", "0", "--findings", outFile, "--diff", diffFile],
+    { env: { ...process.env, VIBETRACE_FILE: traces, VIBETRACE_INGEST_URL: "" }, encoding: "utf8" },
+  );
+  assert.equal(emitted.status, 0, `emit exited ${emitted.status}: ${emitted.stderr}`);
+  const rec = JSON.parse(fs.readFileSync(traces, "utf8").trim());
+  assert.equal(rec.memberCount, 0);
+  assert.equal(rec.cacheHit, false);
+  console.log("ok    record from zero-member stats + carried report -> memberCount 0, cacheHit false");
+}
+
+console.log("\ncouncil-stats tests passed");

--- a/scripts/council-stats.test.mjs
+++ b/scripts/council-stats.test.mjs
@@ -17,6 +17,21 @@ import { councilRunStats } from "./review-delta.mjs";
 const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
 const engine = path.join(scriptsDir, "council-review.mjs");
 const emit = path.join(scriptsDir, "vibetrace-emit.mjs");
+const statsReader = path.join(scriptsDir, "read-council-stats.mjs");
+
+// The exact read action.yml's emit step performs: run the extracted reader
+// script against a stats sidecar and split its "<members> <cacheHit>" line.
+// Driving this instead of hardcoding the expected numbers means a regression
+// in read-council-stats.mjs itself -- the code action.yml actually runs --
+// fails this test, not just a copy of its logic.
+function readStatsViaAction(statsFile) {
+  const out = spawnSync(process.execPath, [statsReader], {
+    env: { VCR_STATS_FILE: statsFile },
+    encoding: "utf8",
+  });
+  const [members, cacheHit] = out.stdout.trim().split(" ");
+  return { members, cacheHit };
+}
 
 const CODE_DIFF = "diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n+const x = 1;\n";
 // Three carried member headings, one of them `(cached)`: under the old
@@ -93,6 +108,9 @@ function readStats(statsFile) {
   const report = fs.readFileSync(run.outFile, "utf8");
   assert.ok(report.includes("M1 — correctness lens"), "dispatched headings must stay in the report");
   assert.ok(!report.includes("(cached)"), "uncached run must not mark headings cached");
+  const { members, cacheHit } = readStatsViaAction(run.statsFile);
+  assert.equal(members, "2", `reader script must derive 2 members: ${members}`);
+  assert.equal(cacheHit, "0", `reader script must derive no cache hit: ${cacheHit}`);
   console.log("ok    two dispatched members -> memberCount 2, cacheHit false");
 }
 
@@ -115,16 +133,19 @@ function readStats(statsFile) {
   console.log("ok    councilRunStats counts results and hits cache only on cached results");
 }
 
-// The record built from the zero-member sidecar (the values the emit step
-// passes as --members/--cache-hit) carries 0/false even though the findings
-// file is full of carried member headings.
+// The record built from the zero-member sidecar (the values action.yml's
+// reader script derives, then passes as --members/--cache-hit) carries
+// 0/false even though the findings file is full of carried member headings.
 {
-  const { result, work, diffFile, outFile } = runEngine(CODE_DIFF, CARRIED);
+  const { result, work, diffFile, outFile, statsFile } = runEngine(CODE_DIFF, CARRIED);
   assert.equal(result.status, 0, `engine exited ${result.status}: ${result.stderr}`);
+  const { members, cacheHit } = readStatsViaAction(statsFile);
+  assert.equal(members, "0", `reader script must derive 0 members: ${members}`);
+  assert.equal(cacheHit, "0", `reader script must derive no cache hit: ${cacheHit}`);
   const traces = path.join(work, "traces.jsonl");
   const emitted = spawnSync(
     process.execPath,
-    [emit, "review.council", "--mode", "full", "--cache-hit", "0", "--members", "0",
+    [emit, "review.council", "--mode", "full", "--cache-hit", cacheHit, "--members", members,
       "--cancelled", "0", "--findings", outFile, "--diff", diffFile],
     { env: { ...process.env, VIBETRACE_FILE: traces, VIBETRACE_INGEST_URL: "" }, encoding: "utf8" },
   );

--- a/scripts/read-council-stats.mjs
+++ b/scripts/read-council-stats.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// Reads the council engine's run-stats sidecar (VCR_STATS_FILE) and prints
+// "<memberCount> <cacheHitFlag>" to stdout. A missing/unreadable/malformed
+// sidecar, or one with a non-integer memberCount, degrades to "0 0" -- never
+// throws -- so the (continue-on-error) emit step can never fail on this.
+// Extracted out of action.yml's inline `node -e` so council-stats.test.mjs
+// can drive the exact code the action ships, not a copy of it.
+import fs from "node:fs";
+
+function readStats(file) {
+  try {
+    const s = JSON.parse(fs.readFileSync(file, "utf8"));
+    const m = Number(s.memberCount);
+    if (!Number.isInteger(m) || m < 0) throw new Error("bad memberCount");
+    return `${m} ${s.cacheHit === true ? "1" : "0"}`;
+  } catch {
+    return "0 0";
+  }
+}
+
+console.log(readStats(process.env.VCR_STATS_FILE));

--- a/scripts/review-delta.mjs
+++ b/scripts/review-delta.mjs
@@ -104,6 +104,14 @@ export function buildFindingsMarkdown(
   return lines.join("\n");
 }
 
+// Telemetry for one council run, from the run's own results — never from the
+// report text. Carried-forward findings reuse old member headings, so parsing
+// the markdown would credit the run with members it never dispatched.
+export function councilRunStats(results) {
+  const list = Array.isArray(results) ? results : [];
+  return { memberCount: list.length, cacheHit: list.some((r) => r?.cached) };
+}
+
 export function buildReviewState(headSha, carry) {
   const encoded = Buffer.from(String(carry || ""), "utf8").toString("base64");
   return `${REVIEW_STATE_MARKER}\nsha:${headSha}\ncarry:${encoded}\n<!-- /vibecodereview:review-state -->`;


### PR DESCRIPTION
Closes #146

## What

`memberCount` and `cacheHit` now come from the current run's results via `councilRunStats(results)`, instead of being recovered by parsing the rendered report.

## Why

The report can carry findings forward from earlier cycles, and those sections keep their original model headings and any `(cached)` suffix. So a run that dispatched **zero** members reported member activity it never had, and a run that hit no cache could report a cache hit.

Reproduced against a report with zero dispatched members and three carried sections, one of them `(cached)`:

```
councilRunStats([])   -> {"memberCount":0,"cacheHit":false}
record memberCount: 0 | cacheHit: false
-> carried text ignored: true

3 dispatched, 1 cached -> {"memberCount":3,"cacheHit":true}
```

This matters for two reasons. `memberCount` is the number the routing work in #130 is justified by, and a metric counted from prose cannot support that. And it contradicted `strength` from #128 — a record claiming three members on a `trivial` delta was producible.

It is the same defect family as the rest of this batch: a value recovered from rendered text rather than from the thing that produced it.

## How I verified

npm test -> exit 0

node --test scripts/*.test.mjs -> 31 tests, 31 pass, 0 fail

node scripts/council-review.mjs --selfcheck -> selfcheck ok

Mutation-tested by the implementing worker: deriving the counts from the report body again gives `AssertionError: carried headings counted as members: {"memberCount":3,"cacheHit":true}`, exit 1.

Two caveats reported honestly by that worker and checked here. Its sandbox blocks loopback bind, so `vibetrace-emit.test.mjs` failed there with `listen EPERM`; it verified the same failure on the untouched base and it passes in this checkout — the 31/31 above is after a rebase onto main. And a live cached dispatch could not be exercised in that sandbox, so `cacheHit: true` is covered by a unit test on the exact function the engine calls rather than by a seeded cache round trip.

Proof: n/a — telemetry values and tests. The evidence is the output above.

Assisted-by: muse:meta-muse-code