### PR TITLE
[VCR-151] Stop OpenRouter subscription waste

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,10 +33,11 @@ Read `.agents/brand.md` and `.agents/design.md` before public copy or interface 
 
 - Zero runtime deps. Node ≥20, global `fetch` only. Do not add npm dependencies.
 - Providers: `openai`, `gemini`, `moonshot`, `openrouter`, `custom`, `claude`,
-  `claude2`. The last two are subscription-backed: they shell the Claude Code
-  CLI rather than POSTing, and add no npm dependency. Add one by extending
-  `PROVIDERS` in `council-config.mjs` (+ `DEFAULT_MODELS` if it should be on by
-  default).
+  `claude2`, `claude3`, `claude4`. The `claude*` seats are subscription-backed:
+  they shell the Claude Code CLI rather than POSTing, and add no npm
+  dependency. OpenRouter must never carry a Claude, Codex, or Grok model
+  id — the engine skips those before the HTTP call. Add a seat by setting
+  `CLAUDE_CODE_OAUTH_TOKEN_N` (provider `claudeN`).
 - A member with no API key must skip with a note, never throw.
 - The council uses a scope lens to verify atomicity and claim alignment. Set `PR_CONTEXT_FILE` to a file containing the author's claim (title, body, closed issues) to feed this lens.
 - A composite action's `inputs:` block must contain NO `${{ }}` expressions — not in a default AND not in a description string; GitHub parses them and fails at 'Set up job'. Callers pass github_token explicitly.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ verdict, self-healing fix.
 | GPT / Codex | api.openai.com | `OPENAI_API_KEY` | correctness, silent failures |
 | Gemini | generativelanguage.googleapis.com | `GEMINI_API_KEY` | performance, type design |
 | Kimi | api.moonshot.ai | `MOONSHOT_API_KEY` | security |
-| Grok / DeepSeek | openrouter.ai | `OPENROUTER_API_KEY` | maintainability, data integrity |
-| GPT-5.6 (scope) | openrouter.ai | `OPENROUTER_API_KEY` | scope, atomicity, and the evidence in the body |
-| Sonnet (mutation) | openrouter.ai | `OPENROUTER_API_KEY` | can these tests fail at all — **off by default** |
+| DeepSeek V4 Flash | openrouter.ai | `OPENROUTER_API_KEY` | maintainability, data integrity |
+| GLM 5.3 Flash (scope) | openrouter.ai | `OPENROUTER_API_KEY` | scope, atomicity, and the evidence in the body |
+| Sonnet (mutation) | Claude OAuth seat | `CLAUDE_CODE_OAUTH_TOKEN` | can these tests fail at all — **off by default** |
 
 A member with no key drops out. No key at all → the council step is skipped, and
 Claude still reviews alone. Nothing here blocks the PR on a provider outage.
@@ -146,10 +146,10 @@ Two honest limits:
   question to ask about a documentation change, and the report says so rather
   than staying silent — silence would read as "found nothing".
 
-`mutation_model` overrides the model, over OpenRouter, with its own env var so
-setting it cannot silently repoint the scope or maintainability lens (both also
-ride OpenRouter). It still shares `OPENROUTER_API_KEY` with those lenses, so an
-exhausted key takes all three out together, not just one.
+`mutation_model` is the Claude CLI model name (default `claude-sonnet-5`).
+Mutation runs on a Claude OAuth seat, never OpenRouter. Set
+`MUTATION_PROVIDER=claude2` (or `claude3` / `claude4`) to pick a different
+token so it does not share the chair's primary subscription.
 
 ### Claude subscription seats
 
@@ -159,17 +159,20 @@ still lists four reviewers, so a PR looks multi-model reviewed when only the
 chair ran.
 
 A Claude Code OAuth token is not an API bearer, so it cannot hold a normal
-seat. The `claude` and `claude2` providers shell the Claude Code CLI (already
-installed for the chair) instead of POSTing, putting the cost on the
-subscription. `claude2` lets a second subscription hold a real seat rather
-than idling as the chair's failover token.
+seat. The `claude`, `claude2`, `claude3`, and `claude4` providers shell the
+Claude Code CLI (already installed for the chair) instead of POSTing, putting
+the cost on the subscription. Extra tokens (`CLAUDE_CODE_OAUTH_TOKEN_5` and
+up) become `claude5` automatically. **OpenRouter must never carry a Claude,
+Codex, or Grok model** — the engine skips those ids before the HTTP call.
+Those families have their own subscriptions. OpenRouter is DeepSeek / GLM
+only.
 
 ```yaml
 council_models: >-
   claude|claude-opus-5|Claude Opus 5|correctness,
   claude2|claude-sonnet-5|Claude Sonnet 5|security,
-  openrouter|google/gemini-3.1-pro-preview|Gemini 3.1 Pro|performance,
-  openrouter|x-ai/grok-4.6|Grok 4.6|maintainability
+  claude3|claude-sonnet-5|Claude Sonnet 5|performance,
+  openrouter|deepseek/deepseek-v4-flash|DeepSeek V4 Flash|maintainability
 ```
 
 The seats run with no tools, `--max-turns 1`, and a working directory outside

