### PR TITLE
[VCR-147] Ignore Python bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ probe.*
 # Cursor cloud — local secrets stay local
 .env.local
 .env.*.local
+
+# Python bytecode from scripts/*.py. Not tracked, and an untracked file
+# still blocks bin/release.mjs, so leaving it out costs a release every time.
+__pycache__/
+*.pyc


### PR DESCRIPTION
Closes #147

## What

Adds `__pycache__/` and `*.pyc` to `.gitignore`.

## Why

`scripts/approve-action-required-runs.py` writes `scripts/__pycache__/` on every run, and `.gitignore` did not cover it. `bin/release.mjs` refuses on any dirty tree, untracked files included:

```
error: the working tree has uncommitted changes
```

So cutting a release required an unexplained `rm -rf scripts/__pycache__` first, and the error pointed at "uncommitted changes" rather than at a build artefact. It cost a step on the v1.4.0 release and would have cost one on every release after.

Ignoring the directory is the whole fix — an ignored file is not untracked, so the release check stops seeing it. No `.pyc` is tracked (`git ls-files "*.pyc"` is empty), so nothing leaves history.

## What I tried and backed out

The issue also suggested narrowing the release dirty-check to tracked files, reasoning that a tag points at a commit so an untracked file cannot change what is released.

**`release.test.mjs` rejected that, and it was right.** The check is not only about what gets released. It also refuses to run from an ambiguous checkout, and the test asserts the caller's untracked file is still present afterwards:

```js
assert.ok(git(clone, ["status", "--short"]).includes("?? dirty.txt"), "working tree was cleaned");
```

That guard was deliberate and tested. I reverted the change rather than weaken it — the gitignore fix alone solves the real problem.

## How I verified

npm test -> 31 tests, 31 pass, 0 fail; selfcheck ok; chair-fallback selfcheck passed; exit 0

`git status --short` is clean with `scripts/__pycache__/x.pyc` present on disk, which is the property that unblocks the release.

The narrowed-check version failed `release.test.mjs` with `AssertionError: v1.3.4 is not newer than existing v1.4.0` — the release proceeded past a guard it should have stopped at. Reverting returned the suite to green.

Proof: n/a — a gitignore entry. The evidence is the test output above.

Assisted-by: claude-personal:claude-opus-5