### PR TITLE
[VCR-129] Report which classes have earned a rule

### DIFF
--- a/scripts/promote-findings.mjs
+++ b/scripts/promote-findings.mjs
@@ -1,0 +1,282 @@
+// Report which finding classKeys have earned promotion to a lint rule, test, or
+// prose guard. Report only — never writes rules or opens PRs.
+//
+// Chair-confirmed counts come from vibetrace JSONL (review.council +
+// review.chair). Live mode optionally enriches via `gh search issues` on
+// vibecodereview-class markers — GitHub is the store for filed recurrence.
+//
+// Usage:
+//   node promote-findings.mjs --repo owner/name --traces traces.jsonl [--promoted rules.json] [--live] [--now ISO]
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+
+export const CONFIRMED = new Set(["confirmed-fixed", "confirmed-open"]);
+export const EVIDENCE_STRENGTH = new Set(["full", "delta"]);
+export const LINT_CRITERION = { min: 3, days: 30 };
+export const PROSE_CRITERION = { min: 5, days: 60 };
+export const DELETE_IDLE_DAYS = 90;
+
+const ISSUE_CLASS_RE = /vibecodereview-class:([a-f0-9]+)/;
+const ISSUE_PR_RE = /review of #(\d+)/i;
+
+/** @param {string} raw */
+export function parseTraceLines(raw) {
+  return String(raw || "")
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+/** @param {unknown[]} records */
+export function pairReviewSessions(records) {
+  /** @type {Map<number, { councils: object[], chairs: object[] }>} */
+  const byPr = new Map();
+  for (const rec of records) {
+    const pr = rec?.attribution?.pr;
+    if (!Number.isInteger(pr) || pr <= 0) continue;
+    if (!byPr.has(pr)) byPr.set(pr, { councils: [], chairs: [] });
+    const bucket = byPr.get(pr);
+    if (rec.type === "review.council") bucket.councils.push(rec);
+    if (rec.type === "review.chair") bucket.chairs.push(rec);
+  }
+  /** @type {{ pr: number, council: object, chair: object|null }[]} */
+  const sessions = [];
+  for (const [pr, { councils, chairs }] of byPr) {
+    councils.sort((a, b) => String(a.ts).localeCompare(String(b.ts)));
+    chairs.sort((a, b) => String(a.ts).localeCompare(String(b.ts)));
+    let ci = 0;
+    for (const council of councils) {
+      while (ci < chairs.length && String(chairs[ci].ts) < String(council.ts)) ci += 1;
+      const chair = ci < chairs.length ? chairs[ci++] : null;
+      sessions.push({ pr, council, chair });
+    }
+  }
+  return sessions;
+}
+
+/** @param {ReturnType<typeof pairReviewSessions>} sessions */
+export function confirmedOccurrencesFromSessions(sessions) {
+  /** @type {Map<string, { pr: number, ts: string, strength: string, disposition: string, path: string, lens: string, id: string }>} */
+  const byKey = new Map();
+  for (const { pr, council, chair } of sessions) {
+    const strength = String(council.strength || "");
+    if (!EVIDENCE_STRENGTH.has(strength)) continue;
+    if (!chair || chair.dispositionsMissing || !Array.isArray(chair.dispositions)) continue;
+    const dispById = new Map(chair.dispositions.map((d) => [d.id, d.disposition]));
+    for (const f of council.findings || []) {
+      const disposition = dispById.get(f.id);
+      if (!CONFIRMED.has(disposition)) continue;
+      const dedupe = `${f.classKey}|${pr}`;
+      if (byKey.has(dedupe)) continue;
+      byKey.set(dedupe, {
+        pr,
+        ts: String(council.ts),
+        strength,
+        disposition,
+        path: f.path,
+        lens: f.lens,
+        id: f.id,
+        classKey: f.classKey,
+      });
+    }
+  }
+  return [...byKey.values()];
+}
+
+/** @param {object[]} hits @param {number} min @param {number} maxDays */
+export function windowQualifies(hits, min, maxDays) {
+  if (hits.length < min) return false;
+  const sorted = [...hits].sort((a, b) => a.ts.localeCompare(b.ts));
+  for (let i = 0; i <= sorted.length - min; i += 1) {
+    const slice = sorted.slice(i, i + min);
+    const span = (Date.parse(slice[slice.length - 1].ts) - Date.parse(slice[0].ts)) / 86400000;
+    if (span <= maxDays) return true;
+  }
+  return false;
+}
+
+/** @param {ReturnType<typeof confirmedOccurrencesFromSessions>} occ @param {string} classKey */
+export function hitsForClass(occ, classKey) {
+  return occ.filter((o) => o.classKey === classKey);
+}
+
+/** @param {ReturnType<typeof confirmedOccurrencesFromSessions>} occ */
+export function strengthSummary(occ) {
+  const counts = {};
+  for (const o of occ) counts[o.strength] = (counts[o.strength] || 0) + 1;
+  return counts;
+}
+
+/** @param {{ path?: string, lens?: string }} sample */
+export function recommendRank(sample) {
+  const lens = String(sample.lens || "").toLowerCase();
+  if (lens === "security" || lens === "correctness") {
+    return { rank: 1, mechanism: "oxlint / type rule", why: "defect class suits static analysis (~0 cost per session)" };
+  }
+  if (sample.path?.includes("/")) {
+    return { rank: 2, mechanism: "unit or CI test", why: "concrete path trigger suits a named failure test" };
+  }
+  return {
+    rank: 3,
+    mechanism: "prose rule in AGENTS.md / .claude/rules",
+    why: "judgment call — only after lint/test ruled out (tokens every session)",
+  };
+}
+
+/** @param {ReturnType<typeof confirmedOccurrencesFromSessions>} occ @param {object} opts */
+export function analyzePromotions(occ, opts = {}) {
+  const now = opts.now ? Date.parse(opts.now) : Date.now();
+  const proseRuled = new Set(opts.proseRuledOut || []);
+  const classKeys = [...new Set(occ.map((o) => o.classKey))];
+  const lintEarned = [];
+  const proseEarned = [];
+  const nearMiss = [];
+
+  for (const classKey of classKeys) {
+    const hits = hitsForClass(occ, classKey);
+    const distinctPrs = new Set(hits.map((h) => h.pr)).size;
+    const rank = recommendRank(hits[0] || {});
+    const strength = strengthSummary(hits);
+    const entry = { classKey, hits: hits.length, distinctPrs, strength, rank, samples: hits.slice(0, 2) };
+
+    if (
+      distinctPrs >= LINT_CRITERION.min
+      && windowQualifies(hits, LINT_CRITERION.min, LINT_CRITERION.days)
+      && rank.rank !== 3
+    ) {
+      lintEarned.push(entry);
+    } else if (
+      proseRuled.has(classKey)
+      && distinctPrs >= PROSE_CRITERION.min
+      && windowQualifies(hits, PROSE_CRITERION.min, PROSE_CRITERION.days)
+    ) {
+      proseEarned.push(entry);
+    } else if (hits.length >= 2) {
+      nearMiss.push(entry);
+    }
+  }
+
+  const promoted = Array.isArray(opts.promoted) ? opts.promoted : [];
+  const deleteCandidates = [];
+  for (const rule of promoted) {
+    const hits = hitsForClass(occ, rule.classKey);
+    const last = hits.sort((a, b) => b.ts.localeCompare(a.ts))[0];
+    const idleDays = last ? (now - Date.parse(last.ts)) / 86400000 : Infinity;
+    if (idleDays >= DELETE_IDLE_DAYS) {
+      deleteCandidates.push({ ...rule, lastConfirmed: last?.ts || null, idleDays: Math.floor(idleDays) });
+    }
+  }
+
+  return { lintEarned, proseEarned, nearMiss, deleteCandidates, now: new Date(now).toISOString() };
+}
+
+export function ghSearchClass(repo, classKey, searchFn = defaultGhSearch) {
+  return searchFn(repo, `vibecodereview-class:${classKey}`);
+}
+
+function defaultGhSearch(repo, needle) {
+  const out = execFileSync(
+    "gh",
+    ["search", "issues", "--repo", repo, "--match", "body", needle, "--json", "number,createdAt,state,body"],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  );
+  return JSON.parse(out || "[]");
+}
+
+/** @param {string} body */
+export function parseIssueClass(body) {
+  const m = ISSUE_CLASS_RE.exec(String(body || ""));
+  return m ? m[1] : null;
+}
+
+/** @param {string} body */
+export function parseIssuePr(body) {
+  const m = ISSUE_PR_RE.exec(String(body || ""));
+  return m ? Number(m[1]) : null;
+}
+
+export function formatReport(repo, analysis) {
+  const lines = [`# Promotion report — ${repo}`, `Generated: ${analysis.now}`, ""];
+  lines.push("Chair-push guard: traces attribute to the review run, not the writer state before the chair pushed fixes. A quiet next PR may be chair-healed, not learned.");
+  lines.push("");
+
+  if (analysis.lintEarned.length) {
+    lines.push("## Earned — lint rule or test (rank 1–2, 3 confirmed / 3 PRs / 30 days)");
+    for (const e of analysis.lintEarned) {
+      lines.push(`- \`${e.classKey.slice(0, 12)}…\` — ${e.distinctPrs} PRs, strength ${JSON.stringify(e.strength)}`);
+      lines.push(`  Recommend rank ${e.rank.rank}: ${e.rank.mechanism} — ${e.rank.why}`);
+      if (e.rank.rank === 3) lines.push("  WARNING: rank 3 not allowed here; use prose path instead.");
+    }
+    lines.push("");
+  } else {
+    lines.push("## Earned — lint/test\n(none)\n");
+  }
+
+  if (analysis.proseEarned.length) {
+    lines.push("## Earned — prose (rank 3, 5 confirmed / 5 PRs / 60 days, lint/test ruled out)");
+    for (const e of analysis.proseEarned) {
+      lines.push(`- \`${e.classKey.slice(0, 12)}…\` — strength ${JSON.stringify(e.strength)}`);
+      lines.push(`  Recommend rank 3 only: ${e.rank.mechanism}`);
+    }
+    lines.push("");
+  }
+
+  if (analysis.deleteCandidates.length) {
+    lines.push(`## Delete candidates (zero confirmed ≥ ${DELETE_IDLE_DAYS} days)`);
+    for (const d of analysis.deleteCandidates) {
+      lines.push(`- ${d.label || d.classKey.slice(0, 12)} — last confirmed ${d.lastConfirmed || "never"}, idle ${d.idleDays}d`);
+    }
+    lines.push("");
+  }
+
+  if (analysis.nearMiss.length) {
+    lines.push("## Near miss (not yet promoted)");
+    for (const e of analysis.nearMiss) {
+      lines.push(`- \`${e.classKey.slice(0, 12)}…\` — ${e.hits} confirmed hits / ${e.distinctPrs} PRs, strength ${JSON.stringify(e.strength)}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+export function runReport({ repo, traces, promoted = [], proseRuledOut = [], live = false, now, searchFn }) {
+  const records = parseTraceLines(traces);
+  const occ = confirmedOccurrencesFromSessions(pairReviewSessions(records));
+  const analysis = analyzePromotions(occ, { promoted, proseRuledOut, now });
+  if (live) {
+    for (const e of [...analysis.lintEarned, ...analysis.proseEarned]) {
+      e.issues = ghSearchClass(repo, e.classKey, searchFn);
+    }
+  }
+  return { analysis, report: formatReport(repo, analysis), occurrences: occ };
+}
+
+function usage() {
+  return `Usage: promote-findings.mjs --repo owner/name --traces FILE [--promoted rules.json] [--prose-ruled classKey,...] [--live] [--now ISO]`;
+}
+
+export async function main(argv) {
+  const opts = { proseRuledOut: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--live") { opts.live = true; continue; }
+    if (a === "--repo") { opts.repo = argv[++i]; continue; }
+    if (a === "--traces") { opts.traces = fs.readFileSync(argv[++i], "utf8"); continue; }
+    if (a === "--promoted") { opts.promoted = JSON.parse(fs.readFileSync(argv[++i], "utf8")); continue; }
+    if (a === "--prose-ruled") { opts.proseRuledOut = argv[++i].split(",").filter(Boolean); continue; }
+    if (a === "--now") { opts.now = argv[++i]; continue; }
+    process.stderr.write(`${usage()}\n`);
+    return 2;
+  }
+  if (!opts.repo || !opts.traces) {
+    process.stderr.write(`${usage()}\n`);
+    return 2;
+  }
+  const { report } = runReport(opts);
+  process.stdout.write(`${report}\n`);
+  return 0;
+}
+
+const invoked = process.argv[1]?.endsWith("promote-findings.mjs");
+if (invoked) main(process.argv.slice(2)).then((c) => { process.exitCode = c; });

--- a/scripts/promote-findings.test.mjs
+++ b/scripts/promote-findings.test.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// Issue #129: promotion ladder measurement — report only, fixtures only (no network).
+import {
+  analyzePromotions,
+  confirmedOccurrencesFromSessions,
+  pairReviewSessions,
+  parseTraceLines,
+  windowQualifies,
+  LINT_CRITERION,
+  DELETE_IDLE_DAYS,
+} from "./promote-findings.mjs";
+import { buildClassKey } from "./file-findings.mjs";
+
+let failed = 0;
+function fail(msg) {
+  console.error(`FAIL ${msg}`);
+  failed += 1;
+}
+function ok(msg) {
+  console.log(`ok - ${msg}`);
+}
+
+const CLASS = buildClassKey("correctness", "src/x.ts", "empty catch block swallows error -> log or rethrow");
+const OTHER = buildClassKey("security", "src/y.ts", "api key in source -> move to env");
+
+function session({ pr, ts, id, classKey = CLASS, disposition, strength = "full" }) {
+  const council = {
+    type: "review.council",
+    ts,
+    strength,
+    findings: [{ id, classKey, path: "src/x.ts", lens: "correctness" }],
+    attribution: { pr, repo: "o/r" },
+  };
+  const chair = {
+    type: "review.chair",
+    ts: new Date(Date.parse(ts) + 1000).toISOString(),
+    dispositionsMissing: false,
+    verdict: "comment",
+    dispositions: [{ id, disposition }],
+    attribution: { pr, repo: "o/r" },
+  };
+  return [council, chair];
+}
+
+function buildTrace(sessions) {
+  return sessions.flat().map((r) => JSON.stringify(r)).join("\n");
+}
+
+function occFromSessions(sessions) {
+  return confirmedOccurrencesFromSessions(pairReviewSessions(parseTraceLines(buildTrace(sessions))));
+}
+
+{
+  const sessions = [
+    session({ pr: 1, ts: "2026-08-01T00:00:00Z", id: "a1", disposition: "confirmed-open" }),
+    session({ pr: 2, ts: "2026-08-10T00:00:00Z", id: "a2", disposition: "confirmed-fixed" }),
+    session({ pr: 3, ts: "2026-08-20T00:00:00Z", id: "a3", disposition: "confirmed-open" }),
+  ];
+  const analysis = analyzePromotions(occFromSessions(sessions), { now: "2026-08-25T00:00:00Z" });
+  if (!analysis.lintEarned.some((e) => e.classKey === CLASS)) {
+    fail("3 confirmed / 3 PRs / 30d should promote lint/test");
+  } else ok("3 confirmed across 3 distinct PRs within 30 days promotes");
+}
+
+{
+  const sessions = [
+    session({ pr: 9, ts: "2026-08-01T00:00:00Z", id: "b1", disposition: "confirmed-open" }),
+    session({ pr: 9, ts: "2026-08-02T00:00:00Z", id: "b2", disposition: "confirmed-open" }),
+    session({ pr: 9, ts: "2026-08-03T00:00:00Z", id: "b3", disposition: "confirmed-fixed" }),
+  ];
+  const analysis = analyzePromotions(occFromSessions(sessions), { now: "2026-08-05T00:00:00Z" });
+  if (analysis.lintEarned.some((e) => e.classKey === CLASS)) {
+    fail("three hits on one PR must not promote (distinct PR rule)");
+  } else ok("3 confirmed hits on one PR does not promote");
+}
+
+{
+  const sessions = [
+    session({ pr: 1, ts: "2026-08-01T00:00:00Z", id: "c1", disposition: "confirmed-open" }),
+    session({ pr: 2, ts: "2026-08-05T00:00:00Z", id: "c2", disposition: "confirmed-open" }),
+    session({ pr: 3, ts: "2026-08-10T00:00:00Z", id: "c3", disposition: "rejected" }),
+  ];
+  const occ = occFromSessions(sessions);
+  if (occ.length !== 2) fail(`expected 2 chair-confirmed, got ${occ.length}`);
+  const analysis = analyzePromotions(occ, { now: "2026-08-15T00:00:00Z" });
+  if (analysis.lintEarned.some((e) => e.classKey === CLASS)) {
+    fail("rejected disposition must not count toward promotion");
+  } else ok("2 confirmed + 1 rejected across 3 PRs does not promote");
+}
+
+{
+  const sessions = [
+    session({ pr: 1, ts: "2026-07-01T00:00:00Z", id: "d1", disposition: "confirmed-open" }),
+    session({ pr: 2, ts: "2026-07-15T00:00:00Z", id: "d2", disposition: "confirmed-open" }),
+    session({ pr: 3, ts: "2026-08-05T00:00:00Z", id: "d3", disposition: "confirmed-open" }),
+  ];
+  const occ = occFromSessions(sessions);
+  if (windowQualifies(occ.filter((o) => o.classKey === CLASS), LINT_CRITERION.min, LINT_CRITERION.days)) {
+    fail("31+ day span must not satisfy 30-day window");
+  } else ok("3 confirmed spanning 31+ days does not promote");
+}
+
+{
+  const occ = occFromSessions([
+    session({ pr: 1, ts: "2026-01-01T00:00:00Z", id: "e1", disposition: "confirmed-open", classKey: OTHER }),
+  ]);
+  const analysis = analyzePromotions(occ, {
+    now: "2026-06-01T00:00:00Z",
+    promoted: [{ classKey: OTHER, label: "old-rule", promotedAt: "2025-01-01T00:00:00Z" }],
+  });
+  if (!analysis.deleteCandidates.some((d) => d.classKey === OTHER)) {
+    fail("promoted rule with no recent confirmed hit should be delete candidate");
+  } else ok(`promoted rule idle ≥ ${DELETE_IDLE_DAYS}d listed as delete candidate`);
+}
+
+{
+  const sessions = [
+    session({ pr: 1, ts: "2026-08-01T00:00:00Z", id: "f1", disposition: "confirmed-open", strength: "trivial" }),
+    session({ pr: 2, ts: "2026-08-10T00:00:00Z", id: "f2", disposition: "confirmed-open", strength: "trivial" }),
+    session({ pr: 3, ts: "2026-08-20T00:00:00Z", id: "f3", disposition: "confirmed-open", strength: "trivial" }),
+  ];
+  if (occFromSessions(sessions).length !== 0) fail("trivial runs must not contribute evidence");
+  else ok("trivial strength skipped — not counted in denominator");
+}
+
+// Decorative guard: any new check must stay ABOVE this line (see AGENTS / issue #129).
+// The distinct-PR rule, exercised directly on analyzePromotions.
+//
+// The end-to-end fixtures cannot reach it: confirmedOccurrencesFromSessions
+// dedupes per (classKey, pr), so hits.length and distinctPrs are always equal
+// by the time analyzePromotions runs, and replacing one with the other passes
+// every other test in this file. Feed it occurrence records that name the same
+// PR three times — the shape a future caller or a relaxed dedupe would produce
+// — so the guard is pinned by intent rather than by an upstream accident.
+{
+  const at = (n) => new Date(Date.now() - n * 86400000).toISOString();
+  const occ = (pr, days) => ({
+    classKey: "K", pr, disposition: "confirmed-open", ts: at(days),
+    strength: "full", path: "src/a.ts", lens: "correctness", id: `i${pr}${days}`,
+  });
+  const onePr = analyzePromotions([occ(7, 5), occ(7, 10), occ(7, 15)]);
+  if (onePr.lintEarned.length !== 0) {
+    console.error("FAIL three occurrences on ONE pr must not promote", onePr.lintEarned);
+    failed++;
+  }
+  const threePrs = analyzePromotions([occ(1, 5), occ(2, 10), occ(3, 15)]);
+  if (threePrs.lintEarned.length !== 1) {
+    console.error("FAIL three occurrences across THREE prs must promote", threePrs);
+    failed++;
+  } else {
+    console.log("ok - promotion counts distinct PRs, not raw occurrences");
+  }
+}
+
+console.log("\npromote-findings tests passed");
+if (failed) process.exit(1);


### PR DESCRIPTION
Closes #129

Targets `vcr-137-chair-dispositions` (#144), not `main` — it consumes the chair-disposition record that PR adds. Retarget to `main` once #144 lands.

## What

`scripts/promote-findings.mjs` reads the council and chair records and reports which finding classes have earned a lint rule, a test, or a prose rule. **Report only** — it writes no rule, edits no file, opens no PR.

```
## Earned — lint rule or test (rank 1–2, 3 confirmed / 3 PRs / 30 days)
- `35f9a427c4a9…` — 3 PRs, strength {"full":3}
  Recommend rank 1: oxlint / type rule — defect class suits static analysis (~0 cost per session)
```

Writing the rule stays a human decision. A tool that both counts and promotes would be free to promote its own noise.

## The ladder

| Rank | Mechanism | Cost per future session |
| --- | --- | --- |
| 1 | oxlint / type rule | ~0, CI already runs it |
| 2 | unit or CI test | CI minutes, not tokens |
| 3 | prose rule | tokens on **every** session, forever |

It never recommends rank 3 where rank 1 or 2 can express the check, and a rank-3 class is excluded from the lint path entirely rather than downgraded silently.

## Three guards keep the count honest

Verified directly:

```
full + confirmed-open              1 occurrence
full + confirmed-fixed             1 occurrence
full + REJECTED                    0     <- a false positive can never become a rule
full + UNMENTIONED                 0
full + dispositions MISSING        0
TRIVIAL strength + confirmed       0     <- a quiet review is not a clean one
SKIPPED strength + confirmed       0
no-keys strength + confirmed       0
delta strength + confirmed         1
same class twice on ONE pr         1     <- deduped per (class, pr)
```

And the criteria themselves:

```
3 confirmed / 3 PRs / within 30d    PROMOTES (rank 1)
3 confirmed all on ONE pr           near-miss
3 confirmed spanning 45 days        near-miss
only 2 PRs                          near-miss
```

The strength guard is the answer to the metric trap in the issue: "findings per PR went down" is won most cheaply by a reviewer that stops reporting, which is indistinguishable from clean code. A `trivial`/`skipped`/`no-keys` run contributes no evidence in either direction.

Expiry is not optional — a class with no confirmed hit in 90 days is reported as a delete candidate. A loop that only ever adds drowns the next writer in context.

## A test gap I found and closed

The distinct-PR rule is the most important criterion, and **replacing `distinctPrs` with `hits.length` passed the entire original suite.** `confirmedOccurrencesFromSessions` dedupes per `(classKey, pr)`, so by the time `analyzePromotions` runs the two are always equal — the end-to-end fixtures cannot reach the guard.

It is not a live bug, but the criterion was pinned by an upstream accident rather than by intent. Added a direct test feeding occurrence records that name one PR three times:

```
M1 (drop the distinct-PR guard) -> FAIL three occurrences on ONE pr must not promote, exit 1
```

## How I verified

npm test -> 37 tests, 37 pass, 0 fail; selfcheck ok; chair-fallback selfcheck passed; exit 0

Mutation-tested both core guards. Counting rejected findings as confirmed fails the suite; dropping the distinct-PR requirement now fails it too (it did not before the added test).

No network in tests. `--live` gates the `gh search issues` path behind an explicit flag.

Proof: n/a — a reporting script and tests. The evidence is the output above.

Assisted-by: cursor:composer-2.5