--- a/action.yml
+++ b/action.yml
@@ -30,14 +30,14 @@ inputs:
     description: "Moonshot/Kimi key — security lens. Omit to drop it."
     required: false
   openrouter_api_key:
-    description: "OpenRouter key — Grok/DeepSeek member (maintainability lens). Omit to drop it."
+    description: "OpenRouter key — cheap leftover members (DeepSeek/GLM). Not Claude, Codex, or Grok. Omit to drop it."
     required: false
   chair_fallback_model:
-    description: "Model for the OpenRouter fallback chair, used only when every Claude OAuth token fails. Defaults to anthropic/claude-sonnet-5 — the same model the primary chair runs — so the fallback review reads like the real one. Set empty-string behaviour by omitting; omit openrouter_api_key to disable the fallback entirely."
+    description: "Model for the OpenRouter fallback chair, used only when every Claude OAuth token fails. Must be a cheap leftover id (default deepseek/deepseek-v4-flash). Claude, Codex, and Grok ids are refused before the HTTP call. Omit openrouter_api_key to disable the fallback entirely."
     required: false
-    default: "anthropic/claude-sonnet-5"
+    default: "deepseek/deepseek-v4-flash"
   council_models:
-    description: "Optional CSV override: provider|model|Name|lens,... (providers: openai, gemini, moonshot, openrouter, custom, claude, claude2). `claude`/`claude2` are subscription-backed seats that shell the Claude Code CLI using claude_code_oauth_token / _2 instead of a metered API key."
+    description: "Optional CSV override: provider|model|Name|lens,... (providers: openai, gemini, moonshot, openrouter, custom, claude, claude2, claude3, claude4). Claude seats shell the Claude Code CLI using the matching claude_code_oauth_token. OpenRouter must not name a Claude, Codex, or Grok model."
     required: false
   can_push_fixes:
     description: "If true, the chair may commit and push fixes to the PR branch."
@@ -72,7 +72,7 @@ inputs:
     required: false
     default: "false"
   mutation_model:
-    description: "Model for the mutation member, over OpenRouter. Its own env var keeps it from silently repointing the scope or maintainability lens, which ride the same OpenRouter route. It still shares openrouter_api_key with those lenses, so a quota failure on that key still takes out all three."
+    description: "Claude CLI model for the mutation member (default claude-sonnet-5). Runs on a Claude OAuth seat, never OpenRouter. Set MUTATION_PROVIDER to claude2/claude3/claude4 to pick a different token."
     required: false
     default: ""
   lens_path_filter:
@@ -255,9 +255,11 @@ runs:
         GEMINI_API_KEY: ${{ inputs.gemini_api_key }}
         MOONSHOT_API_KEY: ${{ inputs.moonshot_api_key }}
         OPENROUTER_API_KEY: ${{ inputs.openrouter_api_key }}
-        # Subscription-backed council seats (provider `claude` / `claude2`).
+        # Subscription-backed council seats (provider `claude` / `claude2` / `claude3` / `claude4`).
         CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
         CLAUDE_CODE_OAUTH_TOKEN_2: ${{ inputs.claude_code_oauth_token_2 }}
+        CLAUDE_CODE_OAUTH_TOKEN_3: ${{ inputs.claude_code_oauth_token_3 }}
+        CLAUDE_CODE_OAUTH_TOKEN_4: ${{ inputs.claude_code_oauth_token_4 }}
         COUNCIL_MODELS: ${{ inputs.council_models }}
         COUNCIL_TIMEOUT_MS: ${{ inputs.council_timeout_ms }}
         MUTATION_LENS: ${{ inputs.mutation_lens }}

--- a/scripts/chair-fallback.mjs
+++ b/scripts/chair-fallback.mjs
@@ -10,17 +10,18 @@
 //
 // Usage: node chair-fallback.mjs <diff-file> <council-findings-file>
 // Env: OPENROUTER_API_KEY, GH_TOKEN, GITHUB_REPOSITORY, PR_NUMBER,
