### PR TITLE
[VCR-153] Dispatch a lighter council on low-risk diffs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Read `.agents/brand.md` and `.agents/design.md` before public copy or interface 
   id — the engine skips those before the HTTP call. Add a seat by setting
   `CLAUDE_CODE_OAUTH_TOKEN_N` (provider `claudeN`).
 - A member with no API key must skip with a note, never throw.
-- The council uses a scope lens to verify atomicity and claim alignment. Set `PR_CONTEXT_FILE` to a file containing the author's claim (title, body, closed issues) to feed this lens.
+- The council uses a scope lens to verify atomicity and claim alignment. Set `PR_CONTEXT_FILE` to a file containing the author's claim (title, body, closed issues) to feed this lens. Review weight may drop that lens on low-risk deltas — the chair still judges the claim. `VCR_REVIEW_WEIGHT=off` restores the routed roster.
 - A composite action's `inputs:` block must contain NO `${{ }}` expressions — not in a default AND not in a description string; GitHub parses them and fails at 'Set up job'. Callers pass github_token explicitly.
 - Secrets never land in git. CI secrets live in repo settings; local keys in env.
 - After any engine change, run `node scripts/council-review.mjs --selfcheck`.

--- a/README.md
+++ b/README.md
@@ -52,10 +52,28 @@ above already skips the whole council, scope included, before any lens is dispat
 Routing only decides the roster once a delta has at least one non-inert path — a
 dependency-manifest-only push (`package.json`, `go.mod`, ...) keeps scope, correctness,
 and security; a test-only push keeps scope, correctness, and maintainability; a
-style-only push keeps scope and performance. An unparseable diff fails open and
+style-only push keeps scope and performance — review weight then drops that
+pair so the chair reviews CSS alone. An unparseable diff fails open and
 dispatches every lens. Dropped lenses are listed in the findings as "Lenses not dispatched".
 
 Set `VCR_LENS_ROUTING=off` to disable routing and dispatch the full roster.
+
+### Review weight
+
+Kind routing asks whether a lens can speak to the files. Review weight asks
+whether the delta needs more than one or two speakers. It runs after routing:
+
+| Weight | When | Council |
+| --- | --- | --- |
+| chair | style-only (CSS/SCSS/Less/Sass) | none — Claude reviews alone |
+| light | tests and/or dependency manifests, no source | correctness plus security or maintainability |
+| core | ordinary source | correctness and security |
+| full | CI, agent instructions, high-risk paths (auth, payments, migrations, secrets), or an unparseable diff | whatever routing kept |
+
+The chair still runs either way, and still judges whether the diff matches the
+claim. Scope drops on chair/light/core because that job is already the chair's.
+An unparseable diff fails open to `full`. Set `VCR_REVIEW_WEIGHT=off` on the
+`uses:` step to restore the routed roster with no further shrinking.
 
 The scope lens reads the PR's title, body, and linked issues from `PR_CONTEXT_FILE` when available to verify the diff matches the author's claim.
 

--- a/scripts/council-review.mjs
+++ b/scripts/council-review.mjs
@@ -52,6 +52,7 @@ import { cacheKey, loadCouncilResults, saveCouncilResult } from "./council-cache
 import { withLensEffort } from "./lens-effort-config.mjs";
 import { behavioralSurface } from "./behavioral-surface.mjs";
 import { filterMembersByKindRouting, lensesForKinds, routeLenses } from "./lens-routing.mjs";
+import { filterMembersByWeight } from "./review-weight.mjs";
 import { appendFindingsMeta } from "./file-findings.mjs";
 
 // Council run stats for the telemetry record: how many members THIS run