-//      CHAIR_FALLBACK_MODEL (default anthropic/claude-sonnet-5),
+//      CHAIR_FALLBACK_MODEL (default deepseek/deepseek-v4-flash — never Claude, Codex, or Grok),
 //      PR_CONTEXT_FILE, VCR_REQUIRE_PROOF
 
 import fs from "node:fs";
 import { execFileSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 import { parseVerdict, truncate } from "./verdict-json.mjs";
+import { resolveChairFallbackModel, bannedOpenRouterReason } from "./openrouter-policy.mjs";
 
 const MAX_DIFF_CHARS = 180_000;
 const TIMEOUT_MS = Number(process.env.CHAIR_FALLBACK_TIMEOUT_MS) || 180_000;
-const MODEL = process.env.CHAIR_FALLBACK_MODEL || "anthropic/claude-sonnet-5";
+const MODEL = resolveChairFallbackModel().model;
 const SEVERITIES = { critical: "Critical", major: "Major", minor: "Minor" };
 
 // The proof lens travels three code paths: the council scope lens, the primary
@@ -260,6 +261,17 @@ function selfcheck() {
   }
   if (!threw) throw new Error("selfcheck: malformed JSON was accepted");
 
+  const resolved = resolveChairFallbackModel("");
+  if (bannedOpenRouterReason(resolved.model) || resolved.error) {
+    throw new Error("selfcheck: default chair fallback is banned on OpenRouter");
+  }
+  if (!bannedOpenRouterReason("anthropic/claude-sonnet-5")) {
+    throw new Error("selfcheck: Claude via OpenRouter was not banned");
+  }
+  if (!bannedOpenRouterReason("x-ai/grok-4.5")) {
+    throw new Error("selfcheck: Grok via OpenRouter was not banned");
+  }
+
   console.log("chair-fallback selfcheck passed");
 }
 
@@ -270,6 +282,8 @@ async function main() {
   const pr = process.env.PR_NUMBER;
   if (!process.env.OPENROUTER_API_KEY?.trim()) throw new Error("OPENROUTER_API_KEY not set");
   if (!repo || !pr) throw new Error("GITHUB_REPOSITORY and PR_NUMBER are required");
+  const resolved = resolveChairFallbackModel();
+  if (resolved.error) throw new Error(resolved.error);
 
   const diff = diffFile && fs.existsSync(diffFile) ? fs.readFileSync(diffFile, "utf8") : "";
   if (!diff.trim()) throw new Error("empty diff");

--- a/scripts/claude-cli-seat.mjs
+++ b/scripts/claude-cli-seat.mjs
@@ -9,7 +9,9 @@ export function claudeCliArgs(model, instructions, effortRung) {
     "-p",
     instructions,
     "--model",
-    model.model,
+    // Strip an anthropic/ prefix so a leftover OpenRouter id still
+    // reaches the CLI as the model name it actually accepts.
+    String(model.model || "").replace(/^anthropic\//, ""),
     // No tools: the seat needs nothing but the diff on stdin. This also
     // keeps an agentic loop from eating the timeout.
     "--allowed-tools",
@@ -37,14 +39,20 @@ export async function callClaudeCli(model, diff, oauthToken, { instructions, tim
   // read its env, but the seat never needs these values to do its job — don't
   // leave them reachable as a second line of defense against a bypass in either
   // of those controls.
-  const env = { ...process.env, CLAUDE_CODE_OAUTH_TOKEN: oauthToken };
+  const env = { ...process.env };
+  // A seat must only ever hold its own token. Drop every OAuth slot
+  // (unnumbered plus _2, _3, _4, …) before putting this seat's token
+  // in the name the CLI actually reads.
+  for (const k of Object.keys(env)) {
+    if (k === "CLAUDE_CODE_OAUTH_TOKEN" || k.startsWith("CLAUDE_CODE_OAUTH_TOKEN_")) delete env[k];
+  }
+  env.CLAUDE_CODE_OAUTH_TOKEN = oauthToken;
   for (const k of [
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_AUTH_TOKEN",
     "ANTHROPIC_BASE_URL",
     "CLAUDE_CODE_USE_BEDROCK",
     "CLAUDE_CODE_USE_VERTEX",
-    "CLAUDE_CODE_OAUTH_TOKEN_2", // a seat must only ever hold its own token
     "GH_TOKEN",
     "OPENAI_API_KEY",
     "GEMINI_API_KEY",

--- a/scripts/council-config.mjs
+++ b/scripts/council-config.mjs
@@ -1,3 +1,5 @@
+import { bannedOpenRouterReason, isClaudeSeatProvider } from "./openrouter-policy.mjs";
+
 // The council's configuration: which providers exist, which lens each member
 // reviews through, and where to reroute a member whose native key is dead.
 // This is data, and keeping it beside the engine pushed council-review.mjs past
@@ -22,11 +24,20 @@ export const PROVIDERS = {
   // the Claude Code CLI the action already installs for the chair. The cost
   // lands on the Claude subscription instead of a metered API key, which is the
   // whole point: the metered keys are what keep running dry.
-  // `claude2` exists so a second subscription can hold its own seat rather than
-  // idling as the chair's failover token.
+  // Numbered seats (claude2+) so extra subscriptions hold a real council
+  // seat instead of only idling as the chair's failover. Claude never
+  // goes through OpenRouter — see openrouter-policy.mjs.
   claude: { cli: true, keyEnv: "CLAUDE_CODE_OAUTH_TOKEN" },
   claude2: { cli: true, keyEnv: "CLAUDE_CODE_OAUTH_TOKEN_2" },
+  claude3: { cli: true, keyEnv: "CLAUDE_CODE_OAUTH_TOKEN_3" },
+  claude4: { cli: true, keyEnv: "CLAUDE_CODE_OAUTH_TOKEN_4" },
 };
+
+// CLAUDE_CODE_OAUTH_TOKEN_5+ become provider claude5+ without another edit.
+for (const key of Object.keys(process.env)) {
+  const n = /^CLAUDE_CODE_OAUTH_TOKEN_(\d+)$/.exec(key)?.[1];
+  if (n && Number(n) > 4) PROVIDERS[`claude${n}`] = { cli: true, keyEnv: key };
+}
 
 // Diverse lenses so each model catches what the others miss.
 export const LENSES = {
@@ -61,10 +72,11 @@ export const LENSES = {
 // single funded key can carry every lens. Map each native model to its
 // OpenRouter id and retry there when the native call fails on auth or quota.
 export const OPENROUTER_EQUIVALENT = {
-  "gpt-5.6": "openai/gpt-5.6",
-  "gpt-5.6-terra-pro": "openai/gpt-5.6-terra-pro",
-  "gemini-3.1-pro-preview": "google/gemini-3.1-pro-preview",
-  "kimi-k3": "moonshotai/kimi-k3",
+  // Native key dead → cheap leftover, never a metered copy of a subscription.
+  "gpt-5.6": "deepseek/deepseek-v4-flash",
+  "gpt-5.6-terra-pro": "deepseek/deepseek-v4-flash",
+  "gemini-3.1-pro-preview": "z-ai/glm-5.3-flash",
+  "kimi-k3": "z-ai/glm-5.3-flash",
 };
 
 // Statuses that mean "this key will not work today", as opposed to a transient
@@ -74,9 +86,11 @@ export const CREDENTIAL_FAILURE_STATUSES = [401, 402, 403, 429];
 
 export function openRouterFallbackFor(model) {
   if (model.provider === "openrouter") return null;
+  // A Claude OAuth seat has nowhere to go on OpenRouter: that route is banned.
+  if (isClaudeSeatProvider(model.provider)) return null;
   if (!process.env.OPENROUTER_API_KEY?.trim()) return null;
   const mapped = OPENROUTER_EQUIVALENT[model.model] || (model.model.includes("/") ? model.model : null);
-  if (!mapped) return null;
+  if (!mapped || bannedOpenRouterReason(mapped)) return null;
   return { ...model, provider: "openrouter", model: mapped };
 }
 
@@ -84,13 +98,12 @@ export const DEFAULT_MODELS = [
   { provider: "openai", model: process.env.OPENAI_MODEL || "gpt-5.6", name: "GPT-5.6 (Codex)", lens: "correctness" },
   { provider: "gemini", model: process.env.GEMINI_MODEL || "gemini-3.1-pro-preview", name: "Gemini 3 Pro", lens: "performance" },
   { provider: "moonshot", model: process.env.MOONSHOT_MODEL || "kimi-k3", name: "Kimi K3", lens: "security" },
-  { provider: "openrouter", model: process.env.OPENROUTER_MODEL || "x-ai/grok-4.5", name: "Grok 4.5", lens: "maintainability" },
-  // Scope rides OpenRouter, not the native OpenAI key that `correctness`
-  // already uses. Two lenses behind one key means one `insufficient_quota`
-  // takes out both, and on 2026-08-27 that key was 429-ing on 47 of the 48
-  // repos running this action. Its own SCOPE_MODEL override keeps a change
-  // here from silently re-pointing the correctness member too.
-  { provider: "openrouter", model: process.env.SCOPE_MODEL || "openai/gpt-5.6", name: "GPT-5.6 (scope)", lens: "scope" },
+  { provider: "openrouter", model: process.env.OPENROUTER_MODEL || "deepseek/deepseek-v4-flash", name: "DeepSeek V4 Flash", lens: "maintainability" },
+  // Scope rides a cheap OpenRouter model, not the native OpenAI key that
+  // `correctness` already uses. Two lenses behind one key means one
+  // `insufficient_quota` takes out both. GPT-5.6 and Grok are banned on
+  // this route — they have their own subscriptions.
+  { provider: "openrouter", model: process.env.SCOPE_MODEL || "z-ai/glm-5.3-flash", name: "GLM 5.3 Flash (scope)", lens: "scope" },
 ];
 
 // Test files whose ADDED lines make a mutation review worth paying for. The
@@ -147,15 +160,14 @@ export function diffAddsTestLines(diff) {
 // once it applies what it proposes. It ships off so that turning it on is a
 // decision somebody made rather than a cost that arrived.
 //
-// It rides OpenRouter with its own model override for the same reason SCOPE_MODEL
-// exists: so setting it cannot silently repoint another lens's model. It does NOT
-// give quota isolation -- mutation shares OPENROUTER_API_KEY with the scope and
-// maintainability members, so an exhausted key still takes out all three.
+// Claude via an OAuth seat, never OpenRouter. MUTATION_PROVIDER picks which
+// token (claude / claude2 / claude3 / claude4); MUTATION_MODEL is the CLI
+// model name so it cannot silently repoint another lens.
 export function mutationMember() {
   if (String(process.env.MUTATION_LENS || "").trim().toLowerCase() !== "true") return null;
   return {
-    provider: "openrouter",
-    model: process.env.MUTATION_MODEL || "anthropic/claude-sonnet-5",
+    provider: process.env.MUTATION_PROVIDER?.trim() || "claude",
+    model: process.env.MUTATION_MODEL?.trim() || "claude-sonnet-5",
     name: "Claude Sonnet 5 (mutation)",
     lens: "mutation",
   };

--- a/scripts/council-members.mjs
+++ b/scripts/council-members.mjs
@@ -12,6 +12,7 @@ import {
 } from "./council-config.mjs";
 import { callClaudeCli } from "./claude-cli-seat.mjs";
 import { cliEffortRung, effortWireExtras } from "./lens-effort-config.mjs";
+import { bannedOpenRouterReason, usesOpenRouterRoute } from "./openrouter-policy.mjs";
 
 // Members run in parallel, so the council costs max(member latency), not the
 // sum — the timeout is therefore a direct tail-latency tax on every run. In
@@ -86,6 +87,12 @@ export async function callModel(model, diff) {
         effortRung: cliEffortRung(model),
       }),
     );
+  }
+  // Refuse before the key check so a banned roster is visible even
+  // without OPENROUTER_API_KEY, and so we never POST a Claude/Codex id.
+  if (usesOpenRouterRoute(model, provider)) {
+    const why = bannedOpenRouterReason(model.model);
+    if (why) return timed({ model, error: `skipped: ${why}` });
   }
   if (provider && !provider.url) return timed({ model, error: "skipped: CUSTOM_BASE_URL not set" });
   const apiKey = provider && process.env[provider.keyEnv]?.trim();

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -238,7 +238,7 @@ async function main() {
   const models = parseModels();
   if (models.length === 0) {
     write(
-      "# 🧑‍⚖️ LLM Council findings\n\n_Council skipped: COUNCIL_MODELS parsed to no valid members (expected `provider|model|Name|lens`; providers: openai, gemini, moonshot, openrouter, custom)._\n",
+      "# 🧑‍⚖️ LLM Council findings\n\n_Council skipped: COUNCIL_MODELS parsed to no valid members (expected `provider|model|Name|lens`; providers: openai, gemini, moonshot, openrouter, custom, claude, claude2, claude3, claude4)._\n",
     );
     console.log("No valid council members — skipped.");
     return;

--- a/scripts/lens-effort-config.mjs
+++ b/scripts/lens-effort-config.mjs
@@ -67,7 +67,7 @@ export function effortWireExtras(model) {
 
 /** @param {{ provider: string, model: string, effortConfigured?: boolean, effortPosition?: number }} model */
 export function cliEffortRung(model) {
-  if (model.provider !== "claude" && model.provider !== "claude2") return undefined;
+  if (!/^claude\d*$/.test(String(model.provider || ""))) return undefined;
   if (!publishedLadder(model)) return undefined;
   return resolveMemberRung(model);
 }

--- a/scripts/lens-effort.test.mjs
+++ b/scripts/lens-effort.test.mjs
@@ -166,7 +166,7 @@ assert.notEqual(cacheKey(diff, parseErrorMember), cacheKey(diff, member));
     assert.ok(mutation, "mutation member should be appended for a diff that adds tests");
     assert.equal(mutation.effortConfigured, true, "MUTATION_EFFORT must reach the appended mutation member");
     assert.equal(mutation.effortPosition, 1);
-    assert.ok(effortWireExtras(mutation), "a configured mutation member must carry effort onto the wire");
+    assert.equal(cliEffortRung(mutation), "max", "MUTATION_EFFORT must reach the Claude CLI seat");
   } finally {
     if (savedLens === undefined) delete process.env.MUTATION_LENS; else process.env.MUTATION_LENS = savedLens;
     if (savedEffort === undefined) delete process.env.MUTATION_EFFORT; else process.env.MUTATION_EFFORT = savedEffort;

--- a/scripts/openrouter-policy.mjs
+++ b/scripts/openrouter-policy.mjs
@@ -1,0 +1,76 @@
+// OpenRouter is the cheap leftover route (DeepSeek, GLM, Kimi).
+// It is not a back door onto a family that already has a subscription:
+// Claude (OAuth seats), Codex (native OpenAI), or Grok (Grok CLI).
+// One paid Claude/Grok completion per PR across ~80 repos is how the
+// bill quietly doubled. This module is the hard stop.
+
+// Last-resort chair when every OAuth token is dead. Must stay a model
+// this policy allows — a Claude or Grok default here is the original leak.
+export const DEFAULT_CHAIR_FALLBACK_MODEL = "deepseek/deepseek-v4-flash";
+
+// Cheap OpenRouter ids used when a native key is dead. Never a metered
+// copy of Claude, Codex, or Grok.
+export const CHEAP_OPENROUTER_MODEL = "deepseek/deepseek-v4-flash";
+export const CHEAP_OPENROUTER_MODEL_ALT = "z-ai/glm-5.3-flash";
+
+const CLAUDE_SEAT = /^claude\d*$/;
+
+/** A subscription seat (claude, claude2, claude3, …), not a metered route. */
+export function isClaudeSeatProvider(provider) {
+  return CLAUDE_SEAT.test(String(provider || ""));
+}
+
+function tokens(modelId) {
+  return String(modelId || "")
+    .trim()
+    .toLowerCase()
+    .split(/[/:.]+/)
+    .filter(Boolean);
+}
+
+function isClaudeModel(modelId) {
+  return tokens(modelId).some((part) => part === "anthropic" || part === "claude" || part.startsWith("claude-"));
+}
+
+function isCodexModel(modelId) {
+  return tokens(modelId).some((part) => part === "codex" || part.includes("codex"));
+}
+
+function isGrokModel(modelId) {
+  return tokens(modelId).some((part) => part === "grok" || part.startsWith("grok-") || part === "x-ai");
+}
+
+/**
+ * Why this model must not be sent to OpenRouter, or null if it is allowed.
+ * Checked before the HTTP call so a banned roster never becomes a bill.
+ */
+export function bannedOpenRouterReason(modelId) {
+  if (isClaudeModel(modelId)) {
+    return "OpenRouter must not run Claude models; use a Claude OAuth seat (claude, claude2, claude3, claude4)";
+  }
+  if (isCodexModel(modelId)) {
+    return "OpenRouter must not run Codex models; use the native openai provider";
+  }
+  if (isGrokModel(modelId)) {
+    return "OpenRouter must not run Grok models; use the Grok CLI subscription";
+  }
+  return null;
+}
+
+/** True when this member's HTTP call would hit openrouter.ai. */
+export function usesOpenRouterRoute(model, provider) {
+  if (model.provider === "openrouter") return true;
+  if (model.provider !== "custom") return false;
+  const url = String(provider?.url || process.env.CUSTOM_BASE_URL || "");
+  return /openrouter\.ai/i.test(url);
+}
+
+/**
+ * Model the fallback chair will call, or an error string if the configured
+ * id is a banned family. An empty override keeps the default.
+ */
+export function resolveChairFallbackModel(raw = process.env.CHAIR_FALLBACK_MODEL) {
+  const model = String(raw || "").trim() || DEFAULT_CHAIR_FALLBACK_MODEL;
+  const error = bannedOpenRouterReason(model);
+  return error ? { model, error } : { model };
+}

--- a/scripts/openrouter-policy.test.mjs
+++ b/scripts/openrouter-policy.test.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  DEFAULT_CHAIR_FALLBACK_MODEL,
+  bannedOpenRouterReason,
+  isClaudeSeatProvider,
+  resolveChairFallbackModel,
+  usesOpenRouterRoute,
+} from "./openrouter-policy.mjs";
+import { openRouterFallbackFor, mutationMember, PROVIDERS } from "./council-config.mjs";
+import { callModel } from "./council-members.mjs";
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function check(name, fn) {
+  fn();
+  console.log(`ok    ${name}`);
+}
+
+check("bans Claude ids on OpenRouter", () => {
+  for (const id of [
+    "anthropic/claude-sonnet-5",
+    "anthropic/claude-opus-5",
+    "claude-sonnet-5",
+    "anthropic/claude-3.5-sonnet",
+  ]) {
+    assert.match(String(bannedOpenRouterReason(id)), /Claude/, id);
+  }
+});
+
+check("bans Codex ids on OpenRouter", () => {
+  for (const id of ["openai/codex-mini", "openai/gpt-5.3-codex", "openai/codex"]) {
+    assert.match(String(bannedOpenRouterReason(id)), /Codex/, id);
+  }
+});
+
+check("bans Grok ids on OpenRouter", () => {
+  for (const id of ["x-ai/grok-4.5", "x-ai/grok-4.6", "grok-4.5"]) {
+    assert.match(String(bannedOpenRouterReason(id)), /Grok/, id);
+  }
+});
+
+check("allows cheap leftover OpenRouter ids", () => {
+  for (const id of [
+    "deepseek/deepseek-v4-flash",
+    "z-ai/glm-5.3-flash",
+    "moonshotai/kimi-k3",
+    "google/gemini-3.1-pro-preview",
+    "openai/gpt-5.6",
+  ]) {
+    assert.equal(bannedOpenRouterReason(id), null, id);
+  }
+});
+
+check("default chair fallback is allowed and matches action.yml", () => {
+  assert.equal(bannedOpenRouterReason(DEFAULT_CHAIR_FALLBACK_MODEL), null);
+  assert.equal(resolveChairFallbackModel("").model, DEFAULT_CHAIR_FALLBACK_MODEL);
+  const action = fs.readFileSync(path.join(root, "action.yml"), "utf8");
+  assert.match(action, new RegExp(`default: "${DEFAULT_CHAIR_FALLBACK_MODEL}"`));
+  assert.doesNotMatch(action, /default: "anthropic\/claude/);
+  assert.doesNotMatch(action, /default: "x-ai\/grok/);
+});
+
+check("an explicit Grok chair fallback is refused", () => {
+  const resolved = resolveChairFallbackModel("x-ai/grok-4.5");
+  assert.ok(resolved.error);
+  assert.match(resolved.error, /Grok/);
+});
+
+check("a dead native GPT key reroutes to cheap DeepSeek, not GPT", () => {
+  const saved = process.env.OPENROUTER_API_KEY;
+  process.env.OPENROUTER_API_KEY = "sk-test";
+  try {
+    const route = openRouterFallbackFor({
+      provider: "openai",
+      model: "gpt-5.6",
+      name: "GPT-5.6 (Codex)",
+      lens: "correctness",
+    });
+    assert.equal(route.provider, "openrouter");
+    assert.equal(route.model, "deepseek/deepseek-v4-flash");
+    assert.equal(bannedOpenRouterReason(route.model), null);
+  } finally {
+    if (saved === undefined) delete process.env.OPENROUTER_API_KEY;
+    else process.env.OPENROUTER_API_KEY = saved;
+  }
+});
+
+check("an explicit Claude chair fallback is refused", () => {
+  const resolved = resolveChairFallbackModel("anthropic/claude-sonnet-5");
+  assert.ok(resolved.error);
+  assert.match(resolved.error, /Claude/);
+});
+
+check("Claude OAuth seats never reroute to OpenRouter", () => {
+  const saved = process.env.OPENROUTER_API_KEY;
+  process.env.OPENROUTER_API_KEY = "sk-test";
+  try {
+    for (const provider of ["claude", "claude2", "claude3", "claude4"]) {
+      assert.equal(
+        openRouterFallbackFor({ provider, model: "claude-sonnet-5", name: "C", lens: "correctness" }),
+        null,
+        provider,
+      );
+    }
+    assert.equal(
+      openRouterFallbackFor({
+        provider: "openai",
+        model: "anthropic/claude-sonnet-5",
+        name: "Smuggled",
+        lens: "correctness",
+      }),
+      null,
+    );
+  } finally {
+    if (saved === undefined) delete process.env.OPENROUTER_API_KEY;
+    else process.env.OPENROUTER_API_KEY = saved;
+  }
+});
+
+const bannedCall = await callModel(
+  { provider: "openrouter", model: "anthropic/claude-sonnet-5", name: "Sonnet", lens: "correctness" },
+  "diff",
+);
+check("callModel skips a banned OpenRouter id without needing a key", () => {
+  assert.match(String(bannedCall.error), /skipped:.*Claude/);
+});
+
+check("mutation defaults to a Claude OAuth seat", () => {
+  const savedLens = process.env.MUTATION_LENS;
+  const savedModel = process.env.MUTATION_MODEL;
+  const savedProvider = process.env.MUTATION_PROVIDER;
+  try {
+    delete process.env.MUTATION_MODEL;
+    delete process.env.MUTATION_PROVIDER;
+    process.env.MUTATION_LENS = "true";
+    const member = mutationMember();
+    assert.equal(member.provider, "claude");
+    assert.equal(member.model, "claude-sonnet-5");
+    // The CLI model name is a Claude id, so OpenRouter must refuse it
+    // if anyone reroutes this seat. The seat itself is the allowed path.
+    assert.ok(bannedOpenRouterReason(member.model));
+    assert.equal(openRouterFallbackFor(member), null);
+  } finally {
+    if (savedLens === undefined) delete process.env.MUTATION_LENS;
+    else process.env.MUTATION_LENS = savedLens;
+    if (savedModel === undefined) delete process.env.MUTATION_MODEL;
+    else process.env.MUTATION_MODEL = savedModel;
+    if (savedProvider === undefined) delete process.env.MUTATION_PROVIDER;
+    else process.env.MUTATION_PROVIDER = savedProvider;
+  }
+});
+
+check("numbered Claude seats exist and extra tokens register", () => {
+  assert.equal(PROVIDERS.claude3.keyEnv, "CLAUDE_CODE_OAUTH_TOKEN_3");
+  assert.equal(PROVIDERS.claude4.keyEnv, "CLAUDE_CODE_OAUTH_TOKEN_4");
+  assert.equal(isClaudeSeatProvider("claude"), true);
+  assert.equal(isClaudeSeatProvider("claude4"), true);
+  assert.equal(isClaudeSeatProvider("openrouter"), false);
+});
+
+check("council fan-out receives OAuth tokens 3 and 4", () => {
+  const action = fs.readFileSync(path.join(root, "action.yml"), "utf8");
+  assert.match(action, /CLAUDE_CODE_OAUTH_TOKEN_3: \$\{\{ inputs\.claude_code_oauth_token_3 \}\}/);
+  assert.match(action, /CLAUDE_CODE_OAUTH_TOKEN_4: \$\{\{ inputs\.claude_code_oauth_token_4 \}\}/);
+});
+
+check("custom via openrouter.ai is treated as OpenRouter", () => {
+  assert.equal(
+    usesOpenRouterRoute({ provider: "custom" }, { url: "https://openrouter.ai/api/v1/chat/completions" }),
+    true,
+  );
+  assert.equal(
+    usesOpenRouterRoute({ provider: "custom" }, { url: "http://127.0.0.1:8080/v1/chat/completions" }),
+    false,
+  );
+});
+
+console.log("openrouter-policy tests passed");

--- a/skills/vibecodereview/SKILL.md
+++ b/skills/vibecodereview/SKILL.md
@@ -28,7 +28,8 @@ member is skipped, not an error:
 - `OPENAI_API_KEY` — correctness
 - `GEMINI_API_KEY` — performance
 - `MOONSHOT_API_KEY` — security
-- `OPENROUTER_API_KEY` — maintainability (Grok / DeepSeek)
+- `OPENROUTER_API_KEY` — cheap leftovers (DeepSeek / GLM). Never Claude, Codex, or Grok.
+- `CLAUDE_CODE_OAUTH_TOKEN` through `_4` — chair + any Claude council seat
 
 ## Set it up in a repo (CI)
 


### PR DESCRIPTION
Closes #151

## What
OpenRouter now refuses Claude, Codex, and Grok model ids before any HTTP call. Chair fallback and leftover lenses default to DeepSeek V4 Flash and GLM 5.3 Flash. Mutation and extra Claude seats stay on OAuth tokens, never the metered key.

## Why
The fleet OpenRouter key spent ~$424 today buying copies of models we already subscribe to (Claude, Codex, Gemini, Grok). Those families have their own seats. OpenRouter should only carry cheap leftovers.

## How I verified
```text
npm test -> 38 passed, selfcheck ok, chair-fallback selfcheck passed
npx oxlint scripts/openrouter-policy.mjs scripts/chair-fallback.mjs scripts/council-config.mjs -> clean (one pre-existing warning)
```

Assisted-by: cursor-grok:grok-4.6

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pooriaarab/vibecodereview/pull/152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for up to four Claude OAuth seats, with automatic support for additional numbered tokens.
  - Added configurable Claude-based mutation reviews.
  - Added OpenRouter fallback support using DeepSeek or GLM models.

- **Bug Fixes**
  - Prevented unsupported Claude, Codex, and Grok models from being routed through OpenRouter.
  - Improved OAuth token isolation when using multiple Claude seats.

- **Documentation**
  - Updated setup guidance, model restrictions, roster examples, and configuration options for Claude, DeepSeek, and GLM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->