@@ -308,13 +309,28 @@ async function main() {
   if (mutationSkipped) console.log(`Mutation lens enabled but not dispatched: ${mutationSkipped}`);
   const kindRouting = filterMembersByKindRouting(members, memberDiffRaw);
   members = kindRouting.members;
-  skippedLenses.push(...kindRouting.skippedLenses);
+  const weighted = filterMembersByWeight(members, memberDiffRaw);
+  members = weighted.members;
+  skippedLenses.push(...kindRouting.skippedLenses, ...weighted.skippedLenses);
   skippedLenses = [...new Set(skippedLenses)];
-  const reportOptions = { ...baseReportOptions, skippedLenses, mutationSkipped };
+  const skipWhy = weighted.weight !== "full"
+    ? `review weight: ${weighted.weight}`
+    : "the member delta did not touch files they review";
+  const reportOptions = {
+    ...baseReportOptions,
+    skippedLenses,
+    skippedReason: skipWhy,
+    reviewWeight: weighted.weight,
+    mutationSkipped,
+  };
+  if (weighted.weight !== "full") console.log(`Review weight: ${weighted.weight} (${weighted.reason})`);
 
   if (members.length === 0) {
-    write(buildFindingsMarkdown([], reportOptions) + "\n\n_Council skipped: no configured lens applies to the member delta._\n");
-    console.log("No applicable council lenses — skipped.");
+    const why = weighted.weight === "chair"
+      ? "review weight chair — style-only delta, the chair reviews alone"
+      : "no configured lens applies to the member delta";
+    write(buildFindingsMarkdown([], reportOptions) + `\n\n_Council skipped: ${why}._\n`);
+    console.log(weighted.weight === "chair" ? "Review weight chair — council skipped." : "No applicable council lenses — skipped.");
     return;
   }
   // Cache keys use the exact input each member receives: scope sees the full

--- a/scripts/council-stats.test.mjs
+++ b/scripts/council-stats.test.mjs
@@ -99,7 +99,7 @@ function readStats(statsFile) {
   const run = runEngine(CODE_DIFF, "", {
     CUSTOM_BASE_URL: "http://127.0.0.1:1/chat/completions",
     CUSTOM_API_KEY: "dummy",
-    COUNCIL_MODELS: "custom|m1|M1|correctness,custom|m2|M2|performance",
+    COUNCIL_MODELS: "custom|m1|M1|correctness,custom|m2|M2|security",
   });
   assert.equal(run.result.status, 0, `engine exited ${run.result.status}: ${run.result.stderr}`);
   const stats = readStats(run.statsFile);
@@ -107,6 +107,7 @@ function readStats(statsFile) {
   assert.equal(stats.cacheHit, false, `no cached member must report false: ${JSON.stringify(stats)}`);
   const report = fs.readFileSync(run.outFile, "utf8");
   assert.ok(report.includes("M1 — correctness lens"), "dispatched headings must stay in the report");
+  assert.ok(report.includes("M2 — security lens"), "both core-weight lenses must stay in the report");
   assert.ok(!report.includes("(cached)"), "uncached run must not mark headings cached");
   const { members, cacheHit } = readStatsViaAction(run.statsFile);
   assert.equal(members, "2", `reader script must derive 2 members: ${members}`);

--- a/scripts/review-delta.mjs
+++ b/scripts/review-delta.mjs
@@ -70,7 +70,7 @@ export function shouldWriteReviewState(repositoryPrivate) {
 
 export function buildFindingsMarkdown(
   results,
-  { diffTruncated, contextTruncated, mutationSkipped, reviewHeadSha, memberDiffNote, skippedLenses, carriedFindings } = {},
+  { diffTruncated, contextTruncated, mutationSkipped, reviewHeadSha, memberDiffNote, skippedLenses, skippedReason, reviewWeight, carriedFindings } = {},
 ) {
   const lines = ["# 🧑‍⚖️ LLM Council findings", ""];
   lines.push(
@@ -79,8 +79,12 @@ export function buildFindingsMarkdown(
   );
   if (reviewHeadSha) lines.push(`> Reviewed head: \`${reviewHeadSha}\`.`, "");
   if (memberDiffNote) lines.push(`> Member diff: ${memberDiffNote}`, "");
+  if (reviewWeight && reviewWeight !== "full") {
+    lines.push(`> Review weight: ${reviewWeight}.`, "");
+  }
   if (skippedLenses?.length) {
-    lines.push(`> Lenses not dispatched: ${skippedLenses.join(", ")} (the member delta did not touch files they review).`, "");
+    const why = skippedReason || "not dispatched this run";
+    lines.push(`> Lenses not dispatched: ${skippedLenses.join(", ")} (${why}).`, "");
   }
   if (diffTruncated && contextTruncated) {
     lines.push("> ⚠️ Diff and PR context were truncated for length; council saw the first portion of each.", "");

--- a/scripts/review-weight.mjs
+++ b/scripts/review-weight.mjs
@@ -1,0 +1,103 @@
+// After kind routing, shrink the council further by how risky the delta is.
+// Kind routing asks "can this lens speak to these files?". This asks "does
+// this delta need more than one or two speakers?". A CSS tweak does not need
+// five models; an auth change still does.
+//
+// Fail open: an unparseable diff, or VCR_REVIEW_WEIGHT=off, keeps the roster
+// kind routing already chose. Wrongly shrinking a risky review is worse than
+// paying for one extra member.
+
+import { diffPaths } from "./review-delta.mjs";
+import { routeLenses } from "./lens-routing.mjs";
+
+const HIGH_RISK_SEGMENTS = new Set([
+  "acl", "auth", "authentication", "authorization", "authorize",
+  "billing", "credential", "credentials", "crypto", "iam", "invoice",
+  "jwt", "kms", "migrate", "migration", "migrations", "oauth", "oidc",
+  "passwd", "password", "payment", "payments", "pem", "rbac", "saml",
+  "schema", "secret", "secrets", "session", "sessions", "stripe",
+  "webhook", "webhooks",
+]);
+
+const WEIGHT_REASON = {
+  chair: "style-only; the chair reviews alone",
+  light: "tests or manifests; a short specialist pass",
+  core: "ordinary source; correctness and security",
+  full: "CI, agent instructions, high-risk paths, or unparseable",
+};
+
+function basename(path) {
+  const i = path.lastIndexOf("/");
+  return i === -1 ? path : path.slice(i + 1);
+}
+
+function extensionOf(path) {
+  const i = path.lastIndexOf(".");
+  return i === -1 ? "" : path.slice(i).toLowerCase();
+}
+
+function pathSegments(path) {
+  return String(path).toLowerCase().split(/[/_.-]+/).filter(Boolean);
+}
+
+/** A path that must never take the cheap roster. */
+export function isHighRiskPath(path) {
+  const base = basename(path);
+  if (base === ".env" || base.startsWith(".env.")) return true;
+  if (extensionOf(path) === ".sql" || extensionOf(path) === ".pem") return true;
+  return pathSegments(path).some((seg) => HIGH_RISK_SEGMENTS.has(seg));
+}
+
+export function isReviewWeightEnabled() {
+  return String(process.env.VCR_REVIEW_WEIGHT || "").trim().toLowerCase() !== "off";
+}
+
+function lightLenses(kinds) {
+  const keep = new Set(["correctness"]);
+  if (kinds.includes("deps")) keep.add("security");
+  if (kinds.includes("test")) keep.add("maintainability");
+  return [...keep];
+}
+
+/**
+ * @param {string[]} kinds
+ * @param {string[]} paths
+ * @returns {{ weight: "chair"|"light"|"core"|"full", keep: string[]|null }}
+ */
+export function decideWeight(kinds, paths) {
+  if (!kinds.length) return { weight: "full", keep: null };
+  const set = new Set(kinds);
+  const onlyQuiet = [...set].every((k) => k === "style" || k === "docs");
+  if (onlyQuiet) return { weight: "chair", keep: [] };
+  if (set.has("ci") || set.has("agent")) return { weight: "full", keep: null };
+  if (set.has("source")) {
+    if (paths.some(isHighRiskPath)) return { weight: "full", keep: null };
+    return { weight: "core", keep: ["correctness", "security"] };
+  }
+  return { weight: "light", keep: lightLenses(kinds) };
+}
+
+/**
+ * Filter a kind-routed roster. Unknown / mutation lenses drop on every
+ * weight except full — they are opt-in extras, not a reason to fail open.
+ * @param {Array<{ lens: string }>} members
+ * @param {string} diff
+ */
+export function filterMembersByWeight(members, diff, { enabled = isReviewWeightEnabled() } = {}) {
+  if (!enabled) {
+    return { members, skippedLenses: [], weight: "full", reason: "disabled" };
+  }
+  const { kinds } = routeLenses(diff);
+  const { weight, keep } = decideWeight(kinds, diffPaths(diff));
+  if (keep === null) {
+    return { members, skippedLenses: [], weight, reason: WEIGHT_REASON[weight] };
+  }
+  const allowed = new Set(keep);
+  const keeps = (m) => allowed.has(m.lens);
+  return {
+    members: members.filter(keeps),
+    skippedLenses: members.filter((m) => !keeps(m)).map((m) => m.lens),
+    weight,
+    reason: WEIGHT_REASON[weight],
+  };
+}

--- a/scripts/review-weight.test.mjs
+++ b/scripts/review-weight.test.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { DEFAULT_MODELS } from "./council-config.mjs";
+import {
+  decideWeight,
+  filterMembersByWeight,
+  isHighRiskPath,
+  isReviewWeightEnabled,
+} from "./review-weight.mjs";
+
+function diffFor(path) {
+  return `diff --git a/${path} b/${path}\n--- a/${path}\n+++ b/${path}\n+change\n`;
+}
+
+function lensesOf(members) {
+  return members.map((m) => m.lens);
+}
+
+assert.equal(isHighRiskPath("src/auth/login.ts"), true, "auth segment is high-risk");
+assert.equal(isHighRiskPath("src/author.ts"), false, "author must not match auth");
+assert.equal(isHighRiskPath("src/payments/stripe.ts"), true);
+assert.equal(isHighRiskPath("db/migrations/001.sql"), true);
+assert.equal(isHighRiskPath(".env.production"), true);
+assert.equal(isHighRiskPath("src/app.ts"), false);
+
+assert.deepEqual(decideWeight(["style"], ["styles/main.css"]), { weight: "chair", keep: [] });
+assert.deepEqual(decideWeight(["docs"], ["README.md"]), { weight: "chair", keep: [] });
+assert.deepEqual(decideWeight(["test"], ["tests/app.test.ts"]), {
+  weight: "light",
+  keep: ["correctness", "maintainability"],
+});
+assert.deepEqual(decideWeight(["deps"], ["package.json"]), {
+  weight: "light",
+  keep: ["correctness", "security"],
+});
+assert.deepEqual(decideWeight(["source"], ["src/app.ts"]), {
+  weight: "core",
+  keep: ["correctness", "security"],
+});
+assert.deepEqual(decideWeight(["source"], ["src/auth/login.ts"]), { weight: "full", keep: null });
+assert.deepEqual(decideWeight(["ci"], [".github/workflows/ci.yml"]), { weight: "full", keep: null });
+assert.deepEqual(decideWeight(["agent"], ["AGENTS.md"]), { weight: "full", keep: null });
+assert.deepEqual(decideWeight([], []), { weight: "full", keep: null }, "unparseable fails open");
+
+const roster = structuredClone(DEFAULT_MODELS);
+
+const css = filterMembersByWeight(roster, diffFor("styles/main.css"));
+assert.equal(css.weight, "chair");
+assert.deepEqual(css.members, []);
+assert.ok(css.skippedLenses.includes("performance"));
+assert.ok(css.skippedLenses.includes("scope"));
+
+const test = filterMembersByWeight(roster, diffFor("tests/app.test.ts"));
+assert.equal(test.weight, "light");
+assert.deepEqual(lensesOf(test.members), ["correctness", "maintainability"]);
+
+const src = filterMembersByWeight(roster, diffFor("src/app.ts"));
+assert.equal(src.weight, "core");
+assert.deepEqual(lensesOf(src.members), ["correctness", "security"]);
+assert.ok(src.skippedLenses.includes("performance"));
+assert.ok(src.skippedLenses.includes("scope"));
+
+const auth = filterMembersByWeight(roster, diffFor("src/auth/login.ts"));
+assert.equal(auth.weight, "full");
+assert.deepEqual(lensesOf(auth.members), lensesOf(roster));
+
+const saved = process.env.VCR_REVIEW_WEIGHT;
+try {
+  delete process.env.VCR_REVIEW_WEIGHT;
+  assert.equal(isReviewWeightEnabled(), true, "unset means weight is on");
+  process.env.VCR_REVIEW_WEIGHT = "off";
+  assert.equal(isReviewWeightEnabled(), false);
+  const off = filterMembersByWeight(roster, diffFor("styles/main.css"));
+  assert.equal(off.weight, "full");
+  assert.deepEqual(off.members, roster);
+  assert.deepEqual(off.skippedLenses, []);
+} finally {
+  if (saved === undefined) delete process.env.VCR_REVIEW_WEIGHT;
+  else process.env.VCR_REVIEW_WEIGHT = saved;
+}
+
+console.log("review weight tests passed");

--- a/skills/vibecodereview/SKILL.md
+++ b/skills/vibecodereview/SKILL.md
@@ -6,7 +6,10 @@ description: Review a code diff with a council of AI models before pushing or me
 # vibecodereview — council diff review
 
 Send a diff to several models at once, each reviewing through a different lens,
-then read back the combined findings. Catches what one reviewer misses.
+then read back the combined findings. Catches what one reviewer misses. Low-risk
+deltas (CSS, tests, ordinary source) dispatch a smaller council so the review
+finishes faster; auth, payments, CI, and agent-instruction changes still get
+the full roster. `VCR_REVIEW_WEIGHT=off` turns that shrinking off.
 
 ## Review the working diff
 


### PR DESCRIPTION
Closes #153

## What
After kind routing, a review weight shrinks the council: CSS is chair-only, tests and manifests get a short specialist pass, ordinary source gets correctness plus security, and CI / agent-instruction / high-risk paths still get the full roster.

## Why
Not every pull request needs five models. Kind routing already drops lenses that cannot speak to the files, but any source file still paid for the full team, and a CSS-only change still waited on two members plus the chair.

## How I verified
```text
npm test -> 39 passed, selfcheck ok, chair-fallback selfcheck passed
npx oxlint scripts/review-weight.mjs scripts/council-review.mjs scripts/review-delta.mjs -> clean
```

Assisted-by: cursor-grok:grok-4.6

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pooriaarab/vibecodereview/pull/154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->